### PR TITLE
chore: pin self-consume skill mirrors from commons sync

### DIFF
--- a/.dev-config/sync.yaml
+++ b/.dev-config/sync.yaml
@@ -10,3 +10,25 @@ pinned:
   - lefthook.yaml
   - biome.json
   - renovate.json
+  # self-consume targets: built from src/skills/ by scripts/build.mjs
+  - .agents/skills/README.md
+  - .agents/skills/commit-conventions/SKILL.md
+  - .agents/skills/commit/SKILL.md
+  - .agents/skills/drive/SKILL.md
+  - .agents/skills/implement/SKILL.md
+  - .agents/skills/lint-rules/SKILL.md
+  - .agents/skills/lint/SKILL.md
+  - .agents/skills/pr/SKILL.md
+  - .agents/skills/review/SKILL.md
+  - .agents/skills/ship/SKILL.md
+  - .agents/skills/test/SKILL.md
+  - .claude/skills/commit-conventions/SKILL.md
+  - .claude/skills/commit/SKILL.md
+  - .claude/skills/drive/SKILL.md
+  - .claude/skills/implement/SKILL.md
+  - .claude/skills/lint-rules/SKILL.md
+  - .claude/skills/lint/SKILL.md
+  - .claude/skills/pr/SKILL.md
+  - .claude/skills/review/SKILL.md
+  - .claude/skills/ship/SKILL.md
+  - .claude/skills/test/SKILL.md


### PR DESCRIPTION
## Summary

- `scripts/build.mjs` が `src/skills/` から `.agents/skills/` と `.claude/skills/` を再生成する自己消費構造（PR #5 で導入）と、commons sync がこれらを上書きする構造が衝突し、毎回の sync で CI を fail する PR が生成される問題を修正
- `.dev-config/sync.yaml` の `pinned` リストに self-consume target 21 ファイル（`.agents/skills/` 配下 11 + `.claude/skills/` 配下 10）を列挙し、commons sync で上書きされないようにする

## Background

[PR #6](https://github.com/ozzy-labs/skills/pull/6) を close した経緯。詳細は [そのレビューコメント](https://github.com/ozzy-labs/skills/pull/6#issuecomment-4318350587) を参照。

## Test plan

- [x] `pnpm run lint:all` 通過
- [x] `pnpm run build` で dist tree out-of-date が出ないこと
- [ ] このマージ後に `sync-commons.yaml` を手動 dispatch し、`.agents/skills/` と `.claude/skills/` 配下が "pinned" 扱いになることを確認
- [ ] 上記で sync された PR（あれば）が CI green になることを確認

## Follow-ups

- 将来 src/skills/ に新スキルを追加した際は、本ファイルの pinned リストも更新する必要がある（保守上の制約）
- 長期的には commons の sync.sh にディレクトリ単位の pinned サポートを追加する方が望ましい（commons 側で別 issue）