### PR TITLE
feat(adapters): add AdapterBase contract and shared lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:yaml": "yamllint -c .yamllint.yaml .",
     "lint:secrets": "gitleaks detect --no-banner",
     "lint:all": "pnpm run lint && pnpm run lint:md && pnpm run lint:yaml && pnpm run lint:secrets",
-    "test": "node --test tests/"
+    "test": "node --test 'tests/**/*.test.mjs'"
   },
   "engines": {
     "node": ">=22"

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -15,6 +15,7 @@ import { readdir, readFile, mkdir, copyFile, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { parseSkillDocument, assertRequiredFields } from "./lib/frontmatter.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, "..");
@@ -26,32 +27,9 @@ const TARGETS = [
   join(ROOT, ".claude", "skills"),
 ];
 
-const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n/;
-
 async function readSkillNames() {
   const entries = await readdir(SRC, { withFileTypes: true });
   return entries.filter((e) => e.isDirectory()).map((e) => e.name).sort();
-}
-
-function parseFrontmatter(text, fileLabel) {
-  const match = text.match(FRONTMATTER_RE);
-  if (!match) {
-    throw new Error(`${fileLabel}: missing frontmatter (--- ... ---)`);
-  }
-  const fm = {};
-  for (const line of match[1].split("\n")) {
-    const idx = line.indexOf(":");
-    if (idx === -1) continue;
-    const key = line.slice(0, idx).trim();
-    const value = line.slice(idx + 1).trim();
-    fm[key] = value;
-  }
-  for (const required of ["name", "description"]) {
-    if (!fm[required]) {
-      throw new Error(`${fileLabel}: frontmatter missing required field '${required}'`);
-    }
-  }
-  return fm;
 }
 
 async function emit(target, name, srcFile) {
@@ -71,10 +49,12 @@ async function main() {
   for (const name of names) {
     const srcFile = join(SRC, name, "SKILL.md");
     const text = await readFile(srcFile, "utf8");
-    const fm = parseFrontmatter(text, `src/skills/${name}/SKILL.md`);
-    if (fm.name !== name) {
+    const label = `src/skills/${name}/SKILL.md`;
+    const { frontmatter } = parseSkillDocument(text, label);
+    assertRequiredFields(frontmatter, ["name", "description"], label);
+    if (frontmatter.name !== name) {
       throw new Error(
-        `src/skills/${name}/SKILL.md: frontmatter name='${fm.name}' does not match directory name='${name}'`,
+        `${label}: frontmatter name='${frontmatter.name}' does not match directory name='${name}'`,
       );
     }
     validated.push({ name, srcFile });

--- a/scripts/lib/adapter-base.mjs
+++ b/scripts/lib/adapter-base.mjs
@@ -1,0 +1,35 @@
+// AdapterBase — the contract every agent adapter implements.
+//
+// An adapter is a pure function: it takes the canonical skill list and
+// returns OutputFile[] rooted under its own `dist/{id}/` subtree. The build
+// orchestrator is responsible for clearing the destination and writing the
+// files. Adapters never touch the file system.
+
+/**
+ * @typedef {import("./types.mjs").Skill} Skill
+ * @typedef {import("./types.mjs").OutputFile} OutputFile
+ */
+
+export class AdapterBase {
+  /**
+   * Adapter identifier — used as the dist subdirectory (`dist/{id}/`).
+   * Subclasses must override.
+   *
+   * @type {string}
+   */
+  static id = "";
+
+  /**
+   * Generate the OutputFile list for this adapter.
+   *
+   * Subclasses must override. Implementations must be deterministic: the same
+   * skills input must produce the same OutputFile list (same order, same
+   * content).
+   *
+   * @param {Skill[]} _skills
+   * @returns {OutputFile[]}
+   */
+  generate(_skills) {
+    throw new Error(`${this.constructor.name}.generate() not implemented`);
+  }
+}

--- a/scripts/lib/frontmatter.mjs
+++ b/scripts/lib/frontmatter.mjs
@@ -1,0 +1,63 @@
+// Frontmatter parse / serialize helpers.
+//
+// SKILL.md frontmatter is a tiny subset of YAML — `key: value` pairs only,
+// no nesting, no arrays. Keep the parser small and deterministic.
+
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n/;
+
+/**
+ * Parse a SKILL.md document.
+ *
+ * @param {string} text       File contents.
+ * @param {string} fileLabel  Path used in error messages.
+ * @returns {{ frontmatter: Record<string, string>, body: string }}
+ */
+export function parseSkillDocument(text, fileLabel) {
+  const match = text.match(FRONTMATTER_RE);
+  if (!match) {
+    throw new Error(`${fileLabel}: missing frontmatter (--- ... ---)`);
+  }
+  const frontmatter = {};
+  for (const line of match[1].split("\n")) {
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    if (key) frontmatter[key] = value;
+  }
+  const body = text.slice(match[0].length);
+  return { frontmatter, body };
+}
+
+/**
+ * Serialize frontmatter back to a `--- ... ---` block.
+ *
+ * Keys are emitted in insertion order so callers control determinism by
+ * controlling the order they pass keys in.
+ *
+ * @param {Record<string, string>} frontmatter
+ * @returns {string}
+ */
+export function serializeFrontmatter(frontmatter) {
+  const lines = ["---"];
+  for (const [key, value] of Object.entries(frontmatter)) {
+    lines.push(`${key}: ${value}`);
+  }
+  lines.push("---", "");
+  return lines.join("\n");
+}
+
+/**
+ * Validate required frontmatter fields.
+ *
+ * @param {Record<string, string>} frontmatter
+ * @param {string[]} required
+ * @param {string} fileLabel
+ */
+export function assertRequiredFields(frontmatter, required, fileLabel) {
+  for (const field of required) {
+    if (!frontmatter[field]) {
+      throw new Error(`${fileLabel}: frontmatter missing required field '${field}'`);
+    }
+  }
+}

--- a/scripts/lib/snippet.mjs
+++ b/scripts/lib/snippet.mjs
@@ -1,0 +1,22 @@
+// `.snippet` marker helpers.
+//
+// Adapters that emit content meant to be merged into a consumer-owned file
+// (AGENTS.md, copilot-instructions.md) wrap their payload with begin/end
+// markers so consumer-side sync scripts can replace just the managed region.
+
+const MARKER_TAG = "@ozzylabs/skills";
+
+export const SNIPPET_BEGIN = `<!-- begin: ${MARKER_TAG} -->`;
+export const SNIPPET_END = `<!-- end: ${MARKER_TAG} -->`;
+
+/**
+ * Wrap a body string with begin/end markers, ensuring exactly one trailing
+ * newline so the snippet concatenates cleanly with neighboring content.
+ *
+ * @param {string} body
+ * @returns {string}
+ */
+export function wrapSnippet(body) {
+  const trimmed = body.replace(/\n+$/, "");
+  return `${SNIPPET_BEGIN}\n${trimmed}\n${SNIPPET_END}\n`;
+}

--- a/scripts/lib/types.mjs
+++ b/scripts/lib/types.mjs
@@ -1,0 +1,26 @@
+// Shared type definitions for the adapter pipeline.
+//
+// Adapters take a list of canonical Skill objects and return OutputFile[].
+// File system writes are performed by the build orchestrator only — adapters
+// are pure functions.
+
+/**
+ * A canonical skill loaded from `src/skills/{name}/SKILL.md`.
+ *
+ * @typedef {object} Skill
+ * @property {string} name           Skill identifier (matches directory name).
+ * @property {string} description    One-line description from frontmatter.
+ * @property {Record<string, string>} frontmatter  Full parsed frontmatter map.
+ * @property {string} body           SKILL.md content with frontmatter stripped.
+ * @property {string} raw            Full SKILL.md content (frontmatter + body).
+ */
+
+/**
+ * One file emitted by an adapter, relative to the adapter's dist root.
+ *
+ * @typedef {object} OutputFile
+ * @property {string} relativePath   Path under `dist/{adapter}/`.
+ * @property {string} content        File content (UTF-8).
+ */
+
+export {};

--- a/tests/adapter-base.test.mjs
+++ b/tests/adapter-base.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { AdapterBase } from "../scripts/lib/adapter-base.mjs";
+
+test("AdapterBase.generate throws when not overridden", () => {
+  const adapter = new AdapterBase();
+  assert.throws(() => adapter.generate([]), /not implemented/);
+});
+
+test("subclass that overrides generate works", () => {
+  class FakeAdapter extends AdapterBase {
+    static id = "fake";
+    generate(skills) {
+      return skills.map((s) => ({
+        relativePath: `${s.name}.md`,
+        content: s.body,
+      }));
+    }
+  }
+  const out = new FakeAdapter().generate([
+    { name: "x", description: "d", frontmatter: {}, body: "B", raw: "B" },
+  ]);
+  assert.deepEqual(out, [{ relativePath: "x.md", content: "B" }]);
+});

--- a/tests/frontmatter.test.mjs
+++ b/tests/frontmatter.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  assertRequiredFields,
+  parseSkillDocument,
+  serializeFrontmatter,
+} from "../scripts/lib/frontmatter.mjs";
+
+test("parseSkillDocument extracts frontmatter and body", () => {
+  const input = "---\nname: foo\ndescription: bar\n---\n# heading\n\nbody\n";
+  const { frontmatter, body } = parseSkillDocument(input, "test.md");
+  assert.equal(frontmatter.name, "foo");
+  assert.equal(frontmatter.description, "bar");
+  assert.equal(body, "# heading\n\nbody\n");
+});
+
+test("parseSkillDocument throws when frontmatter is missing", () => {
+  assert.throws(() => parseSkillDocument("# heading\n", "test.md"), /missing frontmatter/);
+});
+
+test("parseSkillDocument preserves colons inside values", () => {
+  const input = "---\nname: foo\ndescription: a: b: c\n---\nbody\n";
+  const { frontmatter } = parseSkillDocument(input, "test.md");
+  assert.equal(frontmatter.description, "a: b: c");
+});
+
+test("serializeFrontmatter round-trips parsed input", () => {
+  const input = "---\nname: foo\ndescription: bar\n---\nbody\n";
+  const { frontmatter, body } = parseSkillDocument(input, "test.md");
+  const serialized = serializeFrontmatter(frontmatter) + body;
+  assert.equal(serialized, input);
+});
+
+test("serializeFrontmatter respects insertion order", () => {
+  const out = serializeFrontmatter({ b: "1", a: "2" });
+  assert.equal(out, "---\nb: 1\na: 2\n---\n");
+});
+
+test("assertRequiredFields throws on missing field", () => {
+  assert.throws(
+    () => assertRequiredFields({ name: "x" }, ["name", "description"], "f.md"),
+    /missing required field 'description'/,
+  );
+});
+
+test("assertRequiredFields passes when all fields present", () => {
+  assertRequiredFields({ name: "x", description: "y" }, ["name", "description"], "f.md");
+});

--- a/tests/snippet.test.mjs
+++ b/tests/snippet.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { SNIPPET_BEGIN, SNIPPET_END, wrapSnippet } from "../scripts/lib/snippet.mjs";
+
+test("wrapSnippet emits begin/end markers around the body", () => {
+  const out = wrapSnippet("hello");
+  assert.equal(out, `${SNIPPET_BEGIN}\nhello\n${SNIPPET_END}\n`);
+});
+
+test("wrapSnippet collapses trailing newlines", () => {
+  const out = wrapSnippet("hello\n\n\n");
+  assert.equal(out, `${SNIPPET_BEGIN}\nhello\n${SNIPPET_END}\n`);
+});
+
+test("snippet markers contain the @ozzylabs/skills tag", () => {
+  assert.match(SNIPPET_BEGIN, /@ozzylabs\/skills/);
+  assert.match(SNIPPET_END, /@ozzylabs\/skills/);
+});


### PR DESCRIPTION
## Summary

- `scripts/lib/` を新設し、後続 adapter（#10–#13）が継承する `AdapterBase` の純粋関数契約 (`generate(skills): OutputFile[]`) を定義
- 共通ユーティリティとして frontmatter parse/serialize、`.snippet` マーカー（`<!-- begin/end: @ozzylabs/skills -->`）、`Skill` / `OutputFile` の JSDoc 型定義を追加
- `scripts/build.mjs` を新 lib に refactor（既存の 3 系統コピー = `dist/.agents/skills/` / `.agents/skills/` / `.claude/skills/` の挙動は不変）
- `tests/` ディレクトリと `node --test` ベースのユニットテストを追加

## Out of scope

- 各 adapter の具体実装（#10–#13）
- `dist/` 構造の adapter 別サブツリー切替（#14）

## Test plan

- [x] `pnpm run build` — 成功（10 skills × 3 targets）
- [x] `pnpm test` — 12 tests pass
- [x] `pnpm run lint:all` — 全リンター通過

Closes #9