### PR TITLE
ci(adapters): verify adapter determinism and contract

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,3 +65,17 @@ jobs:
             git diff -- dist .agents/skills .claude/skills
             exit 1
           fi
+
+      - name: Verify build is deterministic
+        run: |
+          pnpm build
+          CHANGES=$(git status --porcelain -- dist .agents/skills .claude/skills)
+          if [ -n "$CHANGES" ]; then
+            echo "Second build produced different output — adapter pipeline is non-deterministic."
+            echo "$CHANGES"
+            git diff -- dist .agents/skills .claude/skills
+            exit 1
+          fi
+
+      - name: Test
+        run: pnpm test

--- a/tests/build-pipeline.test.mjs
+++ b/tests/build-pipeline.test.mjs
@@ -1,0 +1,110 @@
+// Integration tests for the adapter pipeline.
+//
+// These run all four adapters against the canonical skill list loaded from
+// src/skills/ and assert end-to-end invariants: deterministic output, every
+// adapter wires up, and required snippet markers are present.
+
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { ClaudeCodeAdapter } from "../scripts/adapters/claude-code.mjs";
+import { CodexCliAdapter } from "../scripts/adapters/codex-cli.mjs";
+import { CopilotAdapter } from "../scripts/adapters/copilot.mjs";
+import { GeminiCliAdapter } from "../scripts/adapters/gemini-cli.mjs";
+import { assertRequiredFields, parseSkillDocument } from "../scripts/lib/frontmatter.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SRC = join(ROOT, "src", "skills");
+
+async function loadCanonicalSkills() {
+  const entries = await readdir(SRC, { withFileTypes: true });
+  const names = entries
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+  const skills = [];
+  for (const name of names) {
+    const srcFile = join(SRC, name, "SKILL.md");
+    const raw = await readFile(srcFile, "utf8");
+    const label = `src/skills/${name}/SKILL.md`;
+    const { frontmatter, body } = parseSkillDocument(raw, label);
+    assertRequiredFields(frontmatter, ["name", "description"], label);
+    skills.push({ name, description: frontmatter.description, frontmatter, body, raw });
+  }
+  return skills;
+}
+
+const ADAPTERS = [
+  new ClaudeCodeAdapter(),
+  new CodexCliAdapter(),
+  new GeminiCliAdapter(),
+  new CopilotAdapter(),
+];
+
+test("every adapter produces non-empty output for canonical skills", async () => {
+  const skills = await loadCanonicalSkills();
+  assert.ok(skills.length > 0, "src/skills/ must contain at least one skill");
+  for (const adapter of ADAPTERS) {
+    const out = adapter.generate(skills);
+    assert.ok(out.length > 0, `${adapter.constructor.name} returned no outputs`);
+    for (const file of out) {
+      assert.ok(file.relativePath, "OutputFile.relativePath must be set");
+      assert.equal(typeof file.content, "string");
+    }
+  }
+});
+
+test("adapter outputs are deterministic across repeated runs", async () => {
+  const skills = await loadCanonicalSkills();
+  for (const adapter of ADAPTERS) {
+    const a = adapter.generate(skills);
+    const b = adapter.generate(skills);
+    assert.deepEqual(a, b, `${adapter.constructor.name} is non-deterministic`);
+  }
+});
+
+test("adapter outputs are deterministic regardless of input order", async () => {
+  const skills = await loadCanonicalSkills();
+  const reversed = [...skills].reverse();
+  for (const adapter of ADAPTERS) {
+    const a = adapter.generate(skills);
+    const b = adapter.generate(reversed);
+    assert.deepEqual(
+      a,
+      b,
+      `${adapter.constructor.name} produces different output for reordered input`,
+    );
+  }
+});
+
+test("Codex CLI and Gemini CLI emit identical AGENTS.md.snippet", async () => {
+  const skills = await loadCanonicalSkills();
+  const codex = new CodexCliAdapter()
+    .generate(skills)
+    .find((o) => o.relativePath === "AGENTS.md.snippet").content;
+  const gemini = new GeminiCliAdapter()
+    .generate(skills)
+    .find((o) => o.relativePath === "AGENTS.md.snippet").content;
+  assert.equal(codex, gemini);
+});
+
+test("every snippet output is wrapped with @ozzylabs/skills markers", async () => {
+  const skills = await loadCanonicalSkills();
+  for (const adapter of ADAPTERS) {
+    for (const file of adapter.generate(skills)) {
+      if (!file.relativePath.endsWith(".snippet")) continue;
+      assert.match(
+        file.content,
+        /<!-- begin: @ozzylabs\/skills -->/,
+        `${file.relativePath} missing begin marker`,
+      );
+      assert.match(
+        file.content,
+        /<!-- end: @ozzylabs\/skills -->/,
+        `${file.relativePath} missing end marker`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Summary

ADR-0018 Decision 3 の CI 検証強化を実装。Decision 4 の PoC consumer / Wave 1-3 段階展開は handbook リポジトリ側のスコープのため、本 PR では skills リポ範囲のみ対応。

### CI 強化

- **決定性検証**: `pnpm build` を 2 回実行し dist に diff が出たら fail
- **dist commit 一致**: 既存の `git status -- dist .agents/skills .claude/skills` チェックは新 adapter 出力 (`dist/claude-code/`, `dist/codex-cli/`, `dist/gemini-cli/`, `dist/copilot/`) を `dist` に含む形で自動カバー
- **adapter test**: \`pnpm test\` を CI ステップに追加（37 tests）

### 統合テスト

- `tests/build-pipeline.test.mjs` で canonical \`src/skills/\` を全 4 adapter にかけ、以下を assert:
  - 全 adapter が非空の OutputFile[] を返す
  - 同入力で再実行・順序入れ替えでも同出力（決定性）
  - Codex CLI と Gemini CLI の \`AGENTS.md.snippet\` が完全一致
  - すべての \`.snippet\` 出力に \`@ozzylabs/skills\` マーカー対が含まれる

### frontmatter contract

#9 で導入した \`assertRequiredFields\` を各 adapter で利用。\`name\` / \`description\` 欠落時は build 失敗。adapter 単体テストでカバー済み。

## Out of scope（handbook リポジトリで継続）

- handbook の \`skills-sync.json\` / Renovate 設定切替
- 4 エージェントでの実機 smoke test
- Wave 1 (commons, create-agentic-app) → Wave 2 (Product 層) → Wave 3 (Frontend/Library 層) の段階展開
- handbook#58 のクローズ
- \`conventions/tool-responsibilities.md\` の更新

## Test plan

- [x] \`pnpm run build\` 1 回目成功
- [x] \`pnpm run build\` 2 回目で diff なし（決定性）
- [x] \`pnpm test\` — 37 tests pass
- [x] \`pnpm run lint:all\` — 全リンター通過

Closes #14