### PR TITLE
feat(skills-sync): expose adapter outputs via per-adapter sub-presets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 
 ## プロジェクト概要
 
-`@ozzylabs/skills`: OzzyLabs 全リポジトリで共有する正準スキルバンドル。`src/skills/{name}/SKILL.md` を SSOT として `dist/.agents/skills/{name}/SKILL.md` を生成し、Renovate sync（`skills-sync.json`）で各 consumer リポへ配信する。
+`@ozzylabs/skills`: OzzyLabs 全リポジトリで共有する正準スキルバンドル。`src/skills/{name}/SKILL.md` を SSOT として `dist/.agents/skills/{name}/SKILL.md` を生成し、Renovate sync（`skills-sync/` preset）で各 consumer リポへ配信する。
 
 ## Tech Stack
 
@@ -45,7 +45,7 @@ pnpm run lint:all          # Biome + markdownlint + yamllint + gitleaks
 - `scripts/build.mjs` — ビルドオーケストレータ
 - `scripts/adapters/{adapter-id}.mjs` — agent 別 adapter（純粋関数、AdapterBase 継承）
 - `scripts/lib/` — 共通 lib（frontmatter, snippet markers, AdapterBase）
-- `skills-sync.json` — consumer 向け Renovate preset
+- `skills-sync/` — consumer 向け Renovate preset（`default.json` がルート preset、`{adapter-id}.json` が adapter opt-in sub-preset）
 - `.dev-config/sync.yaml` — このリポ自身が `commons` consumer であるためのメタデータ
 
 ## 規約

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,6 +47,33 @@ skills_commit: <40-char SHA from main>
 
 Renovate が `ozzy-labs/skills@main` の更新を検知し、`skills_commit` を bump する PR を開く。同梱の `sync.sh`（[ozzy-labs/commons](https://github.com/ozzy-labs/commons) 提供）が本リポの `dist/.agents/skills/` を consumer の `.agents/skills/` へコピーする。
 
+### Adapter opt-in（agent 別出力の取り込み）
+
+agent 別 adapter 出力（`dist/{adapter-id}/`）を取り込む場合は、ルート preset と並べて該当する adapter sub-preset を extends する:
+
+```json
+{
+  "extends": [
+    "github>ozzy-labs/skills//skills-sync",
+    "github>ozzy-labs/skills//skills-sync/claude-code",
+    "github>ozzy-labs/skills//skills-sync/codex-cli",
+    "github>ozzy-labs/skills//skills-sync/gemini-cli",
+    "github>ozzy-labs/skills//skills-sync/copilot"
+  ]
+}
+```
+
+各 adapter sub-preset は Renovate sync PR に `adapter:<id>` ラベルを付与する。sub-preset は加算的で、実際に sync する adapter のみ extends すればよい。
+
+| Sub-preset | Adapter 出力 |
+| --- | --- |
+| `skills-sync/claude-code` | `dist/claude-code/.claude/skills/{name}/SKILL.md` |
+| `skills-sync/codex-cli` | `dist/codex-cli/.agents/skills/{name}/SKILL.md` + `AGENTS.md.snippet` |
+| `skills-sync/gemini-cli` | `dist/gemini-cli/.gemini/settings.json` + `AGENTS.md.snippet` |
+| `skills-sync/copilot` | `dist/copilot/.github/copilot-instructions.md.snippet` |
+
+実ファイルコピーは `commons/sync.sh` が `.dev-config/sync.yaml` と extends された adapter sub-preset を参照してどの `dist/{adapter-id}/` を取り込むかを決定する。既存 consumer は `extends: ["github>ozzy-labs/skills//skills-sync"]` のみでこれまで通り動作する（adapter opt-in は非破壊・加算的）。
+
 ## Adapter 出力
 
 `pnpm build` は `scripts/adapters/` 配下の各 adapter を実行し、`dist/{adapter-id}/` に書き出す:

--- a/README.ja.md
+++ b/README.ja.md
@@ -72,7 +72,7 @@ agent 別 adapter 出力（`dist/{adapter-id}/`）を取り込む場合は、ル
 | `skills-sync/gemini-cli` | `dist/gemini-cli/.gemini/settings.json` + `AGENTS.md.snippet` |
 | `skills-sync/copilot` | `dist/copilot/.github/copilot-instructions.md.snippet` |
 
-実ファイルコピーは `commons/sync.sh` が `.dev-config/sync.yaml` と extends された adapter sub-preset を参照してどの `dist/{adapter-id}/` を取り込むかを決定する。既存 consumer は `extends: ["github>ozzy-labs/skills//skills-sync"]` のみでこれまで通り動作する（adapter opt-in は非破壊・加算的）。
+既存 consumer は `extends: ["github>ozzy-labs/skills//skills-sync"]` のみでこれまで通り動作する（adapter opt-in は非破壊・加算的）。consumer 側の adapter-id ベースファイルコピーは別途 `commons/sync.sh` の拡張として提供され（[commons](https://github.com/ozzy-labs/commons) リポの sub-issue で追跡）、本 preset と `sync.sh` の接続仕様は commons 側で定義される。
 
 ## Adapter 出力
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Each adapter sub-preset adds an `adapter:<id>` label to the Renovate sync PR. Su
 | `skills-sync/gemini-cli` | `dist/gemini-cli/.gemini/settings.json` + `AGENTS.md.snippet` |
 | `skills-sync/copilot` | `dist/copilot/.github/copilot-instructions.md.snippet` |
 
-The actual file copy is performed by `commons/sync.sh`, which reads `.dev-config/sync.yaml` and the consumer's extended adapter sub-presets to determine which `dist/{adapter-id}/` outputs to copy. Existing consumers keep working with `extends: ["github>ozzy-labs/skills//skills-sync"]` alone — adapter opt-in is non-breaking and additive.
+Existing consumers keep working with `extends: ["github>ozzy-labs/skills//skills-sync"]` alone — adapter opt-in is non-breaking and additive. The adapter-id-based file copy on the consumer side is provided by a separate `commons/sync.sh` extension (tracked as a sub-issue on the [commons](https://github.com/ozzy-labs/commons) repo); the connection spec between this preset and `sync.sh` is defined there.
 
 ## Adapter outputs
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,33 @@ skills_commit: <40-char SHA from main>
 
 Renovate detects updates to `ozzy-labs/skills@main` and opens a PR bumping `skills_commit`. The accompanying `sync.sh` (provided by [ozzy-labs/commons](https://github.com/ozzy-labs/commons)) copies `dist/.agents/skills/` from this repository into the consumer's `.agents/skills/`.
 
+### Adapter opt-in (per-agent outputs)
+
+To consume per-agent adapter outputs (`dist/{adapter-id}/`), extend the matching adapter sub-presets alongside the root preset:
+
+```json
+{
+  "extends": [
+    "github>ozzy-labs/skills//skills-sync",
+    "github>ozzy-labs/skills//skills-sync/claude-code",
+    "github>ozzy-labs/skills//skills-sync/codex-cli",
+    "github>ozzy-labs/skills//skills-sync/gemini-cli",
+    "github>ozzy-labs/skills//skills-sync/copilot"
+  ]
+}
+```
+
+Each adapter sub-preset adds an `adapter:<id>` label to the Renovate sync PR. Sub-presets are additive — extend only the adapters you actually sync.
+
+| Sub-preset | Adapter output |
+| --- | --- |
+| `skills-sync/claude-code` | `dist/claude-code/.claude/skills/{name}/SKILL.md` |
+| `skills-sync/codex-cli` | `dist/codex-cli/.agents/skills/{name}/SKILL.md` + `AGENTS.md.snippet` |
+| `skills-sync/gemini-cli` | `dist/gemini-cli/.gemini/settings.json` + `AGENTS.md.snippet` |
+| `skills-sync/copilot` | `dist/copilot/.github/copilot-instructions.md.snippet` |
+
+The actual file copy is performed by `commons/sync.sh`, which reads `.dev-config/sync.yaml` and the consumer's extended adapter sub-presets to determine which `dist/{adapter-id}/` outputs to copy. Existing consumers keep working with `extends: ["github>ozzy-labs/skills//skills-sync"]` alone — adapter opt-in is non-breaking and additive.
+
 ## Adapter outputs
 
 `pnpm build` runs each per-agent adapter under `scripts/adapters/` and writes the result to `dist/{adapter-id}/`:

--- a/skills-sync/claude-code.json
+++ b/skills-sync/claude-code.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Adapter opt-in: claude-code (dist/claude-code/.claude/skills/). Use alongside skills-sync/default.",
+  "extends": ["github>ozzy-labs/skills//skills-sync/default"],
+  "packageRules": [
+    {
+      "matchDepNames": ["ozzy-labs/skills"],
+      "matchDatasources": ["git-refs"],
+      "addLabels": ["adapter:claude-code"]
+    }
+  ]
+}

--- a/skills-sync/codex-cli.json
+++ b/skills-sync/codex-cli.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Adapter opt-in: codex-cli (dist/codex-cli/.agents/skills/ + AGENTS.md.snippet). Use alongside skills-sync/default.",
+  "extends": ["github>ozzy-labs/skills//skills-sync/default"],
+  "packageRules": [
+    {
+      "matchDepNames": ["ozzy-labs/skills"],
+      "matchDatasources": ["git-refs"],
+      "addLabels": ["adapter:codex-cli"]
+    }
+  ]
+}

--- a/skills-sync/copilot.json
+++ b/skills-sync/copilot.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Adapter opt-in: copilot (dist/copilot/.github/copilot-instructions.md.snippet). Use alongside skills-sync/default.",
+  "extends": ["github>ozzy-labs/skills//skills-sync/default"],
+  "packageRules": [
+    {
+      "matchDepNames": ["ozzy-labs/skills"],
+      "matchDatasources": ["git-refs"],
+      "addLabels": ["adapter:copilot"]
+    }
+  ]
+}

--- a/skills-sync/default.json
+++ b/skills-sync/default.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Auto-sync @ozzylabs/skills (ozzy-labs/skills) via Renovate customManagers + git-refs. See https://github.com/ozzy-labs/skills#consumer-setup",
+  "description": "Auto-sync @ozzylabs/skills (ozzy-labs/skills) via Renovate customManagers + git-refs. Extend per-adapter sub-presets (skills-sync/<adapter-id>) to opt in to adapter outputs. See https://github.com/ozzy-labs/skills#consumer-setup",
   "customManagers": [
     {
       "customType": "regex",

--- a/skills-sync/gemini-cli.json
+++ b/skills-sync/gemini-cli.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Adapter opt-in: gemini-cli (dist/gemini-cli/.gemini/settings.json + AGENTS.md.snippet). Use alongside skills-sync/default.",
+  "extends": ["github>ozzy-labs/skills//skills-sync/default"],
+  "packageRules": [
+    {
+      "matchDepNames": ["ozzy-labs/skills"],
+      "matchDatasources": ["git-refs"],
+      "addLabels": ["adapter:gemini-cli"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Restructure the Renovate `skills-sync` preset into a directory with `default.json` (root) and per-adapter sub-presets `{claude-code,codex-cli,gemini-cli,copilot}.json`.
- Existing consumers extending `github>ozzy-labs/skills//skills-sync` continue to work unchanged via Renovate's path resolution to `skills-sync/default.json` (no breaking change).
- Adapter-aware consumers opt in to `dist/{adapter-id}/` outputs by extending the matching sub-preset, which adds an `adapter:<id>` label to the sync PR.
- README (en/ja) and AGENTS.md updated with the opt-in setup.

Connects to handbook#68. The actual `commons/sync.sh` adapter-id-based copy is tracked in the commons sub-issue.

Closes #23

## Test plan

- [x] `pnpm build` — adapter outputs unchanged
- [x] `pnpm test` — 42 tests pass
- [x] `pnpm lint:all` — biome / markdownlint / yamllint / gitleaks all pass
- [ ] Verify Renovate path resolution (`//skills-sync` → `skills-sync/default.json`) by re-running Renovate against an existing consumer post-merge
- [ ] Verify handbook can migrate by adding the 4 adapter sub-preset extends entries