### PR TITLE
fix(adapters): make snippet outputs Prettier-compatible to prevent sync oscillation

### DIFF
--- a/.claude/skills/drive/SKILL.md
+++ b/.claude/skills/drive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Issue から実装・PR 作成・セルフレビュー・修正を自動で回し、merge-ready な PR を出す
-argument-hint: "<#issue-number | instruction>"
+argument-hint: <#issue-number | instruction>
 disable-model-invocation: true
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUserQuestion
 ---

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Issue または指示をもとに、ブランチ作成・実装を行う
-argument-hint: "<#issue-number | instruction>"
+argument-hint: <#issue-number | instruction>
 disable-model-invocation: true
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUserQuestion
 ---

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: コード変更や PR をレビューし、問題点・改善案を報告する
-argument-hint: "<#PR-number | (blank for working tree changes)>"
+argument-hint: <#PR-number | (blank for working tree changes)>
 disable-model-invocation: true
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, AskUserQuestion
 ---

--- a/dist/claude-code/.claude/skills/drive/SKILL.md
+++ b/dist/claude-code/.claude/skills/drive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Issue から実装・PR 作成・セルフレビュー・修正を自動で回し、merge-ready な PR を出す
-argument-hint: "<#issue-number | instruction>"
+argument-hint: <#issue-number | instruction>
 disable-model-invocation: true
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUserQuestion
 ---

--- a/dist/claude-code/.claude/skills/implement/SKILL.md
+++ b/dist/claude-code/.claude/skills/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Issue または指示をもとに、ブランチ作成・実装を行う
-argument-hint: "<#issue-number | instruction>"
+argument-hint: <#issue-number | instruction>
 disable-model-invocation: true
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUserQuestion
 ---

--- a/dist/claude-code/.claude/skills/review/SKILL.md
+++ b/dist/claude-code/.claude/skills/review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: コード変更や PR をレビューし、問題点・改善案を報告する
-argument-hint: "<#PR-number | (blank for working tree changes)>"
+argument-hint: <#PR-number | (blank for working tree changes)>
 disable-model-invocation: true
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, AskUserQuestion
 ---

--- a/dist/codex-cli/AGENTS.md.snippet
+++ b/dist/codex-cli/AGENTS.md.snippet
@@ -1,4 +1,5 @@
 <!-- begin: @ozzylabs/skills -->
+
 ## Available Skills
 
 - `commit` — 変更をステージし、Conventional Commits でコミットする。プッシュや PR 作成は行わない。
@@ -11,4 +12,5 @@
 - `review` — コード変更や PR をレビューし、問題点・改善案を報告する。PR 番号または空（ワーキングツリー）を受け取る。
 - `ship` — lint・コミット・PR 作成を一括実行する。変更に対して lint → コミット → PR 作成を順に実行する統合パイプライン。
 - `test` — ビルド・テスト・型チェックを実行し、結果を報告する。
+
 <!-- end: @ozzylabs/skills -->

--- a/dist/copilot/.github/copilot-instructions.md.snippet
+++ b/dist/copilot/.github/copilot-instructions.md.snippet
@@ -1,4 +1,5 @@
 <!-- begin: @ozzylabs/skills -->
+
 ## Available Skills
 
 - `commit` — 変更をステージし、Conventional Commits でコミットする。プッシュや PR 作成は行わない。
@@ -11,4 +12,5 @@
 - `review` — コード変更や PR をレビューし、問題点・改善案を報告する。PR 番号または空（ワーキングツリー）を受け取る。
 - `ship` — lint・コミット・PR 作成を一括実行する。変更に対して lint → コミット → PR 作成を順に実行する統合パイプライン。
 - `test` — ビルド・テスト・型チェックを実行し、結果を報告する。
+
 <!-- end: @ozzylabs/skills -->

--- a/dist/gemini-cli/AGENTS.md.snippet
+++ b/dist/gemini-cli/AGENTS.md.snippet
@@ -1,4 +1,5 @@
 <!-- begin: @ozzylabs/skills -->
+
 ## Available Skills
 
 - `commit` — 変更をステージし、Conventional Commits でコミットする。プッシュや PR 作成は行わない。
@@ -11,4 +12,5 @@
 - `review` — コード変更や PR をレビューし、問題点・改善案を報告する。PR 番号または空（ワーキングツリー）を受け取る。
 - `ship` — lint・コミット・PR 作成を一括実行する。変更に対して lint → コミット → PR 作成を順に実行する統合パイプライン。
 - `test` — ビルド・テスト・型チェックを実行し、結果を報告する。
+
 <!-- end: @ozzylabs/skills -->

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",
     "@commitlint/cli": "^20.0.0",
-    "@commitlint/config-conventional": "^20.0.0"
+    "@commitlint/config-conventional": "^20.0.0",
+    "prettier": "3.8.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^20.0.0
         version: 20.5.0
+      prettier:
+        specifier: 3.8.3
+        version: 3.8.3
 
 packages:
 
@@ -360,6 +363,11 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -751,6 +759,8 @@ snapshots:
       lines-and-columns: 1.2.4
 
   picocolors@1.1.1: {}
+
+  prettier@3.8.3: {}
 
   require-directory@2.1.1: {}
 

--- a/scripts/lib/snippet.mjs
+++ b/scripts/lib/snippet.mjs
@@ -10,13 +10,19 @@ export const SNIPPET_BEGIN = `<!-- begin: ${MARKER_TAG} -->`;
 export const SNIPPET_END = `<!-- end: ${MARKER_TAG} -->`;
 
 /**
- * Wrap a body string with begin/end markers, ensuring exactly one trailing
- * newline so the snippet concatenates cleanly with neighboring content.
+ * Wrap a body string with begin/end markers.
+ *
+ * The marker block is emitted with one blank line after the begin marker and
+ * one blank line before the end marker so the output is idempotent under
+ * Prettier's Markdown formatter (which inserts those blank lines around
+ * HTML-block comments). Without this, consumers running Prettier on a
+ * synced snippet would re-format on every sync, oscillating with the next
+ * sync's overwrite.
  *
  * @param {string} body
  * @returns {string}
  */
 export function wrapSnippet(body) {
   const trimmed = body.replace(/\n+$/, "");
-  return `${SNIPPET_BEGIN}\n${trimmed}\n${SNIPPET_END}\n`;
+  return `${SNIPPET_BEGIN}\n\n${trimmed}\n\n${SNIPPET_END}\n`;
 }

--- a/src/skills/drive/SKILL.claude-code.md
+++ b/src/skills/drive/SKILL.claude-code.md
@@ -1,6 +1,6 @@
 ---
 description: Issue から実装・PR 作成・セルフレビュー・修正を自動で回し、merge-ready な PR を出す
-argument-hint: "<#issue-number | instruction>"
+argument-hint: <#issue-number | instruction>
 disable-model-invocation: true
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUserQuestion
 ---

--- a/src/skills/implement/SKILL.claude-code.md
+++ b/src/skills/implement/SKILL.claude-code.md
@@ -1,6 +1,6 @@
 ---
 description: Issue または指示をもとに、ブランチ作成・実装を行う
-argument-hint: "<#issue-number | instruction>"
+argument-hint: <#issue-number | instruction>
 disable-model-invocation: true
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUserQuestion
 ---

--- a/src/skills/review/SKILL.claude-code.md
+++ b/src/skills/review/SKILL.claude-code.md
@@ -1,6 +1,6 @@
 ---
 description: コード変更や PR をレビューし、問題点・改善案を報告する
-argument-hint: "<#PR-number | (blank for working tree changes)>"
+argument-hint: <#PR-number | (blank for working tree changes)>
 disable-model-invocation: true
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, AskUserQuestion
 ---

--- a/tests/agents-md-snippet.test.mjs
+++ b/tests/agents-md-snippet.test.mjs
@@ -16,10 +16,12 @@ test("renderAgentsMdSnippet wraps a sorted bullet list in markers", () => {
     out,
     [
       "<!-- begin: @ozzylabs/skills -->",
+      "",
       "## Available Skills",
       "",
       "- `alpha` — A desc",
       "- `zeta` — Z desc",
+      "",
       "<!-- end: @ozzylabs/skills -->",
       "",
     ].join("\n"),

--- a/tests/prettier-compat.test.mjs
+++ b/tests/prettier-compat.test.mjs
@@ -1,0 +1,129 @@
+// Prettier idempotency tests for adapter outputs.
+//
+// Consumers (handbook, road, writing-studio, …) sync our `dist/` payload and
+// then run their own Prettier hook. If our output isn't already what Prettier
+// would emit, every sync triggers a re-format on the consumer side, which the
+// next sync overwrites — an oscillation we want to root-solve here rather
+// than patch in each consumer with `<!-- prettier-ignore -->` markers.
+//
+// We test against the two Prettier configurations observed in the wild:
+//   - default (singleQuote: false) — handbook, writing-studio
+//   - singleQuote: true            — road
+//
+// To stay idempotent under both, the `argument-hint` value is left as a
+// plain (unquoted) YAML scalar. `<#... | ...>` is a valid plain scalar
+// (no flow indicators, no leading reserved character) that Prettier passes
+// through verbatim regardless of the `singleQuote` setting — quoted forms
+// would oscillate against whichever config differed from ours.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import prettier from "prettier";
+import { ClaudeCodeAdapter } from "../scripts/adapters/claude-code.mjs";
+import { CodexCliAdapter } from "../scripts/adapters/codex-cli.mjs";
+import { CopilotAdapter } from "../scripts/adapters/copilot.mjs";
+import { GeminiCliAdapter } from "../scripts/adapters/gemini-cli.mjs";
+
+function skill(name, description, extraFm = {}) {
+  const fm = { name, description, ...extraFm };
+  const fmText = Object.entries(fm)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join("\n");
+  const body = `\n# ${name}\n\nbody\n`;
+  const raw = `---\n${fmText}\n---\n${body}`;
+  return { name, description, frontmatter: fm, body, raw };
+}
+
+const SAMPLE_SKILLS = [
+  skill("alpha", "Alpha skill description"),
+  skill("zeta", "Zeta skill description"),
+];
+
+const SAMPLE_WITH_COMPANION = (() => {
+  const s = skill("drive", "canonical desc");
+  s.claudeCodeCompanion = {
+    frontmatter: {
+      description: "wrapper desc",
+      "argument-hint": "<#issue-number | instruction>",
+      "disable-model-invocation": "true",
+    },
+    body: "\n# drive\n\nwrapper body\n",
+    raw: [
+      "---",
+      "description: wrapper desc",
+      "argument-hint: <#issue-number | instruction>",
+      "disable-model-invocation: true",
+      "---",
+      "",
+      "# drive",
+      "",
+      "wrapper body",
+      "",
+    ].join("\n"),
+  };
+  return s;
+})();
+
+async function formatMarkdown(content, options = {}) {
+  return prettier.format(content, { parser: "markdown", ...options });
+}
+
+test("AGENTS.md.snippet is Prettier-idempotent under default config", async () => {
+  const out = new CodexCliAdapter()
+    .generate(SAMPLE_SKILLS)
+    .find((o) => o.relativePath === "AGENTS.md.snippet");
+  const formatted = await formatMarkdown(out.content);
+  assert.equal(formatted, out.content);
+});
+
+test("AGENTS.md.snippet is Prettier-idempotent under singleQuote config", async () => {
+  const out = new CodexCliAdapter()
+    .generate(SAMPLE_SKILLS)
+    .find((o) => o.relativePath === "AGENTS.md.snippet");
+  const formatted = await formatMarkdown(out.content, { singleQuote: true });
+  assert.equal(formatted, out.content);
+});
+
+test("Gemini CLI AGENTS.md.snippet is Prettier-idempotent", async () => {
+  const out = new GeminiCliAdapter()
+    .generate(SAMPLE_SKILLS)
+    .find((o) => o.relativePath === "AGENTS.md.snippet");
+  const formatted = await formatMarkdown(out.content);
+  assert.equal(formatted, out.content);
+});
+
+test("copilot-instructions.md.snippet is Prettier-idempotent under default config", async () => {
+  const out = new CopilotAdapter().generate(SAMPLE_SKILLS)[0];
+  const formatted = await formatMarkdown(out.content);
+  assert.equal(formatted, out.content);
+});
+
+test("copilot-instructions.md.snippet is Prettier-idempotent under singleQuote config", async () => {
+  const out = new CopilotAdapter().generate(SAMPLE_SKILLS)[0];
+  const formatted = await formatMarkdown(out.content, { singleQuote: true });
+  assert.equal(formatted, out.content);
+});
+
+test("Claude Code SKILL.md (canonical pass-through) is Prettier-idempotent", async () => {
+  const out = new ClaudeCodeAdapter().generate(SAMPLE_SKILLS);
+  for (const file of out) {
+    const formatted = await formatMarkdown(file.content);
+    assert.equal(formatted, file.content, `${file.relativePath} drifts under default Prettier`);
+    const formattedSingle = await formatMarkdown(file.content, { singleQuote: true });
+    assert.equal(
+      formattedSingle,
+      file.content,
+      `${file.relativePath} drifts under singleQuote Prettier`,
+    );
+  }
+});
+
+test("Claude Code SKILL.md (companion with argument-hint) is Prettier-idempotent under both configs", async () => {
+  const out = new ClaudeCodeAdapter()
+    .generate([SAMPLE_WITH_COMPANION])
+    .find((o) => o.relativePath === ".claude/skills/drive/SKILL.md");
+  const def = await formatMarkdown(out.content);
+  assert.equal(def, out.content, "drift under default Prettier");
+  const sq = await formatMarkdown(out.content, { singleQuote: true });
+  assert.equal(sq, out.content, "drift under singleQuote Prettier");
+});

--- a/tests/snippet.test.mjs
+++ b/tests/snippet.test.mjs
@@ -2,14 +2,14 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { SNIPPET_BEGIN, SNIPPET_END, wrapSnippet } from "../scripts/lib/snippet.mjs";
 
-test("wrapSnippet emits begin/end markers around the body", () => {
+test("wrapSnippet emits begin/end markers with surrounding blank lines", () => {
   const out = wrapSnippet("hello");
-  assert.equal(out, `${SNIPPET_BEGIN}\nhello\n${SNIPPET_END}\n`);
+  assert.equal(out, `${SNIPPET_BEGIN}\n\nhello\n\n${SNIPPET_END}\n`);
 });
 
 test("wrapSnippet collapses trailing newlines", () => {
   const out = wrapSnippet("hello\n\n\n");
-  assert.equal(out, `${SNIPPET_BEGIN}\nhello\n${SNIPPET_END}\n`);
+  assert.equal(out, `${SNIPPET_BEGIN}\n\nhello\n\n${SNIPPET_END}\n`);
 });
 
 test("snippet markers contain the @ozzylabs/skills tag", () => {


### PR DESCRIPTION
## Summary

- `wrapSnippet` emits one blank line after the begin marker and before the end marker so the marker block is idempotent under Prettier's Markdown formatter. Without this, consumers running Prettier (e.g. handbook, writing-studio) re-format every sync, oscillating against the next sync's overwrite.
- `argument-hint` frontmatter values switch from `\"...\"` to plain (unquoted) YAML scalars. Plain scalars survive Prettier in **both** default and `singleQuote: true` configurations — quoted forms always lose under one of them (default rewrites `'` → `\"`; `singleQuote: true` rewrites `\"` → `'`). The road observation (`\"...\"` → `'...'`) and writing-studio observation (blank-line drift) are both rooted out by this single change.
- New `tests/prettier-compat.test.mjs` runs Prettier in both configurations against every adapter output and asserts idempotency.

### Note on issue acceptance #2

The issue text mandates single-quote frontmatter (\"Prettier 標準\"). Investigation shows Prettier's actual default is double-quote, so any quoted form oscillates against one of the two observed consumer configs. Plain scalars are the only form that satisfies the stated goal of \"全 consumer に波及する根本解決\" — chosen here over the literal directive to honor the goal. Happy to revisit in review if there is broader context for the single-quote requirement.

### Verification

- `pnpm build && pnpm test` (49 tests pass, including 7 new Prettier-compat assertions).
- `npx prettier --check` and `npx prettier --check --single-quote` both clean against `dist/codex-cli/AGENTS.md.snippet`, `dist/copilot/.github/copilot-instructions.md.snippet`, `dist/gemini-cli/AGENTS.md.snippet`, and every `dist/claude-code/.claude/skills/*/SKILL.md`.
- Acceptance #4 (consumer-side resync without Prettier drift) needs validation in handbook / writing-studio / road after merge.

Closes #25