### PR TITLE
fix(sync): ship replace-snippet.sh with marker-missing auto-recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,10 @@ pnpm run lint:all          # Biome + markdownlint + yamllint + gitleaks
 - `src/skills/{name}/SKILL.claude-code.md` — Claude Code 固有 wrapper（任意）。companion 仕様は README.md を参照
 - `dist/.agents/skills/{name}/SKILL.md` — npm payload / Renovate consumer 向けビルド出力（commit 対象）
 - `dist/{adapter-id}/` — agent 別 adapter 出力（`claude-code` / `codex-cli` / `gemini-cli` / `copilot`）
+- `dist/sync/replace-snippet.sh` — 下流 sync workflow 向けマーカー間置換ヘルパー（マーカー欠落時は append でフォールバック）
 - `scripts/build.mjs` — ビルドオーケストレータ
 - `scripts/adapters/{adapter-id}.mjs` — agent 別 adapter（純粋関数、AdapterBase 継承）
+- `scripts/sync/replace-snippet.sh` — `dist/sync/` にコピーされる sync ヘルパーの SSOT
 - `scripts/lib/` — 共通 lib（frontmatter, snippet markers, AdapterBase）
 - `skills-sync/` — consumer 向け Renovate preset（`default.json` がルート preset、`{adapter-id}.json` が adapter opt-in sub-preset）
 - `.commons/sync.yaml` — このリポ自身が `commons` consumer であるためのメタデータ

--- a/README.ja.md
+++ b/README.ja.md
@@ -74,6 +74,24 @@ agent 別 adapter 出力（`dist/{adapter-id}/`）を取り込む場合は、ル
 
 既存 consumer は `extends: ["github>ozzy-labs/skills//skills-sync"]` のみでこれまで通り動作する（adapter opt-in は非破壊・加算的）。consumer 側の adapter-id ベースファイルコピーは別途 `commons/sync.sh` の拡張として提供され（[commons](https://github.com/ozzy-labs/commons) リポの sub-issue で追跡）、本 preset と `sync.sh` の接続仕様は commons 側で定義される。
 
+### Snippet sync ヘルパー
+
+`dist/sync/replace-snippet.sh` は、snippet ファイル（`AGENTS.md.snippet` / `copilot-instructions.md.snippet`）を consumer 所有ファイルへマージする下流 sync workflow 向けのドロップインヘルパーとして配布される:
+
+```bash
+.sync-skills/dist/sync/replace-snippet.sh \
+  AGENTS.md \
+  .sync-skills/dist/codex-cli/AGENTS.md.snippet
+```
+
+挙動:
+
+- ターゲットに begin マーカーがある場合 → マーカーブロック（begin..end 包括）を snippet 内容で置換する
+- マーカーが欠落している場合（別 sync — 典型的には `commons` — がファイルを上書きしてマネージド領域を消した場合）→ ファイル末尾に snippet を append する。snippet 自体がマーカーを含むため、次回以降は in-place 置換に戻る
+- ターゲットファイルが存在しない場合 → snippet から新規作成する
+
+この自動復旧により、下流 workflow がマーカー処理ロジックを自前で持つ必要がなくなり、`.github/copilot-instructions.md` のような共有ファイルの所有権が複数の sync 元にまたがる場合でも hard failure を回避できる。
+
 ## Adapter 出力
 
 `pnpm build` は `scripts/adapters/` 配下の各 adapter を実行し、`dist/{adapter-id}/` に書き出す:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,24 @@ Each adapter sub-preset adds an `adapter:<id>` label to the Renovate sync PR. Su
 
 Existing consumers keep working with `extends: ["github>ozzy-labs/skills//skills-sync"]` alone — adapter opt-in is non-breaking and additive. The adapter-id-based file copy on the consumer side is provided by a separate `commons/sync.sh` extension (tracked as a sub-issue on the [commons](https://github.com/ozzy-labs/commons) repo); the connection spec between this preset and `sync.sh` is defined there.
 
+### Snippet sync helper
+
+`dist/sync/replace-snippet.sh` is shipped as a drop-in helper for downstream sync workflows that merge snippet files (`AGENTS.md.snippet`, `copilot-instructions.md.snippet`) into consumer-owned files:
+
+```bash
+.sync-skills/dist/sync/replace-snippet.sh \
+  AGENTS.md \
+  .sync-skills/dist/codex-cli/AGENTS.md.snippet
+```
+
+Behavior:
+
+- Target contains the begin marker → replace the marker block (begin..end inclusive) with the snippet contents.
+- Target is missing the marker (e.g. another sync — typically `commons` — overwrote the file and stripped the managed region) → append the snippet to the end of the file. The snippet itself carries the markers, so the next run resumes in-place replacement.
+- Target file does not exist → create it from the snippet.
+
+This auto-recovery removes the need for downstream workflows to carry their own marker-handling logic and avoids hard failures when ownership of a shared file like `.github/copilot-instructions.md` shifts between sync sources.
+
 ## Adapter outputs
 
 `pnpm build` runs each per-agent adapter under `scripts/adapters/` and writes the result to `dist/{adapter-id}/`:

--- a/dist/sync/replace-snippet.sh
+++ b/dist/sync/replace-snippet.sh
@@ -35,7 +35,10 @@ fi
 append_snippet() {
   mkdir -p "$(dirname "${target}")"
   if [[ -s "${target}" ]]; then
-    if [[ "$(tail -c 1 "${target}" 2>/dev/null || printf '')" != $'\n' ]]; then
+    # Ensure the existing file ends with exactly one newline before adding a
+    # blank-line separator. Bash's $() strips trailing newlines, so an empty
+    # capture means the last byte already is a newline.
+    if [[ -n "$(tail -c 1 "${target}" 2>/dev/null)" ]]; then
       printf '\n' >>"${target}"
     fi
     printf '\n' >>"${target}"

--- a/dist/sync/replace-snippet.sh
+++ b/dist/sync/replace-snippet.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# replace-snippet.sh — sync a `@ozzylabs/skills` snippet into a consumer-owned file.
+#
+# Usage:
+#   replace-snippet.sh <target> <snippet>
+#
+# Behavior:
+#   - If <target> exists AND contains the begin marker → replace the marker
+#     block (begin..end inclusive) with the contents of <snippet>.
+#   - Otherwise (file missing OR marker absent) → append <snippet> to
+#     <target> (creating the file and parent directories if needed). This
+#     auto-recovers from upstream tooling (e.g. commons sync) that overwrites
+#     the file and strips the marker block. See ozzy-labs/skills#33.
+#
+# The snippet itself contains the begin/end markers, so the recovered file is
+# immediately re-syncable on subsequent runs.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <target> <snippet>" >&2
+  exit 2
+fi
+
+target="$1"
+snippet="$2"
+
+readonly BEGIN_MARKER='<!-- begin: @ozzylabs/skills -->'
+
+if [[ ! -f "${snippet}" ]]; then
+  echo "Error: snippet file not found: ${snippet}" >&2
+  exit 1
+fi
+
+append_snippet() {
+  mkdir -p "$(dirname "${target}")"
+  if [[ -s "${target}" ]]; then
+    if [[ "$(tail -c 1 "${target}" 2>/dev/null || printf '')" != $'\n' ]]; then
+      printf '\n' >>"${target}"
+    fi
+    printf '\n' >>"${target}"
+  fi
+  cat "${snippet}" >>"${target}"
+  echo "replace-snippet: appended snippet to ${target} (marker missing or file absent)"
+}
+
+if [[ ! -f "${target}" ]] || ! grep -qF "${BEGIN_MARKER}" "${target}"; then
+  append_snippet
+  exit 0
+fi
+
+awk -v snippet_file="${snippet}" '
+  BEGIN { in_block = 0 }
+  /<!-- begin: @ozzylabs\/skills -->/ && !in_block {
+    while ((getline line < snippet_file) > 0) print line
+    close(snippet_file)
+    in_block = 1
+    next
+  }
+  /<!-- end: @ozzylabs\/skills -->/ && in_block {
+    in_block = 0
+    next
+  }
+  !in_block { print }
+' "${target}" >"${target}.tmp"
+mv "${target}.tmp" "${target}"

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -14,7 +14,7 @@
 //      sole writer.
 
 import { existsSync } from "node:fs";
-import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { chmod, copyFile, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { ClaudeCodeAdapter } from "./adapters/claude-code.mjs";
@@ -110,6 +110,18 @@ async function writeLegacyTargets(skills) {
   }
 }
 
+async function writeSyncHelpers() {
+  const src = join(ROOT, "scripts", "sync", "replace-snippet.sh");
+  const destDir = join(DIST, "sync");
+  if (existsSync(destDir)) {
+    await rm(destDir, { recursive: true, force: true });
+  }
+  await mkdir(destDir, { recursive: true });
+  const dest = join(destDir, "replace-snippet.sh");
+  await copyFile(src, dest);
+  await chmod(dest, 0o755);
+}
+
 async function writeAdapterOutputs(skills) {
   for (const adapter of ADAPTERS) {
     const id = adapter.constructor.id;
@@ -133,6 +145,7 @@ async function main() {
   const skills = await loadSkills();
   await writeLegacyTargets(skills);
   await writeAdapterOutputs(skills);
+  await writeSyncHelpers();
 
   console.log(`✓ Built ${skills.length} skill(s)`);
   console.log("Legacy targets:");
@@ -143,6 +156,8 @@ async function main() {
   for (const adapter of ADAPTERS) {
     console.log(`  dist/${adapter.constructor.id}/`);
   }
+  console.log("Sync helpers:");
+  console.log("  dist/sync/replace-snippet.sh");
   console.log("Skills:");
   for (const skill of skills) {
     console.log(`  - ${skill.name}`);

--- a/scripts/sync/replace-snippet.sh
+++ b/scripts/sync/replace-snippet.sh
@@ -35,7 +35,10 @@ fi
 append_snippet() {
   mkdir -p "$(dirname "${target}")"
   if [[ -s "${target}" ]]; then
-    if [[ "$(tail -c 1 "${target}" 2>/dev/null || printf '')" != $'\n' ]]; then
+    # Ensure the existing file ends with exactly one newline before adding a
+    # blank-line separator. Bash's $() strips trailing newlines, so an empty
+    # capture means the last byte already is a newline.
+    if [[ -n "$(tail -c 1 "${target}" 2>/dev/null)" ]]; then
       printf '\n' >>"${target}"
     fi
     printf '\n' >>"${target}"

--- a/scripts/sync/replace-snippet.sh
+++ b/scripts/sync/replace-snippet.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# replace-snippet.sh — sync a `@ozzylabs/skills` snippet into a consumer-owned file.
+#
+# Usage:
+#   replace-snippet.sh <target> <snippet>
+#
+# Behavior:
+#   - If <target> exists AND contains the begin marker → replace the marker
+#     block (begin..end inclusive) with the contents of <snippet>.
+#   - Otherwise (file missing OR marker absent) → append <snippet> to
+#     <target> (creating the file and parent directories if needed). This
+#     auto-recovers from upstream tooling (e.g. commons sync) that overwrites
+#     the file and strips the marker block. See ozzy-labs/skills#33.
+#
+# The snippet itself contains the begin/end markers, so the recovered file is
+# immediately re-syncable on subsequent runs.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <target> <snippet>" >&2
+  exit 2
+fi
+
+target="$1"
+snippet="$2"
+
+readonly BEGIN_MARKER='<!-- begin: @ozzylabs/skills -->'
+
+if [[ ! -f "${snippet}" ]]; then
+  echo "Error: snippet file not found: ${snippet}" >&2
+  exit 1
+fi
+
+append_snippet() {
+  mkdir -p "$(dirname "${target}")"
+  if [[ -s "${target}" ]]; then
+    if [[ "$(tail -c 1 "${target}" 2>/dev/null || printf '')" != $'\n' ]]; then
+      printf '\n' >>"${target}"
+    fi
+    printf '\n' >>"${target}"
+  fi
+  cat "${snippet}" >>"${target}"
+  echo "replace-snippet: appended snippet to ${target} (marker missing or file absent)"
+}
+
+if [[ ! -f "${target}" ]] || ! grep -qF "${BEGIN_MARKER}" "${target}"; then
+  append_snippet
+  exit 0
+fi
+
+awk -v snippet_file="${snippet}" '
+  BEGIN { in_block = 0 }
+  /<!-- begin: @ozzylabs\/skills -->/ && !in_block {
+    while ((getline line < snippet_file) > 0) print line
+    close(snippet_file)
+    in_block = 1
+    next
+  }
+  /<!-- end: @ozzylabs\/skills -->/ && in_block {
+    in_block = 0
+    next
+  }
+  !in_block { print }
+' "${target}" >"${target}.tmp"
+mv "${target}.tmp" "${target}"

--- a/tests/replace-snippet.test.mjs
+++ b/tests/replace-snippet.test.mjs
@@ -1,0 +1,159 @@
+// Tests for scripts/sync/replace-snippet.sh.
+//
+// The helper is the single source of truth for the marker-block sync logic
+// downstream consumers run. Behavior contract:
+//   - target has markers → replace marker block with snippet
+//   - target missing markers → append snippet (auto-recovery for ozzy-labs/skills#33)
+//   - target file does not exist → create file with snippet content
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SCRIPT = join(ROOT, "scripts", "sync", "replace-snippet.sh");
+const SNIPPET = `<!-- begin: @ozzylabs/skills -->
+
+## Available Skills
+
+- \`foo\` — Foo skill
+- \`bar\` — Bar skill
+
+<!-- end: @ozzylabs/skills -->
+`;
+
+async function withTmp(fn) {
+  const dir = await mkdtemp(join(tmpdir(), "replace-snippet-"));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function run(target, snippet) {
+  return spawnSync("bash", [SCRIPT, target, snippet], { encoding: "utf8" });
+}
+
+test("replaces marker block when markers are present", async () => {
+  await withTmp(async (dir) => {
+    const target = join(dir, "AGENTS.md");
+    const snippet = join(dir, "snippet.md");
+    await writeFile(snippet, SNIPPET);
+    await writeFile(
+      target,
+      [
+        "# Project AGENTS",
+        "",
+        "Hand-written intro.",
+        "",
+        "<!-- begin: @ozzylabs/skills -->",
+        "(stale content)",
+        "<!-- end: @ozzylabs/skills -->",
+        "",
+        "## Hand-written tail",
+        "",
+        "More content.",
+        "",
+      ].join("\n"),
+    );
+    const result = run(target, snippet);
+    assert.equal(result.status, 0, result.stderr);
+    const out = await readFile(target, "utf8");
+    assert.match(out, /# Project AGENTS/);
+    assert.match(out, /Hand-written intro\./);
+    assert.match(out, /## Hand-written tail/);
+    assert.match(out, /- `foo` — Foo skill/);
+    assert.doesNotMatch(out, /\(stale content\)/);
+    assert.match(out, /<!-- begin: @ozzylabs\/skills -->/);
+    assert.match(out, /<!-- end: @ozzylabs\/skills -->/);
+  });
+});
+
+test("appends snippet when marker is missing", async () => {
+  await withTmp(async (dir) => {
+    const target = join(dir, "copilot-instructions.md");
+    const snippet = join(dir, "snippet.md");
+    await writeFile(snippet, SNIPPET);
+    await writeFile(target, "# Copilot instructions\n\nHand-written body.\n");
+    const result = run(target, snippet);
+    assert.equal(result.status, 0, result.stderr);
+    const out = await readFile(target, "utf8");
+    assert.match(out, /# Copilot instructions/);
+    assert.match(out, /Hand-written body\./);
+    assert.match(out, /<!-- begin: @ozzylabs\/skills -->/);
+    assert.match(out, /<!-- end: @ozzylabs\/skills -->/);
+    assert.match(out, /- `foo` — Foo skill/);
+    const beginIdx = out.indexOf("<!-- begin: @ozzylabs/skills -->");
+    const handIdx = out.indexOf("Hand-written body.");
+    assert.ok(handIdx < beginIdx, "snippet must be appended after existing content");
+  });
+});
+
+test("creates file when target does not exist", async () => {
+  await withTmp(async (dir) => {
+    const target = join(dir, "nested", "AGENTS.md");
+    const snippet = join(dir, "snippet.md");
+    await writeFile(snippet, SNIPPET);
+    const result = run(target, snippet);
+    assert.equal(result.status, 0, result.stderr);
+    const out = await readFile(target, "utf8");
+    assert.equal(out, SNIPPET);
+  });
+});
+
+test("handles target without trailing newline before append", async () => {
+  await withTmp(async (dir) => {
+    const target = join(dir, "AGENTS.md");
+    const snippet = join(dir, "snippet.md");
+    await writeFile(snippet, SNIPPET);
+    await writeFile(target, "no-trailing-newline");
+    const result = run(target, snippet);
+    assert.equal(result.status, 0, result.stderr);
+    const out = await readFile(target, "utf8");
+    assert.ok(out.startsWith("no-trailing-newline\n"));
+    assert.match(out, /<!-- begin: @ozzylabs\/skills -->/);
+  });
+});
+
+test("re-running on appended file replaces marker block in place", async () => {
+  await withTmp(async (dir) => {
+    const target = join(dir, "AGENTS.md");
+    const snippet = join(dir, "snippet.md");
+    await writeFile(snippet, SNIPPET);
+    await writeFile(target, "# Hand-written\n\nBody.\n");
+
+    const first = run(target, snippet);
+    assert.equal(first.status, 0, first.stderr);
+
+    const second = run(target, snippet);
+    assert.equal(second.status, 0, second.stderr);
+
+    const out = await readFile(target, "utf8");
+    const beginCount = (out.match(/<!-- begin: @ozzylabs\/skills -->/g) ?? []).length;
+    const endCount = (out.match(/<!-- end: @ozzylabs\/skills -->/g) ?? []).length;
+    assert.equal(beginCount, 1, "begin marker must remain unique after re-run");
+    assert.equal(endCount, 1, "end marker must remain unique after re-run");
+  });
+});
+
+test("fails with usage error when args are wrong", async () => {
+  const result = spawnSync("bash", [SCRIPT], { encoding: "utf8" });
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /Usage:/);
+});
+
+test("fails when snippet file is missing", async () => {
+  await withTmp(async (dir) => {
+    const target = join(dir, "AGENTS.md");
+    const snippet = join(dir, "missing.md");
+    await writeFile(target, "x");
+    const result = run(target, snippet);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /snippet file not found/);
+  });
+});

--- a/tests/replace-snippet.test.mjs
+++ b/tests/replace-snippet.test.mjs
@@ -91,6 +91,12 @@ test("appends snippet when marker is missing", async () => {
     const beginIdx = out.indexOf("<!-- begin: @ozzylabs/skills -->");
     const handIdx = out.indexOf("Hand-written body.");
     assert.ok(handIdx < beginIdx, "snippet must be appended after existing content");
+    // Exactly one blank line between existing content and the snippet.
+    assert.match(
+      out,
+      /Hand-written body\.\n\n<!-- begin: @ozzylabs\/skills -->/,
+      "must use exactly one blank line as separator",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #33.

下流の `sync-skills.yaml` は `.github/copilot-instructions.md` から `<!-- begin: @ozzylabs/skills -->` マーカーが失われると hard-fail する。これは commons sync が同ファイルを上書きしてマネージド領域を消した直後に発生していた。

skills 側で `dist/sync/replace-snippet.sh` を配布し、下流 workflow からそのまま呼び出せる単一 SSOT のヘルパーを提供する。挙動:

- ターゲットに begin マーカーあり → マーカーブロック (begin..end 包括) を snippet で置換
- マーカー欠落 / ファイル無し → snippet を append (ファイル新規作成も対応) — 次回以降は in-place 置換に復帰
- snippet 自体がマーカーを含むため自動復旧後の再 sync が冪等

これにより consumer 所有ファイル (`.github/copilot-instructions.md` など) の所有権が複数の sync 元にまたがる場合でも sync workflow が落ちなくなる。

## Changes

- `scripts/sync/replace-snippet.sh` — ヘルパー本体 (SSOT)
- `scripts/build.mjs` — `dist/sync/replace-snippet.sh` への copy + chmod 755 を追加
- `dist/sync/replace-snippet.sh` — ビルド出力 (commit 対象、下流 sync workflow が clone 経由で参照)
- `tests/replace-snippet.test.mjs` — マーカーあり/欠落/ファイル無し/再実行/エラーケースをカバー
- `README.md` / `README.ja.md` / `AGENTS.md` — ヘルパーの利用方法を追記

## Test plan

- [x] `pnpm run build` — `dist/sync/replace-snippet.sh` が生成・755 になる
- [x] `pnpm test` — 56 件すべて通過 (新規 7 ケース含む)
- [x] `pnpm run lint:all` — 全 linter 通過
- [x] `shellcheck scripts/sync/replace-snippet.sh` — クリーン
- [ ] 下流 `sync-skills.yaml` を `.sync-skills/dist/sync/replace-snippet.sh` 呼び出しに切り替え、本変更がリリースされた SHA で marker 欠落シナリオを再現して復旧することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)