### PR TITLE
fix(sync): pin .github/workflows/* to fix Sync commons permission errors

### DIFF
--- a/.commons/sync.yaml
+++ b/.commons/sync.yaml
@@ -11,6 +11,8 @@ pinned:
   - biome.json
   - renovate.json
   - .gitignore
+  - .github/workflows/pr-check.yaml
+  - .github/workflows/sync-commons.yaml
   - .agents/skills/README.md
   - .agents/skills/commit-conventions/SKILL.md
   - .agents/skills/commit/SKILL.md


### PR DESCRIPTION
## Summary

- Add `.github/workflows/pr-check.yaml` and `.github/workflows/sync-commons.yaml` to `.commons/sync.yaml` `pinned`, so they are excluded from automated sync.
- Resolves the recurring `Sync commons` failures where `GITHUB_TOKEN` was rejected with `refusing to allow a GitHub App to create or update workflow ... without workflows permission`.

## Background

`GITHUB_TOKEN` lacks the `workflows` scope and cannot push branches that modify `.github/workflows/*`. Every time upstream commons updated either workflow file, the sync PR creation would fail. See `ozzy-labs/commons#93` for the failure log archive.

The upstream decision (`ozzy-labs/commons#95`, ADR-0012) is to **pin workflows in consumers** instead of distributing a GitHub App. This PR enacts that decision in this repo.

## Trade-off

- ✅ No GitHub App / PAT / org secrets required
- ❌ Workflow improvements from commons no longer propagate automatically — they must be cherry-picked manually (`cp ../commons/dist/.github/workflows/*.yaml .github/workflows/`)

## Test plan

- [x] `git diff main...HEAD` reviewed — only 2 lines added to `.commons/sync.yaml`
- [ ] Merge `ozzy-labs/commons#95` first so upstream `dist/.github/workflows/*` is back to the `GITHUB_TOKEN`-compatible version
- [ ] After both PRs land, manually dispatch `Sync commons` on this repo and confirm the run succeeds (no longer touches the pinned workflow files)

## Refs

- `ozzy-labs/commons#93` — original bug
- `ozzy-labs/commons#95` — upstream switch to pinned strategy + ADR-0012

🤖 Generated with [Claude Code](https://claude.com/claude-code)