### PR TITLE
fix(adapters): emit Prettier-compatible JSON for .gemini/settings.json

### DIFF
--- a/dist/gemini-cli/.gemini/settings.json
+++ b/dist/gemini-cli/.gemini/settings.json
@@ -1,7 +1,1 @@
-{
-  "context": {
-    "fileName": [
-      "AGENTS.md"
-    ]
-  }
-}
+{ "context": { "fileName": ["AGENTS.md"] } }

--- a/scripts/adapters/claude-code.mjs
+++ b/scripts/adapters/claude-code.mjs
@@ -28,9 +28,9 @@ export class ClaudeCodeAdapter extends AdapterBase {
 
   /**
    * @param {Skill[]} skills
-   * @returns {OutputFile[]}
+   * @returns {Promise<OutputFile[]>}
    */
-  generate(skills) {
+  async generate(skills) {
     const sorted = [...skills].sort((a, b) => a.name.localeCompare(b.name));
     return sorted.map((skill) => {
       const canonicalLabel = `src/skills/${skill.name}/SKILL.md`;

--- a/scripts/adapters/codex-cli.mjs
+++ b/scripts/adapters/codex-cli.mjs
@@ -20,9 +20,9 @@ export class CodexCliAdapter extends AdapterBase {
 
   /**
    * @param {Skill[]} skills
-   * @returns {OutputFile[]}
+   * @returns {Promise<OutputFile[]>}
    */
-  generate(skills) {
+  async generate(skills) {
     const sorted = [...skills].sort((a, b) => a.name.localeCompare(b.name));
     const outputs = sorted.map((skill) => {
       const label = `src/skills/${skill.name}/SKILL.md`;

--- a/scripts/adapters/copilot.mjs
+++ b/scripts/adapters/copilot.mjs
@@ -34,9 +34,9 @@ export class CopilotAdapter extends AdapterBase {
 
   /**
    * @param {Skill[]} skills
-   * @returns {OutputFile[]}
+   * @returns {Promise<OutputFile[]>}
    */
-  generate(skills) {
+  async generate(skills) {
     return [
       {
         relativePath: ".github/copilot-instructions.md.snippet",

--- a/scripts/adapters/gemini-cli.mjs
+++ b/scripts/adapters/gemini-cli.mjs
@@ -8,6 +8,7 @@
 //
 // Reference: https://github.com/google-gemini/gemini-cli
 
+import prettier from "prettier";
 import { AdapterBase } from "../lib/adapter-base.mjs";
 import { renderAgentsMdSnippet } from "../lib/agents-md-snippet.mjs";
 
@@ -23,14 +24,18 @@ const SETTINGS = {
 };
 
 /**
- * Stable JSON serializer — emits keys in insertion order with 2-space
- * indent and a trailing newline, matching what we want committed to dist/.
+ * JSON serializer whose output is Prettier-idempotent — `JSON.stringify`'s
+ * default formatter splits every array/object onto multiple lines, which
+ * collides with Prettier/Biome's "collapse short arrays" policy and causes
+ * sync oscillation in downstream repos (skills#35). Routing through
+ * `prettier.format` produces the exact bytes Prettier and Biome would emit,
+ * so consumers can run their formatters over `dist/` without drift.
  *
  * @param {unknown} value
- * @returns {string}
+ * @returns {Promise<string>}
  */
-function stableJsonStringify(value) {
-  return `${JSON.stringify(value, null, 2)}\n`;
+async function stableJsonStringify(value) {
+  return prettier.format(JSON.stringify(value), { parser: "json" });
 }
 
 export class GeminiCliAdapter extends AdapterBase {
@@ -38,14 +43,14 @@ export class GeminiCliAdapter extends AdapterBase {
 
   /**
    * @param {Skill[]} skills
-   * @returns {OutputFile[]}
+   * @returns {Promise<OutputFile[]>}
    */
-  generate(skills) {
+  async generate(skills) {
     const sorted = [...skills].sort((a, b) => a.name.localeCompare(b.name));
     return [
       {
         relativePath: ".gemini/settings.json",
-        content: stableJsonStringify(SETTINGS),
+        content: await stableJsonStringify(SETTINGS),
       },
       {
         relativePath: "AGENTS.md.snippet",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -132,7 +132,7 @@ async function writeAdapterOutputs(skills) {
     if (existsSync(adapterRoot)) {
       await rm(adapterRoot, { recursive: true, force: true });
     }
-    const outputs = adapter.generate(skills);
+    const outputs = await adapter.generate(skills);
     for (const out of outputs) {
       const dest = join(adapterRoot, out.relativePath);
       await mkdir(dirname(dest), { recursive: true });

--- a/scripts/lib/adapter-base.mjs
+++ b/scripts/lib/adapter-base.mjs
@@ -24,10 +24,10 @@ export class AdapterBase {
    *
    * Subclasses must override. Implementations must be deterministic: the same
    * skills input must produce the same OutputFile list (same order, same
-   * content).
+   * content). May be async — the build orchestrator awaits the result.
    *
    * @param {Skill[]} _skills
-   * @returns {OutputFile[]}
+   * @returns {Promise<OutputFile[]> | OutputFile[]}
    */
   generate(_skills) {
     throw new Error(`${this.constructor.name}.generate() not implemented`);

--- a/tests/adapter-base.test.mjs
+++ b/tests/adapter-base.test.mjs
@@ -7,17 +7,17 @@ test("AdapterBase.generate throws when not overridden", () => {
   assert.throws(() => adapter.generate([]), /not implemented/);
 });
 
-test("subclass that overrides generate works", () => {
+test("subclass that overrides generate works", async () => {
   class FakeAdapter extends AdapterBase {
     static id = "fake";
-    generate(skills) {
+    async generate(skills) {
       return skills.map((s) => ({
         relativePath: `${s.name}.md`,
         content: s.body,
       }));
     }
   }
-  const out = new FakeAdapter().generate([
+  const out = await new FakeAdapter().generate([
     { name: "x", description: "d", frontmatter: {}, body: "B", raw: "B" },
   ]);
   assert.deepEqual(out, [{ relativePath: "x.md", content: "B" }]);

--- a/tests/build-pipeline.test.mjs
+++ b/tests/build-pipeline.test.mjs
@@ -66,7 +66,7 @@ test("every adapter produces non-empty output for canonical skills", async () =>
   const skills = await loadCanonicalSkills();
   assert.ok(skills.length > 0, "src/skills/ must contain at least one skill");
   for (const adapter of ADAPTERS) {
-    const out = adapter.generate(skills);
+    const out = await adapter.generate(skills);
     assert.ok(out.length > 0, `${adapter.constructor.name} returned no outputs`);
     for (const file of out) {
       assert.ok(file.relativePath, "OutputFile.relativePath must be set");
@@ -78,8 +78,8 @@ test("every adapter produces non-empty output for canonical skills", async () =>
 test("adapter outputs are deterministic across repeated runs", async () => {
   const skills = await loadCanonicalSkills();
   for (const adapter of ADAPTERS) {
-    const a = adapter.generate(skills);
-    const b = adapter.generate(skills);
+    const a = await adapter.generate(skills);
+    const b = await adapter.generate(skills);
     assert.deepEqual(a, b, `${adapter.constructor.name} is non-deterministic`);
   }
 });
@@ -88,8 +88,8 @@ test("adapter outputs are deterministic regardless of input order", async () => 
   const skills = await loadCanonicalSkills();
   const reversed = [...skills].reverse();
   for (const adapter of ADAPTERS) {
-    const a = adapter.generate(skills);
-    const b = adapter.generate(reversed);
+    const a = await adapter.generate(skills);
+    const b = await adapter.generate(reversed);
     assert.deepEqual(
       a,
       b,
@@ -100,19 +100,19 @@ test("adapter outputs are deterministic regardless of input order", async () => 
 
 test("Codex CLI and Gemini CLI emit identical AGENTS.md.snippet", async () => {
   const skills = await loadCanonicalSkills();
-  const codex = new CodexCliAdapter()
-    .generate(skills)
-    .find((o) => o.relativePath === "AGENTS.md.snippet").content;
-  const gemini = new GeminiCliAdapter()
-    .generate(skills)
-    .find((o) => o.relativePath === "AGENTS.md.snippet").content;
+  const codex = (await new CodexCliAdapter().generate(skills)).find(
+    (o) => o.relativePath === "AGENTS.md.snippet",
+  ).content;
+  const gemini = (await new GeminiCliAdapter().generate(skills)).find(
+    (o) => o.relativePath === "AGENTS.md.snippet",
+  ).content;
   assert.equal(codex, gemini);
 });
 
 test("every snippet output is wrapped with @ozzylabs/skills markers", async () => {
   const skills = await loadCanonicalSkills();
   for (const adapter of ADAPTERS) {
-    for (const file of adapter.generate(skills)) {
+    for (const file of await adapter.generate(skills)) {
       if (!file.relativePath.endsWith(".snippet")) continue;
       assert.match(
         file.content,
@@ -135,7 +135,7 @@ test("Claude Code adapter prefers SKILL.claude-code.md when present", async () =
     withCompanion.length > 0,
     "expected at least one skill to ship a Claude Code companion",
   );
-  const out = new ClaudeCodeAdapter().generate(skills);
+  const out = await new ClaudeCodeAdapter().generate(skills);
   for (const skill of withCompanion) {
     const file = out.find((o) => o.relativePath === `.claude/skills/${skill.name}/SKILL.md`);
     assert.equal(
@@ -150,12 +150,12 @@ test("Claude Code adapter and other adapters diverge for skills with companion",
   const skills = await loadCanonicalSkills();
   const sample = skills.find((s) => s.claudeCodeCompanion);
   if (!sample) return; // no companion in repo — nothing to assert
-  const claudeOut = new ClaudeCodeAdapter()
-    .generate([sample])
-    .find((o) => o.relativePath.endsWith("/SKILL.md"));
-  const codexOut = new CodexCliAdapter()
-    .generate([sample])
-    .find((o) => o.relativePath.endsWith("/SKILL.md"));
+  const claudeOut = (await new ClaudeCodeAdapter().generate([sample])).find((o) =>
+    o.relativePath.endsWith("/SKILL.md"),
+  );
+  const codexOut = (await new CodexCliAdapter().generate([sample])).find((o) =>
+    o.relativePath.endsWith("/SKILL.md"),
+  );
   assert.notEqual(
     claudeOut.content,
     codexOut.content,

--- a/tests/claude-code-adapter.test.mjs
+++ b/tests/claude-code-adapter.test.mjs
@@ -11,15 +11,15 @@ function skill(name, frontmatter, body = "body\n") {
   return { name, description: fm.description, frontmatter: fm, body, raw };
 }
 
-test("Claude Code adapter emits .claude/skills/{name}/SKILL.md", () => {
-  const out = new ClaudeCodeAdapter().generate([skill("foo", { description: "d" })]);
+test("Claude Code adapter emits .claude/skills/{name}/SKILL.md", async () => {
+  const out = await new ClaudeCodeAdapter().generate([skill("foo", { description: "d" })]);
   assert.equal(out.length, 1);
   assert.equal(out[0].relativePath, ".claude/skills/foo/SKILL.md");
   assert.match(out[0].content, /^---\nname: foo\ndescription: d\n---\nbody\n$/);
 });
 
-test("Claude Code adapter is deterministic — sorts by name", () => {
-  const out = new ClaudeCodeAdapter().generate([
+test("Claude Code adapter is deterministic — sorts by name", async () => {
+  const out = await new ClaudeCodeAdapter().generate([
     skill("zeta", { description: "z" }),
     skill("alpha", { description: "a" }),
   ]);
@@ -29,18 +29,18 @@ test("Claude Code adapter is deterministic — sorts by name", () => {
   );
 });
 
-test("Claude Code adapter passes through Claude-specific frontmatter", () => {
+test("Claude Code adapter passes through Claude-specific frontmatter", async () => {
   const s = skill("foo", {
     description: "d",
     "allowed-tools": "Bash,Read",
     "argument-hint": "<file>",
   });
-  const out = new ClaudeCodeAdapter().generate([s]);
+  const out = await new ClaudeCodeAdapter().generate([s]);
   assert.match(out[0].content, /allowed-tools: Bash,Read/);
   assert.match(out[0].content, /argument-hint: <file>/);
 });
 
-test("Claude Code adapter throws when description is missing", () => {
+test("Claude Code adapter throws when description is missing", async () => {
   const bad = {
     name: "foo",
     description: "",
@@ -48,7 +48,7 @@ test("Claude Code adapter throws when description is missing", () => {
     body: "",
     raw: "---\nname: foo\n---\n",
   };
-  assert.throws(
+  await assert.rejects(
     () => new ClaudeCodeAdapter().generate([bad]),
     /missing required field 'description'/,
   );
@@ -58,34 +58,34 @@ test("Claude Code adapter has id 'claude-code'", () => {
   assert.equal(ClaudeCodeAdapter.id, "claude-code");
 });
 
-test("Claude Code adapter emits companion content when present", () => {
+test("Claude Code adapter emits companion content when present", async () => {
   const s = skill("foo", { description: "canonical" });
   s.claudeCodeCompanion = {
     frontmatter: { description: "wrapper", "disable-model-invocation": "true" },
     body: "# foo\n\nwrapper body\n",
     raw: "---\ndescription: wrapper\ndisable-model-invocation: true\n---\n# foo\n\nwrapper body\n",
   };
-  const out = new ClaudeCodeAdapter().generate([s]);
+  const out = await new ClaudeCodeAdapter().generate([s]);
   assert.equal(out[0].content, s.claudeCodeCompanion.raw);
   assert.match(out[0].content, /disable-model-invocation: true/);
   assert.doesNotMatch(out[0].content, /^name: foo/m);
 });
 
-test("Claude Code adapter falls back to canonical when no companion", () => {
+test("Claude Code adapter falls back to canonical when no companion", async () => {
   const s = skill("foo", { description: "canonical" });
   s.claudeCodeCompanion = null;
-  const out = new ClaudeCodeAdapter().generate([s]);
+  const out = await new ClaudeCodeAdapter().generate([s]);
   assert.equal(out[0].content, s.raw);
 });
 
-test("Claude Code adapter throws when companion is missing description", () => {
+test("Claude Code adapter throws when companion is missing description", async () => {
   const s = skill("foo", { description: "canonical" });
   s.claudeCodeCompanion = {
     frontmatter: { "disable-model-invocation": "true" },
     body: "x",
     raw: "---\ndisable-model-invocation: true\n---\nx",
   };
-  assert.throws(
+  await assert.rejects(
     () => new ClaudeCodeAdapter().generate([s]),
     /SKILL\.claude-code\.md.*missing required field 'description'/,
   );

--- a/tests/codex-cli-adapter.test.mjs
+++ b/tests/codex-cli-adapter.test.mjs
@@ -8,8 +8,8 @@ function skill(name, description, body = "body\n") {
   return { name, description, frontmatter: fm, body, raw };
 }
 
-test("Codex CLI adapter emits per-skill SKILL.md plus AGENTS.md.snippet", () => {
-  const out = new CodexCliAdapter().generate([
+test("Codex CLI adapter emits per-skill SKILL.md plus AGENTS.md.snippet", async () => {
+  const out = await new CodexCliAdapter().generate([
     skill("foo", "Foo description"),
     skill("bar", "Bar description"),
   ]);
@@ -21,17 +21,17 @@ test("Codex CLI adapter emits per-skill SKILL.md plus AGENTS.md.snippet", () => 
   ]);
 });
 
-test("Codex CLI snippet contains begin/end markers and skill bullets", () => {
-  const out = new CodexCliAdapter().generate([skill("foo", "Foo description")]);
+test("Codex CLI snippet contains begin/end markers and skill bullets", async () => {
+  const out = await new CodexCliAdapter().generate([skill("foo", "Foo description")]);
   const snippet = out.find((o) => o.relativePath === "AGENTS.md.snippet").content;
   assert.match(snippet, /<!-- begin: @ozzylabs\/skills -->/);
   assert.match(snippet, /<!-- end: @ozzylabs\/skills -->/);
   assert.match(snippet, /- `foo` — Foo description/);
 });
 
-test("Codex CLI adapter is deterministic — sorts skills by name", () => {
-  const a = new CodexCliAdapter().generate([skill("zeta", "z"), skill("alpha", "a")]);
-  const b = new CodexCliAdapter().generate([skill("alpha", "a"), skill("zeta", "z")]);
+test("Codex CLI adapter is deterministic — sorts skills by name", async () => {
+  const a = await new CodexCliAdapter().generate([skill("zeta", "z"), skill("alpha", "a")]);
+  const b = await new CodexCliAdapter().generate([skill("alpha", "a"), skill("zeta", "z")]);
   assert.deepEqual(a, b);
 });
 

--- a/tests/copilot-adapter.test.mjs
+++ b/tests/copilot-adapter.test.mjs
@@ -10,14 +10,14 @@ const skill = (name, description) => ({
   raw: "",
 });
 
-test("Copilot adapter emits a single snippet file", () => {
-  const out = new CopilotAdapter().generate([skill("foo", "Foo")]);
+test("Copilot adapter emits a single snippet file", async () => {
+  const out = await new CopilotAdapter().generate([skill("foo", "Foo")]);
   assert.equal(out.length, 1);
   assert.equal(out[0].relativePath, ".github/copilot-instructions.md.snippet");
 });
 
-test("Copilot snippet contains markers, heading, and bullet list", () => {
-  const out = new CopilotAdapter().generate([skill("foo", "Foo desc")]);
+test("Copilot snippet contains markers, heading, and bullet list", async () => {
+  const out = await new CopilotAdapter().generate([skill("foo", "Foo desc")]);
   const content = out[0].content;
   assert.match(content, /<!-- begin: @ozzylabs\/skills -->/);
   assert.match(content, /## Available Skills/);
@@ -25,9 +25,9 @@ test("Copilot snippet contains markers, heading, and bullet list", () => {
   assert.match(content, /<!-- end: @ozzylabs\/skills -->/);
 });
 
-test("Copilot adapter is deterministic — sorts skills by name", () => {
-  const a = new CopilotAdapter().generate([skill("zeta", "z"), skill("alpha", "a")]);
-  const b = new CopilotAdapter().generate([skill("alpha", "a"), skill("zeta", "z")]);
+test("Copilot adapter is deterministic — sorts skills by name", async () => {
+  const a = await new CopilotAdapter().generate([skill("zeta", "z"), skill("alpha", "a")]);
+  const b = await new CopilotAdapter().generate([skill("alpha", "a"), skill("zeta", "z")]);
   assert.deepEqual(a, b);
   assert.match(a[0].content, /alpha[\s\S]*zeta/);
 });

--- a/tests/gemini-cli-adapter.test.mjs
+++ b/tests/gemini-cli-adapter.test.mjs
@@ -10,35 +10,35 @@ const skill = (name, description) => ({
   raw: `---\nname: ${name}\ndescription: ${description}\n---\n`,
 });
 
-test("Gemini CLI adapter emits settings.json + AGENTS.md.snippet", () => {
-  const out = new GeminiCliAdapter().generate([skill("foo", "Foo")]);
+test("Gemini CLI adapter emits settings.json + AGENTS.md.snippet", async () => {
+  const out = await new GeminiCliAdapter().generate([skill("foo", "Foo")]);
   assert.deepEqual(
     out.map((o) => o.relativePath),
     [".gemini/settings.json", "AGENTS.md.snippet"],
   );
 });
 
-test("Gemini CLI settings.json is deterministic JSON", () => {
-  const out = new GeminiCliAdapter().generate([]);
+test("Gemini CLI settings.json is deterministic JSON with collapsed short array (regression: #35)", async () => {
+  const out = await new GeminiCliAdapter().generate([]);
   const settings = out.find((o) => o.relativePath === ".gemini/settings.json").content;
-  assert.equal(
-    settings,
-    '{\n  "context": {\n    "fileName": [\n      "AGENTS.md"\n    ]\n  }\n}\n',
-  );
   assert.deepEqual(JSON.parse(settings), { context: { fileName: ["AGENTS.md"] } });
+  // The short fileName array must stay on one line — multi-line expansion (the
+  // pre-#35 behavior) collides with Biome/Prettier's collapse-short-arrays
+  // policy and triggers sync oscillation in downstream repos.
+  assert.match(settings, /"fileName": \["AGENTS\.md"\]/);
 });
 
-test("Gemini CLI snippet matches Codex CLI shape (markers + bullets)", () => {
-  const out = new GeminiCliAdapter().generate([skill("foo", "Foo desc")]);
+test("Gemini CLI snippet matches Codex CLI shape (markers + bullets)", async () => {
+  const out = await new GeminiCliAdapter().generate([skill("foo", "Foo desc")]);
   const snippet = out.find((o) => o.relativePath === "AGENTS.md.snippet").content;
   assert.match(snippet, /<!-- begin: @ozzylabs\/skills -->/);
   assert.match(snippet, /- `foo` — Foo desc/);
   assert.match(snippet, /<!-- end: @ozzylabs\/skills -->/);
 });
 
-test("Gemini CLI adapter is deterministic across reordered inputs", () => {
-  const a = new GeminiCliAdapter().generate([skill("zeta", "z"), skill("alpha", "a")]);
-  const b = new GeminiCliAdapter().generate([skill("alpha", "a"), skill("zeta", "z")]);
+test("Gemini CLI adapter is deterministic across reordered inputs", async () => {
+  const a = await new GeminiCliAdapter().generate([skill("zeta", "z"), skill("alpha", "a")]);
+  const b = await new GeminiCliAdapter().generate([skill("alpha", "a"), skill("zeta", "z")]);
   assert.deepEqual(a, b);
 });
 

--- a/tests/prettier-compat.test.mjs
+++ b/tests/prettier-compat.test.mjs
@@ -68,44 +68,56 @@ async function formatMarkdown(content, options = {}) {
   return prettier.format(content, { parser: "markdown", ...options });
 }
 
+async function formatJson(content, options = {}) {
+  return prettier.format(content, { parser: "json", ...options });
+}
+
 test("AGENTS.md.snippet is Prettier-idempotent under default config", async () => {
-  const out = new CodexCliAdapter()
-    .generate(SAMPLE_SKILLS)
-    .find((o) => o.relativePath === "AGENTS.md.snippet");
+  const out = (await new CodexCliAdapter().generate(SAMPLE_SKILLS)).find(
+    (o) => o.relativePath === "AGENTS.md.snippet",
+  );
   const formatted = await formatMarkdown(out.content);
   assert.equal(formatted, out.content);
 });
 
 test("AGENTS.md.snippet is Prettier-idempotent under singleQuote config", async () => {
-  const out = new CodexCliAdapter()
-    .generate(SAMPLE_SKILLS)
-    .find((o) => o.relativePath === "AGENTS.md.snippet");
+  const out = (await new CodexCliAdapter().generate(SAMPLE_SKILLS)).find(
+    (o) => o.relativePath === "AGENTS.md.snippet",
+  );
   const formatted = await formatMarkdown(out.content, { singleQuote: true });
   assert.equal(formatted, out.content);
 });
 
 test("Gemini CLI AGENTS.md.snippet is Prettier-idempotent", async () => {
-  const out = new GeminiCliAdapter()
-    .generate(SAMPLE_SKILLS)
-    .find((o) => o.relativePath === "AGENTS.md.snippet");
+  const out = (await new GeminiCliAdapter().generate(SAMPLE_SKILLS)).find(
+    (o) => o.relativePath === "AGENTS.md.snippet",
+  );
   const formatted = await formatMarkdown(out.content);
   assert.equal(formatted, out.content);
 });
 
+test("Gemini CLI .gemini/settings.json is Prettier-idempotent (regression: #35)", async () => {
+  const out = (await new GeminiCliAdapter().generate(SAMPLE_SKILLS)).find(
+    (o) => o.relativePath === ".gemini/settings.json",
+  );
+  const formatted = await formatJson(out.content);
+  assert.equal(formatted, out.content);
+});
+
 test("copilot-instructions.md.snippet is Prettier-idempotent under default config", async () => {
-  const out = new CopilotAdapter().generate(SAMPLE_SKILLS)[0];
+  const out = (await new CopilotAdapter().generate(SAMPLE_SKILLS))[0];
   const formatted = await formatMarkdown(out.content);
   assert.equal(formatted, out.content);
 });
 
 test("copilot-instructions.md.snippet is Prettier-idempotent under singleQuote config", async () => {
-  const out = new CopilotAdapter().generate(SAMPLE_SKILLS)[0];
+  const out = (await new CopilotAdapter().generate(SAMPLE_SKILLS))[0];
   const formatted = await formatMarkdown(out.content, { singleQuote: true });
   assert.equal(formatted, out.content);
 });
 
 test("Claude Code SKILL.md (canonical pass-through) is Prettier-idempotent", async () => {
-  const out = new ClaudeCodeAdapter().generate(SAMPLE_SKILLS);
+  const out = await new ClaudeCodeAdapter().generate(SAMPLE_SKILLS);
   for (const file of out) {
     const formatted = await formatMarkdown(file.content);
     assert.equal(formatted, file.content, `${file.relativePath} drifts under default Prettier`);
@@ -119,9 +131,9 @@ test("Claude Code SKILL.md (canonical pass-through) is Prettier-idempotent", asy
 });
 
 test("Claude Code SKILL.md (companion with argument-hint) is Prettier-idempotent under both configs", async () => {
-  const out = new ClaudeCodeAdapter()
-    .generate([SAMPLE_WITH_COMPANION])
-    .find((o) => o.relativePath === ".claude/skills/drive/SKILL.md");
+  const out = (await new ClaudeCodeAdapter().generate([SAMPLE_WITH_COMPANION])).find(
+    (o) => o.relativePath === ".claude/skills/drive/SKILL.md",
+  );
   const def = await formatMarkdown(out.content);
   assert.equal(def, out.content, "drift under default Prettier");
   const sq = await formatMarkdown(out.content, { singleQuote: true });


### PR DESCRIPTION
## Summary

- Route `.gemini/settings.json` output through `prettier.format({ parser: "json" })` so the adapter emits exactly what Biome / Prettier would produce, eliminating the sync-oscillation cycle observed in `ozzy-labs/create-agentic-aws`.
- `AdapterBase.generate` becomes async (Prettier's format API is async-only). All four adapters, their callers in `scripts/build.mjs`, and every adapter test (`tests/*.test.mjs`) are updated in lockstep.
- Adds a Prettier-idempotency regression test for `.gemini/settings.json` to `tests/prettier-compat.test.mjs`, alongside the existing snippet-format checks.

## Background

`JSON.stringify(value, null, 2)` always splits arrays onto multiple lines:

```json
{
  "context": {
    "fileName": [
      "AGENTS.md"
    ]
  }
}
```

Biome (and Prettier) collapse short arrays back to one line:

```json
{ "context": { "fileName": ["AGENTS.md"] } }
```

When `create-agentic-aws` synced this file then ran its own `biome check`, the formatter reported drift and broke `main`. See `ozzy-labs/create-agentic-aws#508` for the temporary downstream fix that the next sync would have re-broken.

This PR roots the fix at the source so consumers can run any formatter (Biome, Prettier default, Prettier `singleQuote`) over `dist/` without drift.

## Trade-off

- ✅ No more oscillation; consumers don't need `<!-- prettier-ignore -->` or per-file ignores
- ⚠️ `AdapterBase.generate` is now async, a breaking change for any external adapter authors. Internal usage is fully migrated.

## Test plan

- [x] `pnpm run build` succeeds; `dist/gemini-cli/.gemini/settings.json` is now `{ "context": { "fileName": ["AGENTS.md"] } }`
- [x] `pnpm test` — 57/57 pass (added 1 new regression test)
- [x] `pnpm run lint` clean (Biome)
- [x] Commitlint passes (Conventional Commits)

## Refs

- Closes #35
- Follow-up to #25 / #26 (snippet-side prettier-compat) — same pattern, JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)