### PR TITLE
fix(release-please): set initial-version to 0.1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
     ".": {
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
+      "initial-version": "0.1.0",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [


### PR DESCRIPTION
## Summary

- `release-please-config.json` に `"initial-version": "0.1.0"` を追加し、初回リリースが `1.0.0` ではなく `0.1.0` になるよう修正
- 既存の `bump-minor-pre-major` / `bump-patch-for-minor-pre-major` フラグはそのまま（`0.x` 中の SemVer 挙動を維持）

## Why

release-please は `.release-please-manifest.json` が `0.0.0` 起点のとき、初回 `feat` を MAJOR 扱いして `1.0.0` を発行する。`@ozzylabs/skills` は API 安定前なので `0.x` 系で進めたい。`initial-version` を明示することで初回 Release PR が `0.1.0` に切り替わる。

## Test plan

- [x] `release-please-config.json` の JSON 構文チェック (`jq .`)
- [x] biome / gitleaks / trivy（lefthook pre-commit）pass
- [ ] マージ後、release-please-action が走り、既存 Release PR (#1) のタイトルが `chore(main): release skills 0.1.0` に更新されることを確認