### PR TITLE
docs(drive): clarify observability polling spec

### DIFF
--- a/.agents/skills/drive/SKILL.md
+++ b/.agents/skills/drive/SKILL.md
@@ -162,8 +162,9 @@ wave を順に実行する。
 #### 観測性
 
 - `Agent` tool は subagent 完了時に最終結果のみを返すため、ストリーム的な中間報告は不可
-- 親は wave 起動直後に `gh pr list --search "head:<prefix>" --state open` を polling し、新規作成された PR の URL を表示する
-- subagent の最終 JSON 戻り値で全状態を確定する
+- 親は wave 起動時刻 `<T>` を ISO 8601 で記録し、30 秒間隔で `gh pr list --author @me --state open --search "created:>=<T>" --json number,url,headRefName,title` を polling する
+- 既知 PR との差分から新規作成 PR を検出し、URL を即時表示する
+- 全 subagent 完了時に最終 JSON 戻り値で状態を確定する
 
 #### wave 完了待ち
 

--- a/.claude/skills/drive/SKILL.md
+++ b/.claude/skills/drive/SKILL.md
@@ -42,7 +42,7 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUser
 ### 観測性
 
 - Phase 0 完了時に wave 構成と target リストを表示する
-- `Agent` tool は最終結果のみを返すためストリーム的な中間報告は不可。親は wave 起動直後に `gh pr list --search "head:<prefix>" --state open` を定期実行し、新規 PR の URL を表示する
+- `Agent` tool は最終結果のみを返すためストリーム的な中間報告は不可。親は wave 起動時刻 `<T>` を ISO 8601 で記録し、30 秒間隔で `gh pr list --author @me --state open --search "created:>=<T>" --json number,url,headRefName,title` を polling する。既知 PR との差分から新規 PR を検出して URL を即時表示する
 - Phase Final で集約レポートを出力する
 
 ### 中断時

--- a/dist/.agents/skills/drive/SKILL.md
+++ b/dist/.agents/skills/drive/SKILL.md
@@ -162,8 +162,9 @@ wave を順に実行する。
 #### 観測性
 
 - `Agent` tool は subagent 完了時に最終結果のみを返すため、ストリーム的な中間報告は不可
-- 親は wave 起動直後に `gh pr list --search "head:<prefix>" --state open` を polling し、新規作成された PR の URL を表示する
-- subagent の最終 JSON 戻り値で全状態を確定する
+- 親は wave 起動時刻 `<T>` を ISO 8601 で記録し、30 秒間隔で `gh pr list --author @me --state open --search "created:>=<T>" --json number,url,headRefName,title` を polling する
+- 既知 PR との差分から新規作成 PR を検出し、URL を即時表示する
+- 全 subagent 完了時に最終 JSON 戻り値で状態を確定する
 
 #### wave 完了待ち
 

--- a/dist/claude-code/.claude/skills/drive/SKILL.md
+++ b/dist/claude-code/.claude/skills/drive/SKILL.md
@@ -42,7 +42,7 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUser
 ### 観測性
 
 - Phase 0 完了時に wave 構成と target リストを表示する
-- `Agent` tool は最終結果のみを返すためストリーム的な中間報告は不可。親は wave 起動直後に `gh pr list --search "head:<prefix>" --state open` を定期実行し、新規 PR の URL を表示する
+- `Agent` tool は最終結果のみを返すためストリーム的な中間報告は不可。親は wave 起動時刻 `<T>` を ISO 8601 で記録し、30 秒間隔で `gh pr list --author @me --state open --search "created:>=<T>" --json number,url,headRefName,title` を polling する。既知 PR との差分から新規 PR を検出して URL を即時表示する
 - Phase Final で集約レポートを出力する
 
 ### 中断時

--- a/dist/codex-cli/.agents/skills/drive/SKILL.md
+++ b/dist/codex-cli/.agents/skills/drive/SKILL.md
@@ -162,8 +162,9 @@ wave を順に実行する。
 #### 観測性
 
 - `Agent` tool は subagent 完了時に最終結果のみを返すため、ストリーム的な中間報告は不可
-- 親は wave 起動直後に `gh pr list --search "head:<prefix>" --state open` を polling し、新規作成された PR の URL を表示する
-- subagent の最終 JSON 戻り値で全状態を確定する
+- 親は wave 起動時刻 `<T>` を ISO 8601 で記録し、30 秒間隔で `gh pr list --author @me --state open --search "created:>=<T>" --json number,url,headRefName,title` を polling する
+- 既知 PR との差分から新規作成 PR を検出し、URL を即時表示する
+- 全 subagent 完了時に最終 JSON 戻り値で状態を確定する
 
 #### wave 完了待ち
 

--- a/src/skills/drive/SKILL.claude-code.md
+++ b/src/skills/drive/SKILL.claude-code.md
@@ -42,7 +42,7 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUser
 ### 観測性
 
 - Phase 0 完了時に wave 構成と target リストを表示する
-- `Agent` tool は最終結果のみを返すためストリーム的な中間報告は不可。親は wave 起動直後に `gh pr list --search "head:<prefix>" --state open` を定期実行し、新規 PR の URL を表示する
+- `Agent` tool は最終結果のみを返すためストリーム的な中間報告は不可。親は wave 起動時刻 `<T>` を ISO 8601 で記録し、30 秒間隔で `gh pr list --author @me --state open --search "created:>=<T>" --json number,url,headRefName,title` を polling する。既知 PR との差分から新規 PR を検出して URL を即時表示する
 - Phase Final で集約レポートを出力する
 
 ### 中断時

--- a/src/skills/drive/SKILL.md
+++ b/src/skills/drive/SKILL.md
@@ -162,8 +162,9 @@ wave を順に実行する。
 #### 観測性
 
 - `Agent` tool は subagent 完了時に最終結果のみを返すため、ストリーム的な中間報告は不可
-- 親は wave 起動直後に `gh pr list --search "head:<prefix>" --state open` を polling し、新規作成された PR の URL を表示する
-- subagent の最終 JSON 戻り値で全状態を確定する
+- 親は wave 起動時刻 `<T>` を ISO 8601 で記録し、30 秒間隔で `gh pr list --author @me --state open --search "created:>=<T>" --json number,url,headRefName,title` を polling する
+- 既知 PR との差分から新規作成 PR を検出し、URL を即時表示する
+- 全 subagent 完了時に最終 JSON 戻り値で状態を確定する
 
 #### wave 完了待ち
 


### PR DESCRIPTION
## Summary

- PR #41 のセルフレビュー Iteration 2 で残った Info を解消
- `gh pr list --search \"head:<prefix>\"` の `<prefix>` が未定義だった polling コマンドを、wave 起動時刻ベースの `created:>=<T>` フィルタに変更
- 既知 PR との差分から新規 PR を識別する手順を明記、30 秒間隔・ISO 8601 タイムスタンプを明示

Refs: #40

## Test plan

- [x] `pnpm run build` 成功
- [x] `pnpm test` 全 57 件 pass
- [x] `pnpm run lint:md` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)