### PR TITLE
fix(skills/health): clarify delete recommendation for merged branches

### DIFF
--- a/.agents/skills/health/SKILL.md
+++ b/.agents/skills/health/SKILL.md
@@ -77,11 +77,14 @@ description: リポジトリ改修中に意図せず残る状態（working tree,
 - コマンド: `git branch -vv` および `git for-each-ref --sort=committerdate --format='%(refname:short) %(upstream:track) %(committerdate:relative)' refs/heads/`（古い順）
 - PR 検出（**1 度だけ batch 取得**）: `gh pr list --state all --json number,state,mergedAt,headRefName --limit 100` を 1 回実行し、client side で local branch 名と `headRefName` を join する（branch ごとに gh を呼ばない）
 - 各 branch について:
-  - merged 済みの PR が存在 → `delete`（PR 番号を表示）
+  - merged 済みの PR が存在し、かつ merge base 以降に追加 commit が **ない** → `delete`（PR 番号を表示）
+  - merged 済みの PR が存在し、かつ merge base 以降に追加 commit が **ある** → `要確認`（PR 番号と追加 commit 数を表示。merge 後に作業継続したケース）
   - upstream なし、かつ最終 commit から 14 日以上 → `要確認`
   - upstream なし、かつ 1 commit 以上、かつ最終 commit から 14 日未満 → `push`（新規ブランチで未 push のケース）
   - upstream あり、ahead で未 push、関連 PR なし → `push`
   - それ以外 → 推奨なし
+
+「追加 commit の有無」の判定: PR の merge commit と local branch の `git rev-list --count <merge-commit>..<branch>` を比較し、結果が 0 なら追加なし、1 以上なら追加あり。
 
 #### 6. remote tracking
 

--- a/dist/.agents/skills/health/SKILL.md
+++ b/dist/.agents/skills/health/SKILL.md
@@ -77,11 +77,14 @@ description: リポジトリ改修中に意図せず残る状態（working tree,
 - コマンド: `git branch -vv` および `git for-each-ref --sort=committerdate --format='%(refname:short) %(upstream:track) %(committerdate:relative)' refs/heads/`（古い順）
 - PR 検出（**1 度だけ batch 取得**）: `gh pr list --state all --json number,state,mergedAt,headRefName --limit 100` を 1 回実行し、client side で local branch 名と `headRefName` を join する（branch ごとに gh を呼ばない）
 - 各 branch について:
-  - merged 済みの PR が存在 → `delete`（PR 番号を表示）
+  - merged 済みの PR が存在し、かつ merge base 以降に追加 commit が **ない** → `delete`（PR 番号を表示）
+  - merged 済みの PR が存在し、かつ merge base 以降に追加 commit が **ある** → `要確認`（PR 番号と追加 commit 数を表示。merge 後に作業継続したケース）
   - upstream なし、かつ最終 commit から 14 日以上 → `要確認`
   - upstream なし、かつ 1 commit 以上、かつ最終 commit から 14 日未満 → `push`（新規ブランチで未 push のケース）
   - upstream あり、ahead で未 push、関連 PR なし → `push`
   - それ以外 → 推奨なし
+
+「追加 commit の有無」の判定: PR の merge commit と local branch の `git rev-list --count <merge-commit>..<branch>` を比較し、結果が 0 なら追加なし、1 以上なら追加あり。
 
 #### 6. remote tracking
 

--- a/dist/codex-cli/.agents/skills/health/SKILL.md
+++ b/dist/codex-cli/.agents/skills/health/SKILL.md
@@ -77,11 +77,14 @@ description: リポジトリ改修中に意図せず残る状態（working tree,
 - コマンド: `git branch -vv` および `git for-each-ref --sort=committerdate --format='%(refname:short) %(upstream:track) %(committerdate:relative)' refs/heads/`（古い順）
 - PR 検出（**1 度だけ batch 取得**）: `gh pr list --state all --json number,state,mergedAt,headRefName --limit 100` を 1 回実行し、client side で local branch 名と `headRefName` を join する（branch ごとに gh を呼ばない）
 - 各 branch について:
-  - merged 済みの PR が存在 → `delete`（PR 番号を表示）
+  - merged 済みの PR が存在し、かつ merge base 以降に追加 commit が **ない** → `delete`（PR 番号を表示）
+  - merged 済みの PR が存在し、かつ merge base 以降に追加 commit が **ある** → `要確認`（PR 番号と追加 commit 数を表示。merge 後に作業継続したケース）
   - upstream なし、かつ最終 commit から 14 日以上 → `要確認`
   - upstream なし、かつ 1 commit 以上、かつ最終 commit から 14 日未満 → `push`（新規ブランチで未 push のケース）
   - upstream あり、ahead で未 push、関連 PR なし → `push`
   - それ以外 → 推奨なし
+
+「追加 commit の有無」の判定: PR の merge commit と local branch の `git rev-list --count <merge-commit>..<branch>` を比較し、結果が 0 なら追加なし、1 以上なら追加あり。
 
 #### 6. remote tracking
 

--- a/src/skills/health/SKILL.md
+++ b/src/skills/health/SKILL.md
@@ -77,11 +77,14 @@ description: リポジトリ改修中に意図せず残る状態（working tree,
 - コマンド: `git branch -vv` および `git for-each-ref --sort=committerdate --format='%(refname:short) %(upstream:track) %(committerdate:relative)' refs/heads/`（古い順）
 - PR 検出（**1 度だけ batch 取得**）: `gh pr list --state all --json number,state,mergedAt,headRefName --limit 100` を 1 回実行し、client side で local branch 名と `headRefName` を join する（branch ごとに gh を呼ばない）
 - 各 branch について:
-  - merged 済みの PR が存在 → `delete`（PR 番号を表示）
+  - merged 済みの PR が存在し、かつ merge base 以降に追加 commit が **ない** → `delete`（PR 番号を表示）
+  - merged 済みの PR が存在し、かつ merge base 以降に追加 commit が **ある** → `要確認`（PR 番号と追加 commit 数を表示。merge 後に作業継続したケース）
   - upstream なし、かつ最終 commit から 14 日以上 → `要確認`
   - upstream なし、かつ 1 commit 以上、かつ最終 commit から 14 日未満 → `push`（新規ブランチで未 push のケース）
   - upstream あり、ahead で未 push、関連 PR なし → `push`
   - それ以外 → 推奨なし
+
+「追加 commit の有無」の判定: PR の merge commit と local branch の `git rev-list --count <merge-commit>..<branch>` を比較し、結果が 0 なら追加なし、1 以上なら追加あり。
 
 #### 6. remote tracking
 


### PR DESCRIPTION
## Summary

PR #45 で「v2 課題として残存」と先送りしてしまった指摘を本 PR で対応する（先送り方針の取り消し）。

Section 5 (local branch) の `delete` ルールで、merged PR と紐づくが merge 後に追加 commit がある branch（merge 後に作業継続したケース）を区別する:

- merged PR + 追加 commit なし → `delete`
- merged PR + 追加 commit あり → `要確認`（誤った delete 提案を避ける）

判定方法も明示（`git rev-list --count <merge-commit>..<branch>` で距離を比較）。

Refs #43

## Test plan

- [x] `pnpm run build` 通過
- [x] `pnpm test` 通過
- [x] `pnpm run lint:all` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)