### PR TITLE
chore(deps): unpin uv to 0.11.10

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,7 +2,7 @@
 # Runtime & package managers
 node = "24"
 "npm:pnpm" = "10"  # aqua backend fails: registry expects v11 .tar.gz format (see ozzy-labs/commons#100)
-uv = "0.11.8"  # Pin: 0.11.9 fails attestation verification (see ozzy-labs/commons#98)
+uv = "0.11.10"
 
 # Linters & formatters
 biome = "2"


### PR DESCRIPTION
## Summary

- `.mise.toml` の `uv = "0.11.8"` ピンを `0.11.10` に解除
- 関連コメント（`# Pin: 0.11.9 fails attestation verification ...`）を削除

## Background

- 0.11.8 は 0.11.9 の attestation 検証失敗（`ozzy-labs/commons#98`）を回避するためのピンだった
- `ozzy-labs/commons#98` は CLOSED
- 0.11.10 で attestation 問題が解消されていることをローカルで実機検証済み (`mise install uv --force` が attestation verified を通過)

## Test plan

- [x] `mise install uv --force` で attestation 通過を確認
- [x] `pnpm install` 成功
- [x] `pnpm run lint` 成功
- [x] `pnpm run build` 成功
- [x] `pnpm run test` 成功 (57 passed)
- [ ] CI green

Closes #53