### PR TITLE
fix(review): move severity_rules and exit_criteria into perspective frontmatter

### DIFF
--- a/.agents/skills/health/SKILL.md
+++ b/.agents/skills/health/SKILL.md
@@ -172,11 +172,13 @@ review skill が参照する `src/skills/review/perspectives/<axis>.md`（[ADR-0
   - `.agents/skills/review/perspectives/<axis>.md`（codex / gemini 配信先）
 - 検査項目（順に実施）:
   1. SSOT に存在する `<axis>.md` のうち `README.md` 以外を列挙する
-  2. 各観点 MD の frontmatter に **必須キー** `name`, `category`, `description` が揃っているか確認する
+  2. 各観点 MD の frontmatter に **必須キー** `name`, `category`, `description`, `applies_when`, `default_enabled`, `severity_rules`, `exit_criteria` が揃っているか確認する（`skip_when` は任意）
   3. `name` がファイル名（拡張子なし）と一致するか
   4. `category` が `required` / `design` / `quality` / `ux` のいずれかか
   5. `applies_when` / `skip_when.diff_only_in` の各 glob が文字列として有効か（空でない、`/` ではじまらない、改行を含まない）
-  6. SSOT と配信先のファイル一覧が一致しているか（drift があれば `pnpm run build` の取り違えを示唆）
+  6. `severity_rules` に `critical` / `warning` / `info` の 3 段階がすべて含まれているか
+  7. `exit_criteria.drive_loop` に少なくとも `critical` の許容しきい値が含まれているか
+  8. SSOT と配信先のファイル一覧が一致しているか（drift があれば `pnpm run build` の取り違えを示唆）
 - 推奨アクション:
   - 必須キー欠落 / 値不正 → `要確認`（観点 MD の frontmatter を修正）
   - SSOT と配信先の drift → `要確認`（`pnpm run build` を実行して再生成）

--- a/.agents/skills/review/perspectives/README.md
+++ b/.agents/skills/review/perspectives/README.md
@@ -27,17 +27,20 @@ review skill / `code-reviewer` agent が参照する観点定義の SSOT（[ADR-
 
 ```yaml
 ---
-name: <axis>                              # ファイル名と一致させる
+name: <axis>                                                    # ファイル名と一致させる
 category: required | design | quality | ux
 description: <一行で観点の主旨>
-applies_when: ["<glob>", ...]             # diff にこの glob にマッチするファイルが含まれれば適用
-skip_when:
-  diff_only_in: ["<glob>", ...]           # 全変更ファイルがこの glob 部分集合なら不適用
-default_enabled: true | false             # false の場合は --axes 明示時のみ適用
+applies_when: ["<glob>", ...]                                   # diff にこの glob にマッチするファイルが含まれれば適用
+skip_when: { diff_only_in: ["<glob>", ...] }                    # 全変更ファイルがこの glob 部分集合なら不適用
+default_enabled: true | false                                   # false の場合は --axes 明示時のみ適用
+severity_rules: { critical: "<...>", warning: "<...>", info: "<...>" }
+exit_criteria: { drive_loop: { critical: <N>, warning: <N> } }  # warning キーは省略可（許容を意味する）
 ---
 ```
 
-未定義キーは reader が無視する（forward-compat）。`severity_rules` と `exit_criteria.drive_loop` は本文で記述する。
+`skip_when` / `severity_rules` / `exit_criteria` は flow-style YAML の 1 行で記述する（既存の flat frontmatter parser と整合させるため）。本文には人間可読な severity ガイドや検査項目を冗長に記述してよいが、機械処理の SSOT は frontmatter とする。
+
+未定義キーは reader が無視する（forward-compat）。互換破壊的なスキーマ変更（必須キーの削除等）は ADR を起こす。
 
 ## 観点選別ロジック
 

--- a/.agents/skills/review/perspectives/architecture.md
+++ b/.agents/skills/review/perspectives/architecture.md
@@ -3,9 +3,10 @@ name: architecture
 category: design
 description: レイヤリング・責務配置・抽象度・既存パターン整合
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "既存アーキテクチャ判断 (ADR 等) に明確に反する、取り返しがつかない構造変更", warning: "責務違反、循環依存、既存パターンを破る無理筋、保守性を著しく下げる構造", info: "より良い分離・命名・抽象度の提案、リファクタリング候補" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # architecture — アーキテクチャ

--- a/.agents/skills/review/perspectives/compatibility.md
+++ b/.agents/skills/review/perspectives/compatibility.md
@@ -3,9 +3,10 @@ name: compatibility
 category: design
 description: 後方互換、スキーマ変更、commons-sync 経由のコンシューマ影響
 applies_when: ["src/**", "scripts/**", "dist/**", "package.json", "**/*.json", "**/*.yaml", "**/*.yml", "**/SKILL.md"]
-skip_when:
-  diff_only_in: ["tests/**", "**/*.test.*"]
+skip_when: { diff_only_in: ["tests/**", "**/*.test.*"] }
 default_enabled: true
+severity_rules: { critical: "既存コンシューマが破壊される非互換変更 (rename / 削除 / 型変更) で migration path や CHANGELOG への記載がない", warning: "互換性は保てるがコンシューマ側で対応が必要、または default 変更で挙動が変わる", info: "より丁寧な deprecation の提案、注意喚起" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # compatibility — 互換性

--- a/.agents/skills/review/perspectives/conventions.md
+++ b/.agents/skills/review/perspectives/conventions.md
@@ -4,6 +4,8 @@ category: required
 description: Conventional Commits、lint、ファイル命名、`.yaml` 統一などのリポジトリ規約
 applies_when: ["**/*"]
 default_enabled: true
+severity_rules: { critical: "コミット / PR タイトルが Conventional Commits 違反 (commitlint で fail)、main への直接 push、--no-verify 利用", warning: "lint / formatter 違反、命名規約違反、.yaml / .yml 不整合", info: "より明示的な書き方への改善提案、命名の細かな統一" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # conventions — コーディング規約

--- a/.agents/skills/review/perspectives/correctness.md
+++ b/.agents/skills/review/perspectives/correctness.md
@@ -4,6 +4,8 @@ category: required
 description: ロジック誤り・エッジケース・並行性・エラーハンドリング
 applies_when: ["**/*"]
 default_enabled: true
+severity_rules: { critical: "悪用・データ破壊・誤った状態遷移・無限ループ・回帰の温床になり得るバグ", warning: "通常パスは動くが特定入力で破綻するケース、未処理の例外", info: "防御的コーディングの改善余地、より堅牢な書き方の提案" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # correctness — 正確性

--- a/.agents/skills/review/perspectives/documentation.md
+++ b/.agents/skills/review/perspectives/documentation.md
@@ -3,9 +3,10 @@ name: documentation
 category: ux
 description: README・AGENTS.md・CLAUDE.md・SKILL.md・公開挙動の同期
 applies_when: ["**/*"]
-skip_when:
-  diff_only_in: []
+skip_when: { diff_only_in: [] }
 default_enabled: true
+severity_rules: { critical: "公開 API / 公開 CLI の変更がドキュメントに一切反映されておらず利用者が破壊される", warning: "README / SKILL.md / AGENTS.md の陳腐化、ADR と実装の乖離、誤ったサンプル", info: "ドキュメント追記の提案、説明の改善、表記揺れの統一" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # documentation — ドキュメント整合性

--- a/.agents/skills/review/perspectives/maintainability.md
+++ b/.agents/skills/review/perspectives/maintainability.md
@@ -3,9 +3,10 @@ name: maintainability
 category: design
 description: 命名・複雑度・dead code・コメント負債
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "取り返しのつかない命名 / 構造の選択 (公開 API として固定される名称等)", warning: "顕著な dead code、過剰な複雑度、誤解を招く命名、明らかな重複", info: "命名の細かな改善、コメント整理、軽微なリファクタ提案" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # maintainability — 保守性

--- a/.agents/skills/review/perspectives/observability.md
+++ b/.agents/skills/review/perspectives/observability.md
@@ -3,9 +3,10 @@ name: observability
 category: quality
 description: エラー文脈・ログ・失敗時の手がかり
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "失敗時に何も情報が出ず原因特定不可能、本番で silent failure になる経路", warning: "エラーメッセージが薄い、ログ過剰 / 不足、エラー種別の取り違え", info: "より親切なメッセージ、log level の調整提案" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # observability — 可観測性

--- a/.agents/skills/review/perspectives/performance.md
+++ b/.agents/skills/review/perspectives/performance.md
@@ -3,9 +3,10 @@ name: performance
 category: quality
 description: hot path、不要な逐次 I/O、メモリ
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "顕著な性能退行、production で UX を損なう規模のリグレッション、無限ループ", warning: "hot path 上の非効率、逐次 I/O、明らかな再計算", info: "軽微な最適化提案、cache 化候補" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # performance — パフォーマンス

--- a/.agents/skills/review/perspectives/security.md
+++ b/.agents/skills/review/perspectives/security.md
@@ -4,6 +4,8 @@ category: required
 description: 注入・秘密情報露出・権限昇格・サプライチェーン・スクリプト実行
 applies_when: ["**/*"]
 default_enabled: true
+severity_rules: { critical: "悪用可能な脆弱性、明示的な秘密情報の commit、認証回避、任意コード実行", warning: "防御層の欠落、未サニタイズ入力、過剰な権限、暗黙の信頼境界", info: "改善余地のある defensive coding、CSP / セキュリティヘッダの強化提案" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # security — セキュリティ

--- a/.agents/skills/review/perspectives/testing.md
+++ b/.agents/skills/review/perspectives/testing.md
@@ -3,9 +3,10 @@ name: testing
 category: quality
 description: 新コードのカバレッジ、回帰リスク、bats / Vitest / node:test の妥当性
 applies_when: ["src/**", "scripts/**", "tests/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "公開 API / バグ修正にテストがない、既存テストを根拠なく削除、tautology テスト", warning: "エッジケースの取りこぼし、不安定なテスト (flaky)、mock 過剰", info: "より良いアサーション、テストの整理 / 命名改善" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # testing — テスト

--- a/.agents/skills/review/perspectives/usability.md
+++ b/.agents/skills/review/perspectives/usability.md
@@ -3,9 +3,10 @@ name: usability
 category: ux
 description: CLI 文言・エラーメッセージ・skill argument-hint・README 即座理解性
 applies_when: ["src/**", "**/*.md", "**/SKILL.md", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["tests/**", "**/*.test.*"]
+skip_when: { diff_only_in: ["tests/**", "**/*.test.*"] }
 default_enabled: true
+severity_rules: { critical: "ユーザーが詰まる致命的な UX 不備 (無限ループ的な確認、復旧不可能な操作の無確認実行)", warning: "紛らわしいメッセージ、誤解を招く CLI 文言、argument-hint の欠落", info: "より親切な文言、説明追記、UX の細かな改善" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # usability — ユーザビリティ / DX

--- a/.claude/skills/review/perspectives/README.md
+++ b/.claude/skills/review/perspectives/README.md
@@ -27,17 +27,20 @@ review skill / `code-reviewer` agent が参照する観点定義の SSOT（[ADR-
 
 ```yaml
 ---
-name: <axis>                              # ファイル名と一致させる
+name: <axis>                                                    # ファイル名と一致させる
 category: required | design | quality | ux
 description: <一行で観点の主旨>
-applies_when: ["<glob>", ...]             # diff にこの glob にマッチするファイルが含まれれば適用
-skip_when:
-  diff_only_in: ["<glob>", ...]           # 全変更ファイルがこの glob 部分集合なら不適用
-default_enabled: true | false             # false の場合は --axes 明示時のみ適用
+applies_when: ["<glob>", ...]                                   # diff にこの glob にマッチするファイルが含まれれば適用
+skip_when: { diff_only_in: ["<glob>", ...] }                    # 全変更ファイルがこの glob 部分集合なら不適用
+default_enabled: true | false                                   # false の場合は --axes 明示時のみ適用
+severity_rules: { critical: "<...>", warning: "<...>", info: "<...>" }
+exit_criteria: { drive_loop: { critical: <N>, warning: <N> } }  # warning キーは省略可（許容を意味する）
 ---
 ```
 
-未定義キーは reader が無視する（forward-compat）。`severity_rules` と `exit_criteria.drive_loop` は本文で記述する。
+`skip_when` / `severity_rules` / `exit_criteria` は flow-style YAML の 1 行で記述する（既存の flat frontmatter parser と整合させるため）。本文には人間可読な severity ガイドや検査項目を冗長に記述してよいが、機械処理の SSOT は frontmatter とする。
+
+未定義キーは reader が無視する（forward-compat）。互換破壊的なスキーマ変更（必須キーの削除等）は ADR を起こす。
 
 ## 観点選別ロジック
 

--- a/.claude/skills/review/perspectives/architecture.md
+++ b/.claude/skills/review/perspectives/architecture.md
@@ -3,9 +3,10 @@ name: architecture
 category: design
 description: レイヤリング・責務配置・抽象度・既存パターン整合
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "既存アーキテクチャ判断 (ADR 等) に明確に反する、取り返しがつかない構造変更", warning: "責務違反、循環依存、既存パターンを破る無理筋、保守性を著しく下げる構造", info: "より良い分離・命名・抽象度の提案、リファクタリング候補" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # architecture — アーキテクチャ

--- a/.claude/skills/review/perspectives/compatibility.md
+++ b/.claude/skills/review/perspectives/compatibility.md
@@ -3,9 +3,10 @@ name: compatibility
 category: design
 description: 後方互換、スキーマ変更、commons-sync 経由のコンシューマ影響
 applies_when: ["src/**", "scripts/**", "dist/**", "package.json", "**/*.json", "**/*.yaml", "**/*.yml", "**/SKILL.md"]
-skip_when:
-  diff_only_in: ["tests/**", "**/*.test.*"]
+skip_when: { diff_only_in: ["tests/**", "**/*.test.*"] }
 default_enabled: true
+severity_rules: { critical: "既存コンシューマが破壊される非互換変更 (rename / 削除 / 型変更) で migration path や CHANGELOG への記載がない", warning: "互換性は保てるがコンシューマ側で対応が必要、または default 変更で挙動が変わる", info: "より丁寧な deprecation の提案、注意喚起" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # compatibility — 互換性

--- a/.claude/skills/review/perspectives/conventions.md
+++ b/.claude/skills/review/perspectives/conventions.md
@@ -4,6 +4,8 @@ category: required
 description: Conventional Commits、lint、ファイル命名、`.yaml` 統一などのリポジトリ規約
 applies_when: ["**/*"]
 default_enabled: true
+severity_rules: { critical: "コミット / PR タイトルが Conventional Commits 違反 (commitlint で fail)、main への直接 push、--no-verify 利用", warning: "lint / formatter 違反、命名規約違反、.yaml / .yml 不整合", info: "より明示的な書き方への改善提案、命名の細かな統一" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # conventions — コーディング規約

--- a/.claude/skills/review/perspectives/correctness.md
+++ b/.claude/skills/review/perspectives/correctness.md
@@ -4,6 +4,8 @@ category: required
 description: ロジック誤り・エッジケース・並行性・エラーハンドリング
 applies_when: ["**/*"]
 default_enabled: true
+severity_rules: { critical: "悪用・データ破壊・誤った状態遷移・無限ループ・回帰の温床になり得るバグ", warning: "通常パスは動くが特定入力で破綻するケース、未処理の例外", info: "防御的コーディングの改善余地、より堅牢な書き方の提案" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # correctness — 正確性

--- a/.claude/skills/review/perspectives/documentation.md
+++ b/.claude/skills/review/perspectives/documentation.md
@@ -3,9 +3,10 @@ name: documentation
 category: ux
 description: README・AGENTS.md・CLAUDE.md・SKILL.md・公開挙動の同期
 applies_when: ["**/*"]
-skip_when:
-  diff_only_in: []
+skip_when: { diff_only_in: [] }
 default_enabled: true
+severity_rules: { critical: "公開 API / 公開 CLI の変更がドキュメントに一切反映されておらず利用者が破壊される", warning: "README / SKILL.md / AGENTS.md の陳腐化、ADR と実装の乖離、誤ったサンプル", info: "ドキュメント追記の提案、説明の改善、表記揺れの統一" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # documentation — ドキュメント整合性

--- a/.claude/skills/review/perspectives/maintainability.md
+++ b/.claude/skills/review/perspectives/maintainability.md
@@ -3,9 +3,10 @@ name: maintainability
 category: design
 description: 命名・複雑度・dead code・コメント負債
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "取り返しのつかない命名 / 構造の選択 (公開 API として固定される名称等)", warning: "顕著な dead code、過剰な複雑度、誤解を招く命名、明らかな重複", info: "命名の細かな改善、コメント整理、軽微なリファクタ提案" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # maintainability — 保守性

--- a/.claude/skills/review/perspectives/observability.md
+++ b/.claude/skills/review/perspectives/observability.md
@@ -3,9 +3,10 @@ name: observability
 category: quality
 description: エラー文脈・ログ・失敗時の手がかり
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "失敗時に何も情報が出ず原因特定不可能、本番で silent failure になる経路", warning: "エラーメッセージが薄い、ログ過剰 / 不足、エラー種別の取り違え", info: "より親切なメッセージ、log level の調整提案" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # observability — 可観測性

--- a/.claude/skills/review/perspectives/performance.md
+++ b/.claude/skills/review/perspectives/performance.md
@@ -3,9 +3,10 @@ name: performance
 category: quality
 description: hot path、不要な逐次 I/O、メモリ
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "顕著な性能退行、production で UX を損なう規模のリグレッション、無限ループ", warning: "hot path 上の非効率、逐次 I/O、明らかな再計算", info: "軽微な最適化提案、cache 化候補" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # performance — パフォーマンス

--- a/.claude/skills/review/perspectives/security.md
+++ b/.claude/skills/review/perspectives/security.md
@@ -4,6 +4,8 @@ category: required
 description: 注入・秘密情報露出・権限昇格・サプライチェーン・スクリプト実行
 applies_when: ["**/*"]
 default_enabled: true
+severity_rules: { critical: "悪用可能な脆弱性、明示的な秘密情報の commit、認証回避、任意コード実行", warning: "防御層の欠落、未サニタイズ入力、過剰な権限、暗黙の信頼境界", info: "改善余地のある defensive coding、CSP / セキュリティヘッダの強化提案" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # security — セキュリティ

--- a/.claude/skills/review/perspectives/testing.md
+++ b/.claude/skills/review/perspectives/testing.md
@@ -3,9 +3,10 @@ name: testing
 category: quality
 description: 新コードのカバレッジ、回帰リスク、bats / Vitest / node:test の妥当性
 applies_when: ["src/**", "scripts/**", "tests/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "公開 API / バグ修正にテストがない、既存テストを根拠なく削除、tautology テスト", warning: "エッジケースの取りこぼし、不安定なテスト (flaky)、mock 過剰", info: "より良いアサーション、テストの整理 / 命名改善" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # testing — テスト

--- a/.claude/skills/review/perspectives/usability.md
+++ b/.claude/skills/review/perspectives/usability.md
@@ -3,9 +3,10 @@ name: usability
 category: ux
 description: CLI 文言・エラーメッセージ・skill argument-hint・README 即座理解性
 applies_when: ["src/**", "**/*.md", "**/SKILL.md", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["tests/**", "**/*.test.*"]
+skip_when: { diff_only_in: ["tests/**", "**/*.test.*"] }
 default_enabled: true
+severity_rules: { critical: "ユーザーが詰まる致命的な UX 不備 (無限ループ的な確認、復旧不可能な操作の無確認実行)", warning: "紛らわしいメッセージ、誤解を招く CLI 文言、argument-hint の欠落", info: "より親切な文言、説明追記、UX の細かな改善" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # usability — ユーザビリティ / DX

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,10 @@
 - `/test` — ビルド・テスト・型チェックを実行
 - `/commit` — 変更をステージし、Conventional Commits でコミット
 - `/pr` — 変更を push し、PR を作成・更新
-- `/review` — コード変更や PR をレビュー
+- `/review` — コード変更や PR を 11 観点（正確性 / セキュリティ / 規約 / アーキテクチャ / 互換性 / 保守性 / テスト / パフォーマンス / 可観測性 / ユーザビリティ / ドキュメント整合性）でレビューし、JSON 構造化出力を併載。`--axes=<list>` で観点指定、`--deep` で観点別 subagent 並列起動
 - `/ship` — lint・コミット・PR 作成を一括実行
-- `/drive` — implement + ship + review loop（Issue から merge-ready な PR まで自律駆動）
-- `/health` — リポジトリ状態を 15 領域確認し、推奨アクションを inline 表示（`--deep` で `要確認` 項目を追加調査）
+- `/drive` — implement + ship + review loop（Issue から merge-ready な PR まで自律駆動）。`--review=quick|final-deep|deep` で review モード切替（既定 quick）
+- `/health` — リポジトリ状態と skill catalog 整合性を 16 領域確認し、推奨アクションを inline 表示（`--deep` で `要確認` 項目を追加調査）
 
 ## Skills の共通ルール
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -17,12 +17,12 @@ OzzyLabs 全リポジトリ共通の 11 件:
 | `commit` | 変更をステージし Conventional Commits でコミット |
 | `commit-conventions` | コミット / ブランチ / PR の命名規則 |
 | `drive` | Issue → merge-ready な PR まで自律駆動するループ |
-| `health` | リポジトリ状態を 15 領域に渡って確認し、推奨アクションを inline 表示（`--deep` で `要確認` 項目を追加調査） |
+| `health` | リポジトリ状態と skill catalog 整合性を 16 領域に渡って確認し、推奨アクションを inline 表示（`--deep` で `要確認` 項目を追加調査） |
 | `implement` | Issue または指示をもとに、ブランチ作成・実装 |
 | `lint` | 全リンターを自動修正付きで実行 |
 | `lint-rules` | リンター設定リファレンス |
 | `pr` | 変更を push し PR を作成・更新 |
-| `review` | コード変更や PR をレビュー |
+| `review` | コード変更や PR を 11 観点（正確性 / セキュリティ / 規約 / アーキテクチャ / 互換性 / 保守性 / テスト / パフォーマンス / 可観測性 / ユーザビリティ / ドキュメント整合性）でレビュー。JSON 構造化出力を併載し、`drive` のループ終了判定を機械化する。`--axes` で自動選別を上書き、`--deep` で観点別 subagent 並列起動（Claude Code のみ） |
 | `ship` | lint + commit + PR 作成を一括実行 |
 | `test` | ビルド・テスト・型チェックを実行 |
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ The 11 common skills shared across all OzzyLabs repositories:
 | `commit` | Stage changes and create a Conventional Commit |
 | `commit-conventions` | Commit / branch / PR naming conventions |
 | `drive` | Issue → merge-ready PR autonomous loop |
-| `health` | Inspect repo state across 15 areas with inline recommended actions (`--deep` for follow-up investigation of `要確認` items) |
+| `health` | Inspect repo state and skill catalog consistency across 16 areas with inline recommended actions (`--deep` for follow-up investigation of `要確認` items) |
 | `implement` | Branch creation and implementation from an issue or instructions |
 | `lint` | Run all linters with auto-fix |
 | `lint-rules` | Lint configuration reference |
 | `pr` | Push changes and open or update a PR |
-| `review` | Review code changes or pull requests |
+| `review` | Review code changes or PRs across 11 perspectives (correctness / security / conventions / architecture / compatibility / maintainability / testing / performance / observability / usability / documentation). Emits a JSON-structured payload alongside the human-readable comment so `drive` can terminate its loop deterministically. `--axes` overrides the auto-selection; `--deep` fans out per-axis subagents (Claude Code only) |
 | `ship` | Lint + commit + PR creation in one go |
 | `test` | Run build, tests, and type checks |
 

--- a/dist/.agents/skills/health/SKILL.md
+++ b/dist/.agents/skills/health/SKILL.md
@@ -172,11 +172,13 @@ review skill が参照する `src/skills/review/perspectives/<axis>.md`（[ADR-0
   - `.agents/skills/review/perspectives/<axis>.md`（codex / gemini 配信先）
 - 検査項目（順に実施）:
   1. SSOT に存在する `<axis>.md` のうち `README.md` 以外を列挙する
-  2. 各観点 MD の frontmatter に **必須キー** `name`, `category`, `description` が揃っているか確認する
+  2. 各観点 MD の frontmatter に **必須キー** `name`, `category`, `description`, `applies_when`, `default_enabled`, `severity_rules`, `exit_criteria` が揃っているか確認する（`skip_when` は任意）
   3. `name` がファイル名（拡張子なし）と一致するか
   4. `category` が `required` / `design` / `quality` / `ux` のいずれかか
   5. `applies_when` / `skip_when.diff_only_in` の各 glob が文字列として有効か（空でない、`/` ではじまらない、改行を含まない）
-  6. SSOT と配信先のファイル一覧が一致しているか（drift があれば `pnpm run build` の取り違えを示唆）
+  6. `severity_rules` に `critical` / `warning` / `info` の 3 段階がすべて含まれているか
+  7. `exit_criteria.drive_loop` に少なくとも `critical` の許容しきい値が含まれているか
+  8. SSOT と配信先のファイル一覧が一致しているか（drift があれば `pnpm run build` の取り違えを示唆）
 - 推奨アクション:
   - 必須キー欠落 / 値不正 → `要確認`（観点 MD の frontmatter を修正）
   - SSOT と配信先の drift → `要確認`（`pnpm run build` を実行して再生成）

--- a/dist/.agents/skills/review/perspectives/README.md
+++ b/dist/.agents/skills/review/perspectives/README.md
@@ -27,17 +27,20 @@ review skill / `code-reviewer` agent が参照する観点定義の SSOT（[ADR-
 
 ```yaml
 ---
-name: <axis>                              # ファイル名と一致させる
+name: <axis>                                                    # ファイル名と一致させる
 category: required | design | quality | ux
 description: <一行で観点の主旨>
-applies_when: ["<glob>", ...]             # diff にこの glob にマッチするファイルが含まれれば適用
-skip_when:
-  diff_only_in: ["<glob>", ...]           # 全変更ファイルがこの glob 部分集合なら不適用
-default_enabled: true | false             # false の場合は --axes 明示時のみ適用
+applies_when: ["<glob>", ...]                                   # diff にこの glob にマッチするファイルが含まれれば適用
+skip_when: { diff_only_in: ["<glob>", ...] }                    # 全変更ファイルがこの glob 部分集合なら不適用
+default_enabled: true | false                                   # false の場合は --axes 明示時のみ適用
+severity_rules: { critical: "<...>", warning: "<...>", info: "<...>" }
+exit_criteria: { drive_loop: { critical: <N>, warning: <N> } }  # warning キーは省略可（許容を意味する）
 ---
 ```
 
-未定義キーは reader が無視する（forward-compat）。`severity_rules` と `exit_criteria.drive_loop` は本文で記述する。
+`skip_when` / `severity_rules` / `exit_criteria` は flow-style YAML の 1 行で記述する（既存の flat frontmatter parser と整合させるため）。本文には人間可読な severity ガイドや検査項目を冗長に記述してよいが、機械処理の SSOT は frontmatter とする。
+
+未定義キーは reader が無視する（forward-compat）。互換破壊的なスキーマ変更（必須キーの削除等）は ADR を起こす。
 
 ## 観点選別ロジック
 

--- a/dist/.agents/skills/review/perspectives/architecture.md
+++ b/dist/.agents/skills/review/perspectives/architecture.md
@@ -3,9 +3,10 @@ name: architecture
 category: design
 description: レイヤリング・責務配置・抽象度・既存パターン整合
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "既存アーキテクチャ判断 (ADR 等) に明確に反する、取り返しがつかない構造変更", warning: "責務違反、循環依存、既存パターンを破る無理筋、保守性を著しく下げる構造", info: "より良い分離・命名・抽象度の提案、リファクタリング候補" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # architecture — アーキテクチャ

--- a/dist/.agents/skills/review/perspectives/compatibility.md
+++ b/dist/.agents/skills/review/perspectives/compatibility.md
@@ -3,9 +3,10 @@ name: compatibility
 category: design
 description: 後方互換、スキーマ変更、commons-sync 経由のコンシューマ影響
 applies_when: ["src/**", "scripts/**", "dist/**", "package.json", "**/*.json", "**/*.yaml", "**/*.yml", "**/SKILL.md"]
-skip_when:
-  diff_only_in: ["tests/**", "**/*.test.*"]
+skip_when: { diff_only_in: ["tests/**", "**/*.test.*"] }
 default_enabled: true
+severity_rules: { critical: "既存コンシューマが破壊される非互換変更 (rename / 削除 / 型変更) で migration path や CHANGELOG への記載がない", warning: "互換性は保てるがコンシューマ側で対応が必要、または default 変更で挙動が変わる", info: "より丁寧な deprecation の提案、注意喚起" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # compatibility — 互換性

--- a/dist/.agents/skills/review/perspectives/conventions.md
+++ b/dist/.agents/skills/review/perspectives/conventions.md
@@ -4,6 +4,8 @@ category: required
 description: Conventional Commits、lint、ファイル命名、`.yaml` 統一などのリポジトリ規約
 applies_when: ["**/*"]
 default_enabled: true
+severity_rules: { critical: "コミット / PR タイトルが Conventional Commits 違反 (commitlint で fail)、main への直接 push、--no-verify 利用", warning: "lint / formatter 違反、命名規約違反、.yaml / .yml 不整合", info: "より明示的な書き方への改善提案、命名の細かな統一" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # conventions — コーディング規約

--- a/dist/.agents/skills/review/perspectives/correctness.md
+++ b/dist/.agents/skills/review/perspectives/correctness.md
@@ -4,6 +4,8 @@ category: required
 description: ロジック誤り・エッジケース・並行性・エラーハンドリング
 applies_when: ["**/*"]
 default_enabled: true
+severity_rules: { critical: "悪用・データ破壊・誤った状態遷移・無限ループ・回帰の温床になり得るバグ", warning: "通常パスは動くが特定入力で破綻するケース、未処理の例外", info: "防御的コーディングの改善余地、より堅牢な書き方の提案" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # correctness — 正確性

--- a/dist/.agents/skills/review/perspectives/documentation.md
+++ b/dist/.agents/skills/review/perspectives/documentation.md
@@ -3,9 +3,10 @@ name: documentation
 category: ux
 description: README・AGENTS.md・CLAUDE.md・SKILL.md・公開挙動の同期
 applies_when: ["**/*"]
-skip_when:
-  diff_only_in: []
+skip_when: { diff_only_in: [] }
 default_enabled: true
+severity_rules: { critical: "公開 API / 公開 CLI の変更がドキュメントに一切反映されておらず利用者が破壊される", warning: "README / SKILL.md / AGENTS.md の陳腐化、ADR と実装の乖離、誤ったサンプル", info: "ドキュメント追記の提案、説明の改善、表記揺れの統一" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # documentation — ドキュメント整合性

--- a/dist/.agents/skills/review/perspectives/maintainability.md
+++ b/dist/.agents/skills/review/perspectives/maintainability.md
@@ -3,9 +3,10 @@ name: maintainability
 category: design
 description: 命名・複雑度・dead code・コメント負債
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "取り返しのつかない命名 / 構造の選択 (公開 API として固定される名称等)", warning: "顕著な dead code、過剰な複雑度、誤解を招く命名、明らかな重複", info: "命名の細かな改善、コメント整理、軽微なリファクタ提案" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # maintainability — 保守性

--- a/dist/.agents/skills/review/perspectives/observability.md
+++ b/dist/.agents/skills/review/perspectives/observability.md
@@ -3,9 +3,10 @@ name: observability
 category: quality
 description: エラー文脈・ログ・失敗時の手がかり
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "失敗時に何も情報が出ず原因特定不可能、本番で silent failure になる経路", warning: "エラーメッセージが薄い、ログ過剰 / 不足、エラー種別の取り違え", info: "より親切なメッセージ、log level の調整提案" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # observability — 可観測性

--- a/dist/.agents/skills/review/perspectives/performance.md
+++ b/dist/.agents/skills/review/perspectives/performance.md
@@ -3,9 +3,10 @@ name: performance
 category: quality
 description: hot path、不要な逐次 I/O、メモリ
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "顕著な性能退行、production で UX を損なう規模のリグレッション、無限ループ", warning: "hot path 上の非効率、逐次 I/O、明らかな再計算", info: "軽微な最適化提案、cache 化候補" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # performance — パフォーマンス

--- a/dist/.agents/skills/review/perspectives/security.md
+++ b/dist/.agents/skills/review/perspectives/security.md
@@ -4,6 +4,8 @@ category: required
 description: 注入・秘密情報露出・権限昇格・サプライチェーン・スクリプト実行
 applies_when: ["**/*"]
 default_enabled: true
+severity_rules: { critical: "悪用可能な脆弱性、明示的な秘密情報の commit、認証回避、任意コード実行", warning: "防御層の欠落、未サニタイズ入力、過剰な権限、暗黙の信頼境界", info: "改善余地のある defensive coding、CSP / セキュリティヘッダの強化提案" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # security — セキュリティ

--- a/dist/.agents/skills/review/perspectives/testing.md
+++ b/dist/.agents/skills/review/perspectives/testing.md
@@ -3,9 +3,10 @@ name: testing
 category: quality
 description: 新コードのカバレッジ、回帰リスク、bats / Vitest / node:test の妥当性
 applies_when: ["src/**", "scripts/**", "tests/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "公開 API / バグ修正にテストがない、既存テストを根拠なく削除、tautology テスト", warning: "エッジケースの取りこぼし、不安定なテスト (flaky)、mock 過剰", info: "より良いアサーション、テストの整理 / 命名改善" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # testing — テスト

--- a/dist/.agents/skills/review/perspectives/usability.md
+++ b/dist/.agents/skills/review/perspectives/usability.md
@@ -3,9 +3,10 @@ name: usability
 category: ux
 description: CLI 文言・エラーメッセージ・skill argument-hint・README 即座理解性
 applies_when: ["src/**", "**/*.md", "**/SKILL.md", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["tests/**", "**/*.test.*"]
+skip_when: { diff_only_in: ["tests/**", "**/*.test.*"] }
 default_enabled: true
+severity_rules: { critical: "ユーザーが詰まる致命的な UX 不備 (無限ループ的な確認、復旧不可能な操作の無確認実行)", warning: "紛らわしいメッセージ、誤解を招く CLI 文言、argument-hint の欠落", info: "より親切な文言、説明追記、UX の細かな改善" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # usability — ユーザビリティ / DX

--- a/dist/claude-code/.claude/skills/review/perspectives/README.md
+++ b/dist/claude-code/.claude/skills/review/perspectives/README.md
@@ -27,17 +27,20 @@ review skill / `code-reviewer` agent が参照する観点定義の SSOT（[ADR-
 
 ```yaml
 ---
-name: <axis>                              # ファイル名と一致させる
+name: <axis>                                                    # ファイル名と一致させる
 category: required | design | quality | ux
 description: <一行で観点の主旨>
-applies_when: ["<glob>", ...]             # diff にこの glob にマッチするファイルが含まれれば適用
-skip_when:
-  diff_only_in: ["<glob>", ...]           # 全変更ファイルがこの glob 部分集合なら不適用
-default_enabled: true | false             # false の場合は --axes 明示時のみ適用
+applies_when: ["<glob>", ...]                                   # diff にこの glob にマッチするファイルが含まれれば適用
+skip_when: { diff_only_in: ["<glob>", ...] }                    # 全変更ファイルがこの glob 部分集合なら不適用
+default_enabled: true | false                                   # false の場合は --axes 明示時のみ適用
+severity_rules: { critical: "<...>", warning: "<...>", info: "<...>" }
+exit_criteria: { drive_loop: { critical: <N>, warning: <N> } }  # warning キーは省略可（許容を意味する）
 ---
 ```
 
-未定義キーは reader が無視する（forward-compat）。`severity_rules` と `exit_criteria.drive_loop` は本文で記述する。
+`skip_when` / `severity_rules` / `exit_criteria` は flow-style YAML の 1 行で記述する（既存の flat frontmatter parser と整合させるため）。本文には人間可読な severity ガイドや検査項目を冗長に記述してよいが、機械処理の SSOT は frontmatter とする。
+
+未定義キーは reader が無視する（forward-compat）。互換破壊的なスキーマ変更（必須キーの削除等）は ADR を起こす。
 
 ## 観点選別ロジック
 

--- a/dist/claude-code/.claude/skills/review/perspectives/architecture.md
+++ b/dist/claude-code/.claude/skills/review/perspectives/architecture.md
@@ -3,9 +3,10 @@ name: architecture
 category: design
 description: レイヤリング・責務配置・抽象度・既存パターン整合
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "既存アーキテクチャ判断 (ADR 等) に明確に反する、取り返しがつかない構造変更", warning: "責務違反、循環依存、既存パターンを破る無理筋、保守性を著しく下げる構造", info: "より良い分離・命名・抽象度の提案、リファクタリング候補" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # architecture — アーキテクチャ

--- a/dist/claude-code/.claude/skills/review/perspectives/compatibility.md
+++ b/dist/claude-code/.claude/skills/review/perspectives/compatibility.md
@@ -3,9 +3,10 @@ name: compatibility
 category: design
 description: 後方互換、スキーマ変更、commons-sync 経由のコンシューマ影響
 applies_when: ["src/**", "scripts/**", "dist/**", "package.json", "**/*.json", "**/*.yaml", "**/*.yml", "**/SKILL.md"]
-skip_when:
-  diff_only_in: ["tests/**", "**/*.test.*"]
+skip_when: { diff_only_in: ["tests/**", "**/*.test.*"] }
 default_enabled: true
+severity_rules: { critical: "既存コンシューマが破壊される非互換変更 (rename / 削除 / 型変更) で migration path や CHANGELOG への記載がない", warning: "互換性は保てるがコンシューマ側で対応が必要、または default 変更で挙動が変わる", info: "より丁寧な deprecation の提案、注意喚起" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # compatibility — 互換性

--- a/dist/claude-code/.claude/skills/review/perspectives/conventions.md
+++ b/dist/claude-code/.claude/skills/review/perspectives/conventions.md
@@ -4,6 +4,8 @@ category: required
 description: Conventional Commits、lint、ファイル命名、`.yaml` 統一などのリポジトリ規約
 applies_when: ["**/*"]
 default_enabled: true
+severity_rules: { critical: "コミット / PR タイトルが Conventional Commits 違反 (commitlint で fail)、main への直接 push、--no-verify 利用", warning: "lint / formatter 違反、命名規約違反、.yaml / .yml 不整合", info: "より明示的な書き方への改善提案、命名の細かな統一" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # conventions — コーディング規約

--- a/dist/claude-code/.claude/skills/review/perspectives/correctness.md
+++ b/dist/claude-code/.claude/skills/review/perspectives/correctness.md
@@ -4,6 +4,8 @@ category: required
 description: ロジック誤り・エッジケース・並行性・エラーハンドリング
 applies_when: ["**/*"]
 default_enabled: true
+severity_rules: { critical: "悪用・データ破壊・誤った状態遷移・無限ループ・回帰の温床になり得るバグ", warning: "通常パスは動くが特定入力で破綻するケース、未処理の例外", info: "防御的コーディングの改善余地、より堅牢な書き方の提案" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # correctness — 正確性

--- a/dist/claude-code/.claude/skills/review/perspectives/documentation.md
+++ b/dist/claude-code/.claude/skills/review/perspectives/documentation.md
@@ -3,9 +3,10 @@ name: documentation
 category: ux
 description: README・AGENTS.md・CLAUDE.md・SKILL.md・公開挙動の同期
 applies_when: ["**/*"]
-skip_when:
-  diff_only_in: []
+skip_when: { diff_only_in: [] }
 default_enabled: true
+severity_rules: { critical: "公開 API / 公開 CLI の変更がドキュメントに一切反映されておらず利用者が破壊される", warning: "README / SKILL.md / AGENTS.md の陳腐化、ADR と実装の乖離、誤ったサンプル", info: "ドキュメント追記の提案、説明の改善、表記揺れの統一" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # documentation — ドキュメント整合性

--- a/dist/claude-code/.claude/skills/review/perspectives/maintainability.md
+++ b/dist/claude-code/.claude/skills/review/perspectives/maintainability.md
@@ -3,9 +3,10 @@ name: maintainability
 category: design
 description: 命名・複雑度・dead code・コメント負債
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "取り返しのつかない命名 / 構造の選択 (公開 API として固定される名称等)", warning: "顕著な dead code、過剰な複雑度、誤解を招く命名、明らかな重複", info: "命名の細かな改善、コメント整理、軽微なリファクタ提案" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # maintainability — 保守性

--- a/dist/claude-code/.claude/skills/review/perspectives/observability.md
+++ b/dist/claude-code/.claude/skills/review/perspectives/observability.md
@@ -3,9 +3,10 @@ name: observability
 category: quality
 description: エラー文脈・ログ・失敗時の手がかり
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "失敗時に何も情報が出ず原因特定不可能、本番で silent failure になる経路", warning: "エラーメッセージが薄い、ログ過剰 / 不足、エラー種別の取り違え", info: "より親切なメッセージ、log level の調整提案" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # observability — 可観測性

--- a/dist/claude-code/.claude/skills/review/perspectives/performance.md
+++ b/dist/claude-code/.claude/skills/review/perspectives/performance.md
@@ -3,9 +3,10 @@ name: performance
 category: quality
 description: hot path、不要な逐次 I/O、メモリ
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "顕著な性能退行、production で UX を損なう規模のリグレッション、無限ループ", warning: "hot path 上の非効率、逐次 I/O、明らかな再計算", info: "軽微な最適化提案、cache 化候補" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # performance — パフォーマンス

--- a/dist/claude-code/.claude/skills/review/perspectives/security.md
+++ b/dist/claude-code/.claude/skills/review/perspectives/security.md
@@ -4,6 +4,8 @@ category: required
 description: 注入・秘密情報露出・権限昇格・サプライチェーン・スクリプト実行
 applies_when: ["**/*"]
 default_enabled: true
+severity_rules: { critical: "悪用可能な脆弱性、明示的な秘密情報の commit、認証回避、任意コード実行", warning: "防御層の欠落、未サニタイズ入力、過剰な権限、暗黙の信頼境界", info: "改善余地のある defensive coding、CSP / セキュリティヘッダの強化提案" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # security — セキュリティ

--- a/dist/claude-code/.claude/skills/review/perspectives/testing.md
+++ b/dist/claude-code/.claude/skills/review/perspectives/testing.md
@@ -3,9 +3,10 @@ name: testing
 category: quality
 description: 新コードのカバレッジ、回帰リスク、bats / Vitest / node:test の妥当性
 applies_when: ["src/**", "scripts/**", "tests/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "公開 API / バグ修正にテストがない、既存テストを根拠なく削除、tautology テスト", warning: "エッジケースの取りこぼし、不安定なテスト (flaky)、mock 過剰", info: "より良いアサーション、テストの整理 / 命名改善" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # testing — テスト

--- a/dist/claude-code/.claude/skills/review/perspectives/usability.md
+++ b/dist/claude-code/.claude/skills/review/perspectives/usability.md
@@ -3,9 +3,10 @@ name: usability
 category: ux
 description: CLI 文言・エラーメッセージ・skill argument-hint・README 即座理解性
 applies_when: ["src/**", "**/*.md", "**/SKILL.md", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["tests/**", "**/*.test.*"]
+skip_when: { diff_only_in: ["tests/**", "**/*.test.*"] }
 default_enabled: true
+severity_rules: { critical: "ユーザーが詰まる致命的な UX 不備 (無限ループ的な確認、復旧不可能な操作の無確認実行)", warning: "紛らわしいメッセージ、誤解を招く CLI 文言、argument-hint の欠落", info: "より親切な文言、説明追記、UX の細かな改善" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # usability — ユーザビリティ / DX

--- a/dist/codex-cli/.agents/skills/health/SKILL.md
+++ b/dist/codex-cli/.agents/skills/health/SKILL.md
@@ -172,11 +172,13 @@ review skill が参照する `src/skills/review/perspectives/<axis>.md`（[ADR-0
   - `.agents/skills/review/perspectives/<axis>.md`（codex / gemini 配信先）
 - 検査項目（順に実施）:
   1. SSOT に存在する `<axis>.md` のうち `README.md` 以外を列挙する
-  2. 各観点 MD の frontmatter に **必須キー** `name`, `category`, `description` が揃っているか確認する
+  2. 各観点 MD の frontmatter に **必須キー** `name`, `category`, `description`, `applies_when`, `default_enabled`, `severity_rules`, `exit_criteria` が揃っているか確認する（`skip_when` は任意）
   3. `name` がファイル名（拡張子なし）と一致するか
   4. `category` が `required` / `design` / `quality` / `ux` のいずれかか
   5. `applies_when` / `skip_when.diff_only_in` の各 glob が文字列として有効か（空でない、`/` ではじまらない、改行を含まない）
-  6. SSOT と配信先のファイル一覧が一致しているか（drift があれば `pnpm run build` の取り違えを示唆）
+  6. `severity_rules` に `critical` / `warning` / `info` の 3 段階がすべて含まれているか
+  7. `exit_criteria.drive_loop` に少なくとも `critical` の許容しきい値が含まれているか
+  8. SSOT と配信先のファイル一覧が一致しているか（drift があれば `pnpm run build` の取り違えを示唆）
 - 推奨アクション:
   - 必須キー欠落 / 値不正 → `要確認`（観点 MD の frontmatter を修正）
   - SSOT と配信先の drift → `要確認`（`pnpm run build` を実行して再生成）

--- a/dist/codex-cli/.agents/skills/review/perspectives/README.md
+++ b/dist/codex-cli/.agents/skills/review/perspectives/README.md
@@ -27,17 +27,20 @@ review skill / `code-reviewer` agent が参照する観点定義の SSOT（[ADR-
 
 ```yaml
 ---
-name: <axis>                              # ファイル名と一致させる
+name: <axis>                                                    # ファイル名と一致させる
 category: required | design | quality | ux
 description: <一行で観点の主旨>
-applies_when: ["<glob>", ...]             # diff にこの glob にマッチするファイルが含まれれば適用
-skip_when:
-  diff_only_in: ["<glob>", ...]           # 全変更ファイルがこの glob 部分集合なら不適用
-default_enabled: true | false             # false の場合は --axes 明示時のみ適用
+applies_when: ["<glob>", ...]                                   # diff にこの glob にマッチするファイルが含まれれば適用
+skip_when: { diff_only_in: ["<glob>", ...] }                    # 全変更ファイルがこの glob 部分集合なら不適用
+default_enabled: true | false                                   # false の場合は --axes 明示時のみ適用
+severity_rules: { critical: "<...>", warning: "<...>", info: "<...>" }
+exit_criteria: { drive_loop: { critical: <N>, warning: <N> } }  # warning キーは省略可（許容を意味する）
 ---
 ```
 
-未定義キーは reader が無視する（forward-compat）。`severity_rules` と `exit_criteria.drive_loop` は本文で記述する。
+`skip_when` / `severity_rules` / `exit_criteria` は flow-style YAML の 1 行で記述する（既存の flat frontmatter parser と整合させるため）。本文には人間可読な severity ガイドや検査項目を冗長に記述してよいが、機械処理の SSOT は frontmatter とする。
+
+未定義キーは reader が無視する（forward-compat）。互換破壊的なスキーマ変更（必須キーの削除等）は ADR を起こす。
 
 ## 観点選別ロジック
 

--- a/dist/codex-cli/.agents/skills/review/perspectives/architecture.md
+++ b/dist/codex-cli/.agents/skills/review/perspectives/architecture.md
@@ -3,9 +3,10 @@ name: architecture
 category: design
 description: レイヤリング・責務配置・抽象度・既存パターン整合
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "既存アーキテクチャ判断 (ADR 等) に明確に反する、取り返しがつかない構造変更", warning: "責務違反、循環依存、既存パターンを破る無理筋、保守性を著しく下げる構造", info: "より良い分離・命名・抽象度の提案、リファクタリング候補" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # architecture — アーキテクチャ

--- a/dist/codex-cli/.agents/skills/review/perspectives/compatibility.md
+++ b/dist/codex-cli/.agents/skills/review/perspectives/compatibility.md
@@ -3,9 +3,10 @@ name: compatibility
 category: design
 description: 後方互換、スキーマ変更、commons-sync 経由のコンシューマ影響
 applies_when: ["src/**", "scripts/**", "dist/**", "package.json", "**/*.json", "**/*.yaml", "**/*.yml", "**/SKILL.md"]
-skip_when:
-  diff_only_in: ["tests/**", "**/*.test.*"]
+skip_when: { diff_only_in: ["tests/**", "**/*.test.*"] }
 default_enabled: true
+severity_rules: { critical: "既存コンシューマが破壊される非互換変更 (rename / 削除 / 型変更) で migration path や CHANGELOG への記載がない", warning: "互換性は保てるがコンシューマ側で対応が必要、または default 変更で挙動が変わる", info: "より丁寧な deprecation の提案、注意喚起" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # compatibility — 互換性

--- a/dist/codex-cli/.agents/skills/review/perspectives/conventions.md
+++ b/dist/codex-cli/.agents/skills/review/perspectives/conventions.md
@@ -4,6 +4,8 @@ category: required
 description: Conventional Commits、lint、ファイル命名、`.yaml` 統一などのリポジトリ規約
 applies_when: ["**/*"]
 default_enabled: true
+severity_rules: { critical: "コミット / PR タイトルが Conventional Commits 違反 (commitlint で fail)、main への直接 push、--no-verify 利用", warning: "lint / formatter 違反、命名規約違反、.yaml / .yml 不整合", info: "より明示的な書き方への改善提案、命名の細かな統一" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # conventions — コーディング規約

--- a/dist/codex-cli/.agents/skills/review/perspectives/correctness.md
+++ b/dist/codex-cli/.agents/skills/review/perspectives/correctness.md
@@ -4,6 +4,8 @@ category: required
 description: ロジック誤り・エッジケース・並行性・エラーハンドリング
 applies_when: ["**/*"]
 default_enabled: true
+severity_rules: { critical: "悪用・データ破壊・誤った状態遷移・無限ループ・回帰の温床になり得るバグ", warning: "通常パスは動くが特定入力で破綻するケース、未処理の例外", info: "防御的コーディングの改善余地、より堅牢な書き方の提案" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # correctness — 正確性

--- a/dist/codex-cli/.agents/skills/review/perspectives/documentation.md
+++ b/dist/codex-cli/.agents/skills/review/perspectives/documentation.md
@@ -3,9 +3,10 @@ name: documentation
 category: ux
 description: README・AGENTS.md・CLAUDE.md・SKILL.md・公開挙動の同期
 applies_when: ["**/*"]
-skip_when:
-  diff_only_in: []
+skip_when: { diff_only_in: [] }
 default_enabled: true
+severity_rules: { critical: "公開 API / 公開 CLI の変更がドキュメントに一切反映されておらず利用者が破壊される", warning: "README / SKILL.md / AGENTS.md の陳腐化、ADR と実装の乖離、誤ったサンプル", info: "ドキュメント追記の提案、説明の改善、表記揺れの統一" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # documentation — ドキュメント整合性

--- a/dist/codex-cli/.agents/skills/review/perspectives/maintainability.md
+++ b/dist/codex-cli/.agents/skills/review/perspectives/maintainability.md
@@ -3,9 +3,10 @@ name: maintainability
 category: design
 description: 命名・複雑度・dead code・コメント負債
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "取り返しのつかない命名 / 構造の選択 (公開 API として固定される名称等)", warning: "顕著な dead code、過剰な複雑度、誤解を招く命名、明らかな重複", info: "命名の細かな改善、コメント整理、軽微なリファクタ提案" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # maintainability — 保守性

--- a/dist/codex-cli/.agents/skills/review/perspectives/observability.md
+++ b/dist/codex-cli/.agents/skills/review/perspectives/observability.md
@@ -3,9 +3,10 @@ name: observability
 category: quality
 description: エラー文脈・ログ・失敗時の手がかり
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "失敗時に何も情報が出ず原因特定不可能、本番で silent failure になる経路", warning: "エラーメッセージが薄い、ログ過剰 / 不足、エラー種別の取り違え", info: "より親切なメッセージ、log level の調整提案" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # observability — 可観測性

--- a/dist/codex-cli/.agents/skills/review/perspectives/performance.md
+++ b/dist/codex-cli/.agents/skills/review/perspectives/performance.md
@@ -3,9 +3,10 @@ name: performance
 category: quality
 description: hot path、不要な逐次 I/O、メモリ
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "顕著な性能退行、production で UX を損なう規模のリグレッション、無限ループ", warning: "hot path 上の非効率、逐次 I/O、明らかな再計算", info: "軽微な最適化提案、cache 化候補" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # performance — パフォーマンス

--- a/dist/codex-cli/.agents/skills/review/perspectives/security.md
+++ b/dist/codex-cli/.agents/skills/review/perspectives/security.md
@@ -4,6 +4,8 @@ category: required
 description: 注入・秘密情報露出・権限昇格・サプライチェーン・スクリプト実行
 applies_when: ["**/*"]
 default_enabled: true
+severity_rules: { critical: "悪用可能な脆弱性、明示的な秘密情報の commit、認証回避、任意コード実行", warning: "防御層の欠落、未サニタイズ入力、過剰な権限、暗黙の信頼境界", info: "改善余地のある defensive coding、CSP / セキュリティヘッダの強化提案" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # security — セキュリティ

--- a/dist/codex-cli/.agents/skills/review/perspectives/testing.md
+++ b/dist/codex-cli/.agents/skills/review/perspectives/testing.md
@@ -3,9 +3,10 @@ name: testing
 category: quality
 description: 新コードのカバレッジ、回帰リスク、bats / Vitest / node:test の妥当性
 applies_when: ["src/**", "scripts/**", "tests/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "公開 API / バグ修正にテストがない、既存テストを根拠なく削除、tautology テスト", warning: "エッジケースの取りこぼし、不安定なテスト (flaky)、mock 過剰", info: "より良いアサーション、テストの整理 / 命名改善" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # testing — テスト

--- a/dist/codex-cli/.agents/skills/review/perspectives/usability.md
+++ b/dist/codex-cli/.agents/skills/review/perspectives/usability.md
@@ -3,9 +3,10 @@ name: usability
 category: ux
 description: CLI 文言・エラーメッセージ・skill argument-hint・README 即座理解性
 applies_when: ["src/**", "**/*.md", "**/SKILL.md", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["tests/**", "**/*.test.*"]
+skip_when: { diff_only_in: ["tests/**", "**/*.test.*"] }
 default_enabled: true
+severity_rules: { critical: "ユーザーが詰まる致命的な UX 不備 (無限ループ的な確認、復旧不可能な操作の無確認実行)", warning: "紛らわしいメッセージ、誤解を招く CLI 文言、argument-hint の欠落", info: "より親切な文言、説明追記、UX の細かな改善" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # usability — ユーザビリティ / DX

--- a/src/skills/health/SKILL.md
+++ b/src/skills/health/SKILL.md
@@ -172,11 +172,13 @@ review skill が参照する `src/skills/review/perspectives/<axis>.md`（[ADR-0
   - `.agents/skills/review/perspectives/<axis>.md`（codex / gemini 配信先）
 - 検査項目（順に実施）:
   1. SSOT に存在する `<axis>.md` のうち `README.md` 以外を列挙する
-  2. 各観点 MD の frontmatter に **必須キー** `name`, `category`, `description` が揃っているか確認する
+  2. 各観点 MD の frontmatter に **必須キー** `name`, `category`, `description`, `applies_when`, `default_enabled`, `severity_rules`, `exit_criteria` が揃っているか確認する（`skip_when` は任意）
   3. `name` がファイル名（拡張子なし）と一致するか
   4. `category` が `required` / `design` / `quality` / `ux` のいずれかか
   5. `applies_when` / `skip_when.diff_only_in` の各 glob が文字列として有効か（空でない、`/` ではじまらない、改行を含まない）
-  6. SSOT と配信先のファイル一覧が一致しているか（drift があれば `pnpm run build` の取り違えを示唆）
+  6. `severity_rules` に `critical` / `warning` / `info` の 3 段階がすべて含まれているか
+  7. `exit_criteria.drive_loop` に少なくとも `critical` の許容しきい値が含まれているか
+  8. SSOT と配信先のファイル一覧が一致しているか（drift があれば `pnpm run build` の取り違えを示唆）
 - 推奨アクション:
   - 必須キー欠落 / 値不正 → `要確認`（観点 MD の frontmatter を修正）
   - SSOT と配信先の drift → `要確認`（`pnpm run build` を実行して再生成）

--- a/src/skills/review/perspectives/README.md
+++ b/src/skills/review/perspectives/README.md
@@ -27,17 +27,20 @@ review skill / `code-reviewer` agent が参照する観点定義の SSOT（[ADR-
 
 ```yaml
 ---
-name: <axis>                              # ファイル名と一致させる
+name: <axis>                                                    # ファイル名と一致させる
 category: required | design | quality | ux
 description: <一行で観点の主旨>
-applies_when: ["<glob>", ...]             # diff にこの glob にマッチするファイルが含まれれば適用
-skip_when:
-  diff_only_in: ["<glob>", ...]           # 全変更ファイルがこの glob 部分集合なら不適用
-default_enabled: true | false             # false の場合は --axes 明示時のみ適用
+applies_when: ["<glob>", ...]                                   # diff にこの glob にマッチするファイルが含まれれば適用
+skip_when: { diff_only_in: ["<glob>", ...] }                    # 全変更ファイルがこの glob 部分集合なら不適用
+default_enabled: true | false                                   # false の場合は --axes 明示時のみ適用
+severity_rules: { critical: "<...>", warning: "<...>", info: "<...>" }
+exit_criteria: { drive_loop: { critical: <N>, warning: <N> } }  # warning キーは省略可（許容を意味する）
 ---
 ```
 
-未定義キーは reader が無視する（forward-compat）。`severity_rules` と `exit_criteria.drive_loop` は本文で記述する。
+`skip_when` / `severity_rules` / `exit_criteria` は flow-style YAML の 1 行で記述する（既存の flat frontmatter parser と整合させるため）。本文には人間可読な severity ガイドや検査項目を冗長に記述してよいが、機械処理の SSOT は frontmatter とする。
+
+未定義キーは reader が無視する（forward-compat）。互換破壊的なスキーマ変更（必須キーの削除等）は ADR を起こす。
 
 ## 観点選別ロジック
 

--- a/src/skills/review/perspectives/architecture.md
+++ b/src/skills/review/perspectives/architecture.md
@@ -3,9 +3,10 @@ name: architecture
 category: design
 description: レイヤリング・責務配置・抽象度・既存パターン整合
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "既存アーキテクチャ判断 (ADR 等) に明確に反する、取り返しがつかない構造変更", warning: "責務違反、循環依存、既存パターンを破る無理筋、保守性を著しく下げる構造", info: "より良い分離・命名・抽象度の提案、リファクタリング候補" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # architecture — アーキテクチャ

--- a/src/skills/review/perspectives/compatibility.md
+++ b/src/skills/review/perspectives/compatibility.md
@@ -3,9 +3,10 @@ name: compatibility
 category: design
 description: 後方互換、スキーマ変更、commons-sync 経由のコンシューマ影響
 applies_when: ["src/**", "scripts/**", "dist/**", "package.json", "**/*.json", "**/*.yaml", "**/*.yml", "**/SKILL.md"]
-skip_when:
-  diff_only_in: ["tests/**", "**/*.test.*"]
+skip_when: { diff_only_in: ["tests/**", "**/*.test.*"] }
 default_enabled: true
+severity_rules: { critical: "既存コンシューマが破壊される非互換変更 (rename / 削除 / 型変更) で migration path や CHANGELOG への記載がない", warning: "互換性は保てるがコンシューマ側で対応が必要、または default 変更で挙動が変わる", info: "より丁寧な deprecation の提案、注意喚起" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # compatibility — 互換性

--- a/src/skills/review/perspectives/conventions.md
+++ b/src/skills/review/perspectives/conventions.md
@@ -4,6 +4,8 @@ category: required
 description: Conventional Commits、lint、ファイル命名、`.yaml` 統一などのリポジトリ規約
 applies_when: ["**/*"]
 default_enabled: true
+severity_rules: { critical: "コミット / PR タイトルが Conventional Commits 違反 (commitlint で fail)、main への直接 push、--no-verify 利用", warning: "lint / formatter 違反、命名規約違反、.yaml / .yml 不整合", info: "より明示的な書き方への改善提案、命名の細かな統一" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # conventions — コーディング規約

--- a/src/skills/review/perspectives/correctness.md
+++ b/src/skills/review/perspectives/correctness.md
@@ -4,6 +4,8 @@ category: required
 description: ロジック誤り・エッジケース・並行性・エラーハンドリング
 applies_when: ["**/*"]
 default_enabled: true
+severity_rules: { critical: "悪用・データ破壊・誤った状態遷移・無限ループ・回帰の温床になり得るバグ", warning: "通常パスは動くが特定入力で破綻するケース、未処理の例外", info: "防御的コーディングの改善余地、より堅牢な書き方の提案" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # correctness — 正確性

--- a/src/skills/review/perspectives/documentation.md
+++ b/src/skills/review/perspectives/documentation.md
@@ -3,9 +3,10 @@ name: documentation
 category: ux
 description: README・AGENTS.md・CLAUDE.md・SKILL.md・公開挙動の同期
 applies_when: ["**/*"]
-skip_when:
-  diff_only_in: []
+skip_when: { diff_only_in: [] }
 default_enabled: true
+severity_rules: { critical: "公開 API / 公開 CLI の変更がドキュメントに一切反映されておらず利用者が破壊される", warning: "README / SKILL.md / AGENTS.md の陳腐化、ADR と実装の乖離、誤ったサンプル", info: "ドキュメント追記の提案、説明の改善、表記揺れの統一" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # documentation — ドキュメント整合性

--- a/src/skills/review/perspectives/maintainability.md
+++ b/src/skills/review/perspectives/maintainability.md
@@ -3,9 +3,10 @@ name: maintainability
 category: design
 description: 命名・複雑度・dead code・コメント負債
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "取り返しのつかない命名 / 構造の選択 (公開 API として固定される名称等)", warning: "顕著な dead code、過剰な複雑度、誤解を招く命名、明らかな重複", info: "命名の細かな改善、コメント整理、軽微なリファクタ提案" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # maintainability — 保守性

--- a/src/skills/review/perspectives/observability.md
+++ b/src/skills/review/perspectives/observability.md
@@ -3,9 +3,10 @@ name: observability
 category: quality
 description: エラー文脈・ログ・失敗時の手がかり
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "失敗時に何も情報が出ず原因特定不可能、本番で silent failure になる経路", warning: "エラーメッセージが薄い、ログ過剰 / 不足、エラー種別の取り違え", info: "より親切なメッセージ、log level の調整提案" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # observability — 可観測性

--- a/src/skills/review/perspectives/performance.md
+++ b/src/skills/review/perspectives/performance.md
@@ -3,9 +3,10 @@ name: performance
 category: quality
 description: hot path、不要な逐次 I/O、メモリ
 applies_when: ["src/**", "scripts/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "tests/**", "**/*.test.*", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "顕著な性能退行、production で UX を損なう規模のリグレッション、無限ループ", warning: "hot path 上の非効率、逐次 I/O、明らかな再計算", info: "軽微な最適化提案、cache 化候補" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # performance — パフォーマンス

--- a/src/skills/review/perspectives/security.md
+++ b/src/skills/review/perspectives/security.md
@@ -4,6 +4,8 @@ category: required
 description: 注入・秘密情報露出・権限昇格・サプライチェーン・スクリプト実行
 applies_when: ["**/*"]
 default_enabled: true
+severity_rules: { critical: "悪用可能な脆弱性、明示的な秘密情報の commit、認証回避、任意コード実行", warning: "防御層の欠落、未サニタイズ入力、過剰な権限、暗黙の信頼境界", info: "改善余地のある defensive coding、CSP / セキュリティヘッダの強化提案" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # security — セキュリティ

--- a/src/skills/review/perspectives/testing.md
+++ b/src/skills/review/perspectives/testing.md
@@ -3,9 +3,10 @@ name: testing
 category: quality
 description: 新コードのカバレッジ、回帰リスク、bats / Vitest / node:test の妥当性
 applies_when: ["src/**", "scripts/**", "tests/**", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"]
+skip_when: { diff_only_in: ["**/*.md", "docs/**", "**/*.yaml", "**/*.yml", "**/*.json"] }
 default_enabled: true
+severity_rules: { critical: "公開 API / バグ修正にテストがない、既存テストを根拠なく削除、tautology テスト", warning: "エッジケースの取りこぼし、不安定なテスト (flaky)、mock 過剰", info: "より良いアサーション、テストの整理 / 命名改善" }
+exit_criteria: { drive_loop: { critical: 0, warning: 0 } }
 ---
 
 # testing — テスト

--- a/src/skills/review/perspectives/usability.md
+++ b/src/skills/review/perspectives/usability.md
@@ -3,9 +3,10 @@ name: usability
 category: ux
 description: CLI 文言・エラーメッセージ・skill argument-hint・README 即座理解性
 applies_when: ["src/**", "**/*.md", "**/SKILL.md", "**/*.ts", "**/*.tsx", "**/*.mjs", "**/*.js", "**/*.py", "**/*.sh"]
-skip_when:
-  diff_only_in: ["tests/**", "**/*.test.*"]
+skip_when: { diff_only_in: ["tests/**", "**/*.test.*"] }
 default_enabled: true
+severity_rules: { critical: "ユーザーが詰まる致命的な UX 不備 (無限ループ的な確認、復旧不可能な操作の無確認実行)", warning: "紛らわしいメッセージ、誤解を招く CLI 文言、argument-hint の欠落", info: "より親切な文言、説明追記、UX の細かな改善" }
+exit_criteria: { drive_loop: { critical: 0 } }
 ---
 
 # usability — ユーザビリティ / DX

--- a/tests/perspectives.test.mjs
+++ b/tests/perspectives.test.mjs
@@ -32,17 +32,66 @@ test("perspectives directory exists with at least one axis file", async () => {
 
 test("each perspective MD has required frontmatter keys", async () => {
   const axes = await listAxes();
+  // Match Issue #59 scope: name, category, description, applies_when,
+  // default_enabled, severity_rules, exit_criteria. (skip_when is optional —
+  // required-category axes need no skip rules.)
+  const required = [
+    "name",
+    "category",
+    "description",
+    "applies_when",
+    "default_enabled",
+    "severity_rules",
+    "exit_criteria",
+  ];
   for (const filename of axes) {
     const path = join(PERSPECTIVES_DIR, filename);
     const raw = await readFile(path, "utf8");
     const label = `src/skills/review/perspectives/${filename}`;
     const { frontmatter } = parseSkillDocument(raw, label);
-    for (const key of ["name", "category", "description"]) {
+    for (const key of required) {
       assert.ok(
         frontmatter[key] && frontmatter[key].length > 0,
         `${label}: missing required frontmatter key '${key}'`,
       );
     }
+  }
+});
+
+test("severity_rules frontmatter mentions all three severities", async () => {
+  const axes = await listAxes();
+  for (const filename of axes) {
+    const path = join(PERSPECTIVES_DIR, filename);
+    const raw = await readFile(path, "utf8");
+    const label = `src/skills/review/perspectives/${filename}`;
+    const { frontmatter } = parseSkillDocument(raw, label);
+    for (const sev of ["critical", "warning", "info"]) {
+      assert.match(
+        frontmatter.severity_rules,
+        new RegExp(`\\b${sev}\\b`),
+        `${label}: severity_rules must declare '${sev}'`,
+      );
+    }
+  }
+});
+
+test("exit_criteria frontmatter declares drive_loop", async () => {
+  const axes = await listAxes();
+  for (const filename of axes) {
+    const path = join(PERSPECTIVES_DIR, filename);
+    const raw = await readFile(path, "utf8");
+    const label = `src/skills/review/perspectives/${filename}`;
+    const { frontmatter } = parseSkillDocument(raw, label);
+    assert.match(
+      frontmatter.exit_criteria,
+      /drive_loop\s*:/,
+      `${label}: exit_criteria must declare drive_loop`,
+    );
+    assert.match(
+      frontmatter.exit_criteria,
+      /critical\s*:/,
+      `${label}: exit_criteria.drive_loop must declare critical threshold`,
+    );
   }
 });
 


### PR DESCRIPTION
## Summary

PR #60 のマージ後に総チェックで発見した Issue #59 スコープ漏れと公開ドキュメント陳腐化への follow-up。

### Issue #59 のスコープに対する漏れ

- **frontmatter スキーマ**: Issue scope は `severity_rules` と `exit_criteria.drive_loop` を **frontmatter に置く** 設計だったが、PR #60 では本文に書いていた。本 PR で flow-style YAML（1 行）で frontmatter に移行し、本文の severity ガイドはそのまま人間可読の説明として残す
- 既存 frontmatter parser（`scripts/lib/frontmatter.mjs`）は flat key:value のみ扱うため、ネストした block-style YAML を書くと key collision が発生する。flow-style の 1 行記述なら parser は scalar として読み、Claude は YAML としても解釈できる

### 公開ドキュメント更新

- `README.md` / `README.ja.md` / `CLAUDE.md` の `review` description を「11 観点」「JSON 出力」「`--axes` / `--deep`」に更新
- 同 3 ファイルの `health` description を「16 領域」「skill catalog 整合性」に更新

### health skill lint 強化

- 領域 #16（perspective MD frontmatter）の検査項目に `severity_rules` / `exit_criteria` の必須化を追加

### テスト

- `tests/perspectives.test.mjs` に severity_rules（3 段階すべて）と `exit_criteria.drive_loop` の検証を追加
- 全 73 tests pass

closes follow-up gap from #60

## Test plan

- [x] \`pnpm run build\`: pass
- [x] \`pnpm run lint\` (biome): pass
- [x] \`pnpm run lint:md\` (markdownlint): pass
- [x] \`pnpm run lint:yaml\` (yamllint): pass
- [x] \`node --test 'tests/**/*.test.mjs'\`: 73 tests pass (was 71; +2 新規)
- [ ] CI: lint / test / build が green

🤖 Generated with [Claude Code](https://claude.com/claude-code)