### PR TITLE
feat(skills): add phase-issue skill for Phase-N tracking issues

### DIFF
--- a/.agents/skills/phase-issue/SKILL.md
+++ b/.agents/skills/phase-issue/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: phase-issue
+description: Phase-N tracking issue を生成する。cross-session handoff context、決定事項表、PR ごとのタスク、DoD、Phase N+1 outlook を含む構造化された issue body を組み立てて gh issue create で起票する。引数で全項目を渡す非対話モードと、不足分を補う対話モード（Claude Code companion）に対応する。
+---
+
+# phase-issue - Phase-N tracking issue 生成
+
+ozzy-labs で繰り返し発生する Phase-N tracking issue（cross-session handoff context + 決定事項表 + PR ごとのタスク + DoD + Phase N+1 outlook）の構造をハードコードし、引数または対話で集めた内容から決定論的に issue body を組み立てる。`gh issue create --body-file` で起票するか、`--draft` 指定時は stdout に出力する。
+
+このスキル単体で起票まで完結する。drive 連携や Phase 番号の自動採番は行わない（スコープ外）。
+
+## 入力
+
+```text
+phase-issue <phase-number> "<title>"
+  --description "..."         (project description; プロジェクト概要)
+  --refs "owner/repo1,owner/repo2"  (参考実装。カンマ区切り)
+  --donts "..."               (やってはいけないこと。改行区切り)
+  --decisions-file <path>     (決定事項 YAML/Markdown ファイル)
+  --tasks-file <path>         (PR ごとのタスクファイル)
+  --dod "..."                 (Definition of Done。改行区切り)
+  --outlook "..."             (Phase N+1 outlook)
+  --related "..."             (関連 issue/PR/ADR。改行区切り)
+  --label "<label>"           (issue label。既定: "chore")
+  --repo "<owner/repo>"       (起票先リポ。省略時はカレントリポ)
+  --draft                     (起票せず stdout に body を出力)
+```
+
+### 必須引数
+
+- `<phase-number>`: 整数（例: `0`, `1`, `2`）
+- `<title>`: 引用符でくくった文字列（例: `"agentic-watch foundation"`）
+
+### 任意引数の取り扱い（非対話モード）
+
+canonical SKILL.md は **非対話前提** で動作する。任意引数が不足している場合、対応するセクションは body から **省略**する（プレースホルダーでは埋めない）。「不明分は対話で集めたい」場合は Claude Code companion（`SKILL.claude-code.md`）を使う。
+
+`--decisions-file` および `--tasks-file` が指定された場合、ファイル内容をそのまま該当セクションに転記する（解析・整形はしない。ユーザー側で markdown 整形済みであることを期待する）。
+
+## ハードコードされた章立て
+
+issue body は以下の章立てで構築する。**順序は固定**で、変更しない:
+
+```markdown
+# Phase {{N}}: {{title}}
+
+## Cross-session handoff
+
+このセクションは新しいセッション/エージェントが本 issue を読んだだけで作業を引き継げるよう、必要な context を集約する。
+
+- **プロジェクト概要:** {{description}}
+- **参考実装:** {{refs (linked)}}
+- **やってはいけないこと:** {{donts (bulleted)}}
+
+## 決定事項
+
+{{decisions-file の内容、または "(TBD)"}}
+
+## タスク（PR ごと）
+
+{{tasks-file の内容、または "(TBD)"}}
+
+## Definition of Done
+
+{{dod (bulleted)}}
+
+## Phase {{N+1}} outlook
+
+{{outlook、または "(未定)"}}
+
+## 関連
+
+{{related (bulleted)}}
+```
+
+### セクションごとの整形ルール
+
+- **Cross-session handoff:**
+  - `--description` がない場合は `(未記入)` ではなく **行ごと省略**（bulleted item を出さない）
+  - `--refs` はカンマ区切りを bulleted list に展開し、`owner/repo` は `https://github.com/owner/repo` に linkify する
+  - `--donts` は改行区切りを bulleted list に展開する
+  - 3 項目すべてが空の場合、`## Cross-session handoff` セクション自体を省略する
+- **決定事項 / タスク（PR ごと）:** ファイルが指定されない場合、セクション本文を `(TBD)` とする（セクション自体は残す）。Phase issue で **決定事項とタスクは骨格** に当たるため、未記入でもプレースホルダーを残して後追いを促す
+- **DoD:** 改行区切りを `- [ ] item` 形式の checkbox list に展開する。空の場合 `(TBD)` とする
+- **Phase N+1 outlook:** 文字列をそのまま転記する。空の場合 `(未定)` とする
+- **関連:** 改行区切りを bulleted list に展開する。`#N` / `owner/repo#N` / URL いずれも許容（linkify はせず原文を保持）。空の場合セクションを省略する
+
+### マーカーブロック注記
+
+cross-session handoff の冒頭に以下の HTML コメントを必ず埋め込む。これは将来 phase-issue で再生成・更新する際の anchor として機能する:
+
+```markdown
+<!-- phase-issue:v1 phase=N -->
+```
+
+`v1` は本スキルが生成する body のフォーマットバージョン。schema を変える場合は bump する。
+
+## 手順
+
+### 1. 引数解析
+
+1. `<phase-number>` と `<title>` を取得する。どちらも必須。欠落時はエラーを表示して中断する
+2. オプションを解析する。同じオプションが複数回指定された場合は最後のものを採用する
+3. `--decisions-file` / `--tasks-file` が指定された場合、ファイルの存在と読み取り可否を確認する。失敗時はエラーを表示して中断する
+
+### 2. body 組み立て
+
+1. ハードコードされた章立てに従って body を組み立てる
+2. プレースホルダー `{{N}}` / `{{title}}` / `{{N+1}}` を実値で置換する
+3. 各セクションの整形ルールに従い、空セクションは省略 / TBD / 未定 を適切に出し分ける
+4. マーカーブロックを cross-session handoff の冒頭に挿入する
+
+### 3. 起票または stdout 出力
+
+- `--draft` 指定時:
+  - body を stdout に出力する
+  - `gh` コマンドは呼び出さない
+- `--draft` 未指定時:
+  - body を一時ファイルに書き出す
+  - `gh issue create --title "Phase {{N}}: {{title}}" --label "<label>" --body-file <tmp>` を実行する
+  - `--repo` が指定されていれば `--repo` 引数を gh に渡す
+  - 起票成功時は issue URL を表示する
+
+### 4. 完了報告
+
+```text
+phase-issue 完了:
+  タイトル: Phase <N>: <title>
+  起票先:    <repo>
+  Issue:    <URL>  (--draft 指定時は "(stdout に出力)")
+```
+
+## 注意事項
+
+- 引数で渡されない任意項目は body から省略するか TBD で埋める。Claude が想像で内容を補完しない
+- `gh` CLI が未認証の場合はエラーメッセージを表示して中断する
+- `--draft` モードでは外部副作用なし（ファイル書き込みも `gh` 呼び出しもない）
+- title は double quote でくくる前提。コマンド側のシェルエスケープは呼び出し元の責任
+- canonical SKILL.md は非対話前提。対話的に項目を集めたい場合は Claude Code companion を使う
+- **過去 issue からの style 学習はしない**: 章立ては SKILL.md 内に固定する（学習機構は実装複雑度に対し対価が小さい）
+- **Phase 番号の自動採番はしない**: `<phase-number>` は呼び出し元が明示する
+- **drive 連携はしない**: phase-issue は起票で完結する。生成された issue の分割・実装は別途 drive で回す

--- a/.claude/skills/phase-issue/SKILL.md
+++ b/.claude/skills/phase-issue/SKILL.md
@@ -1,0 +1,60 @@
+---
+description: Phase-N tracking issue を生成する。引数で渡された項目はそのまま使い、不足分は AskUserQuestion で対話的に補う。`--draft` で stdout 出力、それ以外は `gh issue create` で起票する。
+argument-hint: <phase-number> "<title>" [--description ...] [--refs ...] [--donts ...] [--decisions-file ...] [--tasks-file ...] [--dod ...] [--outlook ...] [--related ...] [--label ...] [--repo ...] [--draft]
+disable-model-invocation: true
+allowed-tools: Bash, Read, Write, AskUserQuestion
+---
+
+# phase-issue
+
+`.agents/skills/phase-issue/SKILL.md` を Read し、ワークフロー手順に従う。
+
+**重要:** 章立て・整形ルール・マーカーブロックは canonical SKILL.md の規約に厳密に従う。Claude の自由判断で章を増減しない。
+
+## Claude Code 固有の追加事項
+
+### 引数解析
+
+`$ARGUMENTS` を解析する:
+
+- `<phase-number>` と `<title>` が欠落している場合、AskUserQuestion でそれぞれ確認する（`answers` パラメータは設定しない）
+- 任意オプション（`--description`, `--refs`, `--donts`, `--decisions-file`, `--tasks-file`, `--dod`, `--outlook`, `--related`, `--label`, `--repo`, `--draft`）は引数から取得する
+
+### 不足項目の対話補完
+
+引数で渡されなかった任意項目について、AskUserQuestion で **個別に** 補完するか確認する（`answers` パラメータは設定しない）。
+
+質問順序（章立て順に従う）:
+
+1. **「プロジェクト概要を入力する」** / 「省略する」 → `--description` 相当
+2. **「参考実装を入力する」** / 「省略する」 → `--refs` 相当（カンマ区切り）
+3. **「やってはいけないことを入力する」** / 「省略する」 → `--donts` 相当（改行区切り）
+4. **「決定事項ファイルを指定する」** / 「TBD で残す」 → `--decisions-file` 相当
+5. **「タスクファイルを指定する」** / 「TBD で残す」 → `--tasks-file` 相当
+6. **「DoD を入力する」** / 「TBD で残す」 → `--dod` 相当（改行区切り）
+7. **「Phase N+1 outlook を入力する」** / 「(未定) で残す」 → `--outlook` 相当
+8. **「関連を入力する」** / 「省略する」 → `--related` 相当（改行区切り）
+
+「入力する」を選んだ場合は AskUserQuestion で具体的な内容を尋ねる（自由記述は別の AskUserQuestion 呼び出しで行う）。
+
+引数で既に渡された項目については **質問しない**（同じ情報を二重で集めない）。
+
+### body プレビューと最終確認
+
+body 組み立て後、起票または stdout 出力の前に、AskUserQuestion で確認する（`answers` パラメータは設定しない）:
+
+- **「この内容で起票する」** → `gh issue create --body-file` で起票（`--draft` 指定時は stdout 出力）
+- **「修正する」** → 修正対象セクションを尋ねて該当項目を再入力する
+- **「キャンセル」** → 中断する
+
+**重要:** 承認なしに `gh issue create` を実行しない。`--draft` モードでも、stdout 出力前に内容確認を行う。
+
+### 完了後の次のアクション
+
+完了報告の直後に AskUserQuestion を呼び出す（`answers` パラメータは設定しない）:
+
+- **「この issue から `/drive` で実装を始める」** → 起票した issue 番号を引数として `/drive` を案内する（実行はしない）
+- **「別の Phase issue を作成する」** → 本スキルを再度実行するよう案内する
+- **「終了する」** → 終了する
+
+ネクストアクションはユーザーの確認なく実行しない。

--- a/dist/.agents/skills/phase-issue/SKILL.md
+++ b/dist/.agents/skills/phase-issue/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: phase-issue
+description: Phase-N tracking issue を生成する。cross-session handoff context、決定事項表、PR ごとのタスク、DoD、Phase N+1 outlook を含む構造化された issue body を組み立てて gh issue create で起票する。引数で全項目を渡す非対話モードと、不足分を補う対話モード（Claude Code companion）に対応する。
+---
+
+# phase-issue - Phase-N tracking issue 生成
+
+ozzy-labs で繰り返し発生する Phase-N tracking issue（cross-session handoff context + 決定事項表 + PR ごとのタスク + DoD + Phase N+1 outlook）の構造をハードコードし、引数または対話で集めた内容から決定論的に issue body を組み立てる。`gh issue create --body-file` で起票するか、`--draft` 指定時は stdout に出力する。
+
+このスキル単体で起票まで完結する。drive 連携や Phase 番号の自動採番は行わない（スコープ外）。
+
+## 入力
+
+```text
+phase-issue <phase-number> "<title>"
+  --description "..."         (project description; プロジェクト概要)
+  --refs "owner/repo1,owner/repo2"  (参考実装。カンマ区切り)
+  --donts "..."               (やってはいけないこと。改行区切り)
+  --decisions-file <path>     (決定事項 YAML/Markdown ファイル)
+  --tasks-file <path>         (PR ごとのタスクファイル)
+  --dod "..."                 (Definition of Done。改行区切り)
+  --outlook "..."             (Phase N+1 outlook)
+  --related "..."             (関連 issue/PR/ADR。改行区切り)
+  --label "<label>"           (issue label。既定: "chore")
+  --repo "<owner/repo>"       (起票先リポ。省略時はカレントリポ)
+  --draft                     (起票せず stdout に body を出力)
+```
+
+### 必須引数
+
+- `<phase-number>`: 整数（例: `0`, `1`, `2`）
+- `<title>`: 引用符でくくった文字列（例: `"agentic-watch foundation"`）
+
+### 任意引数の取り扱い（非対話モード）
+
+canonical SKILL.md は **非対話前提** で動作する。任意引数が不足している場合、対応するセクションは body から **省略**する（プレースホルダーでは埋めない）。「不明分は対話で集めたい」場合は Claude Code companion（`SKILL.claude-code.md`）を使う。
+
+`--decisions-file` および `--tasks-file` が指定された場合、ファイル内容をそのまま該当セクションに転記する（解析・整形はしない。ユーザー側で markdown 整形済みであることを期待する）。
+
+## ハードコードされた章立て
+
+issue body は以下の章立てで構築する。**順序は固定**で、変更しない:
+
+```markdown
+# Phase {{N}}: {{title}}
+
+## Cross-session handoff
+
+このセクションは新しいセッション/エージェントが本 issue を読んだだけで作業を引き継げるよう、必要な context を集約する。
+
+- **プロジェクト概要:** {{description}}
+- **参考実装:** {{refs (linked)}}
+- **やってはいけないこと:** {{donts (bulleted)}}
+
+## 決定事項
+
+{{decisions-file の内容、または "(TBD)"}}
+
+## タスク（PR ごと）
+
+{{tasks-file の内容、または "(TBD)"}}
+
+## Definition of Done
+
+{{dod (bulleted)}}
+
+## Phase {{N+1}} outlook
+
+{{outlook、または "(未定)"}}
+
+## 関連
+
+{{related (bulleted)}}
+```
+
+### セクションごとの整形ルール
+
+- **Cross-session handoff:**
+  - `--description` がない場合は `(未記入)` ではなく **行ごと省略**（bulleted item を出さない）
+  - `--refs` はカンマ区切りを bulleted list に展開し、`owner/repo` は `https://github.com/owner/repo` に linkify する
+  - `--donts` は改行区切りを bulleted list に展開する
+  - 3 項目すべてが空の場合、`## Cross-session handoff` セクション自体を省略する
+- **決定事項 / タスク（PR ごと）:** ファイルが指定されない場合、セクション本文を `(TBD)` とする（セクション自体は残す）。Phase issue で **決定事項とタスクは骨格** に当たるため、未記入でもプレースホルダーを残して後追いを促す
+- **DoD:** 改行区切りを `- [ ] item` 形式の checkbox list に展開する。空の場合 `(TBD)` とする
+- **Phase N+1 outlook:** 文字列をそのまま転記する。空の場合 `(未定)` とする
+- **関連:** 改行区切りを bulleted list に展開する。`#N` / `owner/repo#N` / URL いずれも許容（linkify はせず原文を保持）。空の場合セクションを省略する
+
+### マーカーブロック注記
+
+cross-session handoff の冒頭に以下の HTML コメントを必ず埋め込む。これは将来 phase-issue で再生成・更新する際の anchor として機能する:
+
+```markdown
+<!-- phase-issue:v1 phase=N -->
+```
+
+`v1` は本スキルが生成する body のフォーマットバージョン。schema を変える場合は bump する。
+
+## 手順
+
+### 1. 引数解析
+
+1. `<phase-number>` と `<title>` を取得する。どちらも必須。欠落時はエラーを表示して中断する
+2. オプションを解析する。同じオプションが複数回指定された場合は最後のものを採用する
+3. `--decisions-file` / `--tasks-file` が指定された場合、ファイルの存在と読み取り可否を確認する。失敗時はエラーを表示して中断する
+
+### 2. body 組み立て
+
+1. ハードコードされた章立てに従って body を組み立てる
+2. プレースホルダー `{{N}}` / `{{title}}` / `{{N+1}}` を実値で置換する
+3. 各セクションの整形ルールに従い、空セクションは省略 / TBD / 未定 を適切に出し分ける
+4. マーカーブロックを cross-session handoff の冒頭に挿入する
+
+### 3. 起票または stdout 出力
+
+- `--draft` 指定時:
+  - body を stdout に出力する
+  - `gh` コマンドは呼び出さない
+- `--draft` 未指定時:
+  - body を一時ファイルに書き出す
+  - `gh issue create --title "Phase {{N}}: {{title}}" --label "<label>" --body-file <tmp>` を実行する
+  - `--repo` が指定されていれば `--repo` 引数を gh に渡す
+  - 起票成功時は issue URL を表示する
+
+### 4. 完了報告
+
+```text
+phase-issue 完了:
+  タイトル: Phase <N>: <title>
+  起票先:    <repo>
+  Issue:    <URL>  (--draft 指定時は "(stdout に出力)")
+```
+
+## 注意事項
+
+- 引数で渡されない任意項目は body から省略するか TBD で埋める。Claude が想像で内容を補完しない
+- `gh` CLI が未認証の場合はエラーメッセージを表示して中断する
+- `--draft` モードでは外部副作用なし（ファイル書き込みも `gh` 呼び出しもない）
+- title は double quote でくくる前提。コマンド側のシェルエスケープは呼び出し元の責任
+- canonical SKILL.md は非対話前提。対話的に項目を集めたい場合は Claude Code companion を使う
+- **過去 issue からの style 学習はしない**: 章立ては SKILL.md 内に固定する（学習機構は実装複雑度に対し対価が小さい）
+- **Phase 番号の自動採番はしない**: `<phase-number>` は呼び出し元が明示する
+- **drive 連携はしない**: phase-issue は起票で完結する。生成された issue の分割・実装は別途 drive で回す

--- a/dist/claude-code/.claude/skills/phase-issue/SKILL.md
+++ b/dist/claude-code/.claude/skills/phase-issue/SKILL.md
@@ -1,0 +1,60 @@
+---
+description: Phase-N tracking issue を生成する。引数で渡された項目はそのまま使い、不足分は AskUserQuestion で対話的に補う。`--draft` で stdout 出力、それ以外は `gh issue create` で起票する。
+argument-hint: <phase-number> "<title>" [--description ...] [--refs ...] [--donts ...] [--decisions-file ...] [--tasks-file ...] [--dod ...] [--outlook ...] [--related ...] [--label ...] [--repo ...] [--draft]
+disable-model-invocation: true
+allowed-tools: Bash, Read, Write, AskUserQuestion
+---
+
+# phase-issue
+
+`.agents/skills/phase-issue/SKILL.md` を Read し、ワークフロー手順に従う。
+
+**重要:** 章立て・整形ルール・マーカーブロックは canonical SKILL.md の規約に厳密に従う。Claude の自由判断で章を増減しない。
+
+## Claude Code 固有の追加事項
+
+### 引数解析
+
+`$ARGUMENTS` を解析する:
+
+- `<phase-number>` と `<title>` が欠落している場合、AskUserQuestion でそれぞれ確認する（`answers` パラメータは設定しない）
+- 任意オプション（`--description`, `--refs`, `--donts`, `--decisions-file`, `--tasks-file`, `--dod`, `--outlook`, `--related`, `--label`, `--repo`, `--draft`）は引数から取得する
+
+### 不足項目の対話補完
+
+引数で渡されなかった任意項目について、AskUserQuestion で **個別に** 補完するか確認する（`answers` パラメータは設定しない）。
+
+質問順序（章立て順に従う）:
+
+1. **「プロジェクト概要を入力する」** / 「省略する」 → `--description` 相当
+2. **「参考実装を入力する」** / 「省略する」 → `--refs` 相当（カンマ区切り）
+3. **「やってはいけないことを入力する」** / 「省略する」 → `--donts` 相当（改行区切り）
+4. **「決定事項ファイルを指定する」** / 「TBD で残す」 → `--decisions-file` 相当
+5. **「タスクファイルを指定する」** / 「TBD で残す」 → `--tasks-file` 相当
+6. **「DoD を入力する」** / 「TBD で残す」 → `--dod` 相当（改行区切り）
+7. **「Phase N+1 outlook を入力する」** / 「(未定) で残す」 → `--outlook` 相当
+8. **「関連を入力する」** / 「省略する」 → `--related` 相当（改行区切り）
+
+「入力する」を選んだ場合は AskUserQuestion で具体的な内容を尋ねる（自由記述は別の AskUserQuestion 呼び出しで行う）。
+
+引数で既に渡された項目については **質問しない**（同じ情報を二重で集めない）。
+
+### body プレビューと最終確認
+
+body 組み立て後、起票または stdout 出力の前に、AskUserQuestion で確認する（`answers` パラメータは設定しない）:
+
+- **「この内容で起票する」** → `gh issue create --body-file` で起票（`--draft` 指定時は stdout 出力）
+- **「修正する」** → 修正対象セクションを尋ねて該当項目を再入力する
+- **「キャンセル」** → 中断する
+
+**重要:** 承認なしに `gh issue create` を実行しない。`--draft` モードでも、stdout 出力前に内容確認を行う。
+
+### 完了後の次のアクション
+
+完了報告の直後に AskUserQuestion を呼び出す（`answers` パラメータは設定しない）:
+
+- **「この issue から `/drive` で実装を始める」** → 起票した issue 番号を引数として `/drive` を案内する（実行はしない）
+- **「別の Phase issue を作成する」** → 本スキルを再度実行するよう案内する
+- **「終了する」** → 終了する
+
+ネクストアクションはユーザーの確認なく実行しない。

--- a/dist/codex-cli/.agents/skills/phase-issue/SKILL.md
+++ b/dist/codex-cli/.agents/skills/phase-issue/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: phase-issue
+description: Phase-N tracking issue を生成する。cross-session handoff context、決定事項表、PR ごとのタスク、DoD、Phase N+1 outlook を含む構造化された issue body を組み立てて gh issue create で起票する。引数で全項目を渡す非対話モードと、不足分を補う対話モード（Claude Code companion）に対応する。
+---
+
+# phase-issue - Phase-N tracking issue 生成
+
+ozzy-labs で繰り返し発生する Phase-N tracking issue（cross-session handoff context + 決定事項表 + PR ごとのタスク + DoD + Phase N+1 outlook）の構造をハードコードし、引数または対話で集めた内容から決定論的に issue body を組み立てる。`gh issue create --body-file` で起票するか、`--draft` 指定時は stdout に出力する。
+
+このスキル単体で起票まで完結する。drive 連携や Phase 番号の自動採番は行わない（スコープ外）。
+
+## 入力
+
+```text
+phase-issue <phase-number> "<title>"
+  --description "..."         (project description; プロジェクト概要)
+  --refs "owner/repo1,owner/repo2"  (参考実装。カンマ区切り)
+  --donts "..."               (やってはいけないこと。改行区切り)
+  --decisions-file <path>     (決定事項 YAML/Markdown ファイル)
+  --tasks-file <path>         (PR ごとのタスクファイル)
+  --dod "..."                 (Definition of Done。改行区切り)
+  --outlook "..."             (Phase N+1 outlook)
+  --related "..."             (関連 issue/PR/ADR。改行区切り)
+  --label "<label>"           (issue label。既定: "chore")
+  --repo "<owner/repo>"       (起票先リポ。省略時はカレントリポ)
+  --draft                     (起票せず stdout に body を出力)
+```
+
+### 必須引数
+
+- `<phase-number>`: 整数（例: `0`, `1`, `2`）
+- `<title>`: 引用符でくくった文字列（例: `"agentic-watch foundation"`）
+
+### 任意引数の取り扱い（非対話モード）
+
+canonical SKILL.md は **非対話前提** で動作する。任意引数が不足している場合、対応するセクションは body から **省略**する（プレースホルダーでは埋めない）。「不明分は対話で集めたい」場合は Claude Code companion（`SKILL.claude-code.md`）を使う。
+
+`--decisions-file` および `--tasks-file` が指定された場合、ファイル内容をそのまま該当セクションに転記する（解析・整形はしない。ユーザー側で markdown 整形済みであることを期待する）。
+
+## ハードコードされた章立て
+
+issue body は以下の章立てで構築する。**順序は固定**で、変更しない:
+
+```markdown
+# Phase {{N}}: {{title}}
+
+## Cross-session handoff
+
+このセクションは新しいセッション/エージェントが本 issue を読んだだけで作業を引き継げるよう、必要な context を集約する。
+
+- **プロジェクト概要:** {{description}}
+- **参考実装:** {{refs (linked)}}
+- **やってはいけないこと:** {{donts (bulleted)}}
+
+## 決定事項
+
+{{decisions-file の内容、または "(TBD)"}}
+
+## タスク（PR ごと）
+
+{{tasks-file の内容、または "(TBD)"}}
+
+## Definition of Done
+
+{{dod (bulleted)}}
+
+## Phase {{N+1}} outlook
+
+{{outlook、または "(未定)"}}
+
+## 関連
+
+{{related (bulleted)}}
+```
+
+### セクションごとの整形ルール
+
+- **Cross-session handoff:**
+  - `--description` がない場合は `(未記入)` ではなく **行ごと省略**（bulleted item を出さない）
+  - `--refs` はカンマ区切りを bulleted list に展開し、`owner/repo` は `https://github.com/owner/repo` に linkify する
+  - `--donts` は改行区切りを bulleted list に展開する
+  - 3 項目すべてが空の場合、`## Cross-session handoff` セクション自体を省略する
+- **決定事項 / タスク（PR ごと）:** ファイルが指定されない場合、セクション本文を `(TBD)` とする（セクション自体は残す）。Phase issue で **決定事項とタスクは骨格** に当たるため、未記入でもプレースホルダーを残して後追いを促す
+- **DoD:** 改行区切りを `- [ ] item` 形式の checkbox list に展開する。空の場合 `(TBD)` とする
+- **Phase N+1 outlook:** 文字列をそのまま転記する。空の場合 `(未定)` とする
+- **関連:** 改行区切りを bulleted list に展開する。`#N` / `owner/repo#N` / URL いずれも許容（linkify はせず原文を保持）。空の場合セクションを省略する
+
+### マーカーブロック注記
+
+cross-session handoff の冒頭に以下の HTML コメントを必ず埋め込む。これは将来 phase-issue で再生成・更新する際の anchor として機能する:
+
+```markdown
+<!-- phase-issue:v1 phase=N -->
+```
+
+`v1` は本スキルが生成する body のフォーマットバージョン。schema を変える場合は bump する。
+
+## 手順
+
+### 1. 引数解析
+
+1. `<phase-number>` と `<title>` を取得する。どちらも必須。欠落時はエラーを表示して中断する
+2. オプションを解析する。同じオプションが複数回指定された場合は最後のものを採用する
+3. `--decisions-file` / `--tasks-file` が指定された場合、ファイルの存在と読み取り可否を確認する。失敗時はエラーを表示して中断する
+
+### 2. body 組み立て
+
+1. ハードコードされた章立てに従って body を組み立てる
+2. プレースホルダー `{{N}}` / `{{title}}` / `{{N+1}}` を実値で置換する
+3. 各セクションの整形ルールに従い、空セクションは省略 / TBD / 未定 を適切に出し分ける
+4. マーカーブロックを cross-session handoff の冒頭に挿入する
+
+### 3. 起票または stdout 出力
+
+- `--draft` 指定時:
+  - body を stdout に出力する
+  - `gh` コマンドは呼び出さない
+- `--draft` 未指定時:
+  - body を一時ファイルに書き出す
+  - `gh issue create --title "Phase {{N}}: {{title}}" --label "<label>" --body-file <tmp>` を実行する
+  - `--repo` が指定されていれば `--repo` 引数を gh に渡す
+  - 起票成功時は issue URL を表示する
+
+### 4. 完了報告
+
+```text
+phase-issue 完了:
+  タイトル: Phase <N>: <title>
+  起票先:    <repo>
+  Issue:    <URL>  (--draft 指定時は "(stdout に出力)")
+```
+
+## 注意事項
+
+- 引数で渡されない任意項目は body から省略するか TBD で埋める。Claude が想像で内容を補完しない
+- `gh` CLI が未認証の場合はエラーメッセージを表示して中断する
+- `--draft` モードでは外部副作用なし（ファイル書き込みも `gh` 呼び出しもない）
+- title は double quote でくくる前提。コマンド側のシェルエスケープは呼び出し元の責任
+- canonical SKILL.md は非対話前提。対話的に項目を集めたい場合は Claude Code companion を使う
+- **過去 issue からの style 学習はしない**: 章立ては SKILL.md 内に固定する（学習機構は実装複雑度に対し対価が小さい）
+- **Phase 番号の自動採番はしない**: `<phase-number>` は呼び出し元が明示する
+- **drive 連携はしない**: phase-issue は起票で完結する。生成された issue の分割・実装は別途 drive で回す

--- a/dist/codex-cli/AGENTS.md.snippet
+++ b/dist/codex-cli/AGENTS.md.snippet
@@ -9,6 +9,7 @@
 - `implement` — Issue または指示をもとに、ブランチ作成・実装計画・コード変更を行う。Issue 番号またはテキスト指示を受け取る。
 - `lint` — 全リンターを自動修正付きで実行し、結果を報告する。コード品質チェック、フォーマット、型チェック、セキュリティスキャンを含む。
 - `lint-rules` — 拡張子別リンター・フォーマッターのコマンド対応表と型チェックルール。他スキルから参照される。
+- `phase-issue` — Phase-N tracking issue を生成する。cross-session handoff context、決定事項表、PR ごとのタスク、DoD、Phase N+1 outlook を含む構造化された issue body を組み立てて gh issue create で起票する。引数で全項目を渡す非対話モードと、不足分を補う対話モード（Claude Code companion）に対応する。
 - `pr` — コミット済みの変更をリモートにプッシュし、PR を作成・更新する。
 - `review` — コード変更や PR を 11 観点（perspectives）でレビューし、JSON 構造化出力 + 人間可読レポートで報告する。quick / deep モードを切替可能。PR 番号またはワーキングツリー差分を入力に取る。
 - `ship` — lint・コミット・PR 作成を一括実行する。変更に対して lint → コミット → PR 作成を順に実行する統合パイプライン。

--- a/dist/copilot/.github/copilot-instructions.md.snippet
+++ b/dist/copilot/.github/copilot-instructions.md.snippet
@@ -9,6 +9,7 @@
 - `implement` — Issue または指示をもとに、ブランチ作成・実装計画・コード変更を行う。Issue 番号またはテキスト指示を受け取る。
 - `lint` — 全リンターを自動修正付きで実行し、結果を報告する。コード品質チェック、フォーマット、型チェック、セキュリティスキャンを含む。
 - `lint-rules` — 拡張子別リンター・フォーマッターのコマンド対応表と型チェックルール。他スキルから参照される。
+- `phase-issue` — Phase-N tracking issue を生成する。cross-session handoff context、決定事項表、PR ごとのタスク、DoD、Phase N+1 outlook を含む構造化された issue body を組み立てて gh issue create で起票する。引数で全項目を渡す非対話モードと、不足分を補う対話モード（Claude Code companion）に対応する。
 - `pr` — コミット済みの変更をリモートにプッシュし、PR を作成・更新する。
 - `review` — コード変更や PR を 11 観点（perspectives）でレビューし、JSON 構造化出力 + 人間可読レポートで報告する。quick / deep モードを切替可能。PR 番号またはワーキングツリー差分を入力に取る。
 - `ship` — lint・コミット・PR 作成を一括実行する。変更に対して lint → コミット → PR 作成を順に実行する統合パイプライン。

--- a/dist/gemini-cli/AGENTS.md.snippet
+++ b/dist/gemini-cli/AGENTS.md.snippet
@@ -9,6 +9,7 @@
 - `implement` — Issue または指示をもとに、ブランチ作成・実装計画・コード変更を行う。Issue 番号またはテキスト指示を受け取る。
 - `lint` — 全リンターを自動修正付きで実行し、結果を報告する。コード品質チェック、フォーマット、型チェック、セキュリティスキャンを含む。
 - `lint-rules` — 拡張子別リンター・フォーマッターのコマンド対応表と型チェックルール。他スキルから参照される。
+- `phase-issue` — Phase-N tracking issue を生成する。cross-session handoff context、決定事項表、PR ごとのタスク、DoD、Phase N+1 outlook を含む構造化された issue body を組み立てて gh issue create で起票する。引数で全項目を渡す非対話モードと、不足分を補う対話モード（Claude Code companion）に対応する。
 - `pr` — コミット済みの変更をリモートにプッシュし、PR を作成・更新する。
 - `review` — コード変更や PR を 11 観点（perspectives）でレビューし、JSON 構造化出力 + 人間可読レポートで報告する。quick / deep モードを切替可能。PR 番号またはワーキングツリー差分を入力に取る。
 - `ship` — lint・コミット・PR 作成を一括実行する。変更に対して lint → コミット → PR 作成を順に実行する統合パイプライン。

--- a/src/skills/phase-issue/SKILL.claude-code.md
+++ b/src/skills/phase-issue/SKILL.claude-code.md
@@ -1,0 +1,60 @@
+---
+description: Phase-N tracking issue を生成する。引数で渡された項目はそのまま使い、不足分は AskUserQuestion で対話的に補う。`--draft` で stdout 出力、それ以外は `gh issue create` で起票する。
+argument-hint: <phase-number> "<title>" [--description ...] [--refs ...] [--donts ...] [--decisions-file ...] [--tasks-file ...] [--dod ...] [--outlook ...] [--related ...] [--label ...] [--repo ...] [--draft]
+disable-model-invocation: true
+allowed-tools: Bash, Read, Write, AskUserQuestion
+---
+
+# phase-issue
+
+`.agents/skills/phase-issue/SKILL.md` を Read し、ワークフロー手順に従う。
+
+**重要:** 章立て・整形ルール・マーカーブロックは canonical SKILL.md の規約に厳密に従う。Claude の自由判断で章を増減しない。
+
+## Claude Code 固有の追加事項
+
+### 引数解析
+
+`$ARGUMENTS` を解析する:
+
+- `<phase-number>` と `<title>` が欠落している場合、AskUserQuestion でそれぞれ確認する（`answers` パラメータは設定しない）
+- 任意オプション（`--description`, `--refs`, `--donts`, `--decisions-file`, `--tasks-file`, `--dod`, `--outlook`, `--related`, `--label`, `--repo`, `--draft`）は引数から取得する
+
+### 不足項目の対話補完
+
+引数で渡されなかった任意項目について、AskUserQuestion で **個別に** 補完するか確認する（`answers` パラメータは設定しない）。
+
+質問順序（章立て順に従う）:
+
+1. **「プロジェクト概要を入力する」** / 「省略する」 → `--description` 相当
+2. **「参考実装を入力する」** / 「省略する」 → `--refs` 相当（カンマ区切り）
+3. **「やってはいけないことを入力する」** / 「省略する」 → `--donts` 相当（改行区切り）
+4. **「決定事項ファイルを指定する」** / 「TBD で残す」 → `--decisions-file` 相当
+5. **「タスクファイルを指定する」** / 「TBD で残す」 → `--tasks-file` 相当
+6. **「DoD を入力する」** / 「TBD で残す」 → `--dod` 相当（改行区切り）
+7. **「Phase N+1 outlook を入力する」** / 「(未定) で残す」 → `--outlook` 相当
+8. **「関連を入力する」** / 「省略する」 → `--related` 相当（改行区切り）
+
+「入力する」を選んだ場合は AskUserQuestion で具体的な内容を尋ねる（自由記述は別の AskUserQuestion 呼び出しで行う）。
+
+引数で既に渡された項目については **質問しない**（同じ情報を二重で集めない）。
+
+### body プレビューと最終確認
+
+body 組み立て後、起票または stdout 出力の前に、AskUserQuestion で確認する（`answers` パラメータは設定しない）:
+
+- **「この内容で起票する」** → `gh issue create --body-file` で起票（`--draft` 指定時は stdout 出力）
+- **「修正する」** → 修正対象セクションを尋ねて該当項目を再入力する
+- **「キャンセル」** → 中断する
+
+**重要:** 承認なしに `gh issue create` を実行しない。`--draft` モードでも、stdout 出力前に内容確認を行う。
+
+### 完了後の次のアクション
+
+完了報告の直後に AskUserQuestion を呼び出す（`answers` パラメータは設定しない）:
+
+- **「この issue から `/drive` で実装を始める」** → 起票した issue 番号を引数として `/drive` を案内する（実行はしない）
+- **「別の Phase issue を作成する」** → 本スキルを再度実行するよう案内する
+- **「終了する」** → 終了する
+
+ネクストアクションはユーザーの確認なく実行しない。

--- a/src/skills/phase-issue/SKILL.md
+++ b/src/skills/phase-issue/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: phase-issue
+description: Phase-N tracking issue を生成する。cross-session handoff context、決定事項表、PR ごとのタスク、DoD、Phase N+1 outlook を含む構造化された issue body を組み立てて gh issue create で起票する。引数で全項目を渡す非対話モードと、不足分を補う対話モード（Claude Code companion）に対応する。
+---
+
+# phase-issue - Phase-N tracking issue 生成
+
+ozzy-labs で繰り返し発生する Phase-N tracking issue（cross-session handoff context + 決定事項表 + PR ごとのタスク + DoD + Phase N+1 outlook）の構造をハードコードし、引数または対話で集めた内容から決定論的に issue body を組み立てる。`gh issue create --body-file` で起票するか、`--draft` 指定時は stdout に出力する。
+
+このスキル単体で起票まで完結する。drive 連携や Phase 番号の自動採番は行わない（スコープ外）。
+
+## 入力
+
+```text
+phase-issue <phase-number> "<title>"
+  --description "..."         (project description; プロジェクト概要)
+  --refs "owner/repo1,owner/repo2"  (参考実装。カンマ区切り)
+  --donts "..."               (やってはいけないこと。改行区切り)
+  --decisions-file <path>     (決定事項 YAML/Markdown ファイル)
+  --tasks-file <path>         (PR ごとのタスクファイル)
+  --dod "..."                 (Definition of Done。改行区切り)
+  --outlook "..."             (Phase N+1 outlook)
+  --related "..."             (関連 issue/PR/ADR。改行区切り)
+  --label "<label>"           (issue label。既定: "chore")
+  --repo "<owner/repo>"       (起票先リポ。省略時はカレントリポ)
+  --draft                     (起票せず stdout に body を出力)
+```
+
+### 必須引数
+
+- `<phase-number>`: 整数（例: `0`, `1`, `2`）
+- `<title>`: 引用符でくくった文字列（例: `"agentic-watch foundation"`）
+
+### 任意引数の取り扱い（非対話モード）
+
+canonical SKILL.md は **非対話前提** で動作する。任意引数が不足している場合、対応するセクションは body から **省略**する（プレースホルダーでは埋めない）。「不明分は対話で集めたい」場合は Claude Code companion（`SKILL.claude-code.md`）を使う。
+
+`--decisions-file` および `--tasks-file` が指定された場合、ファイル内容をそのまま該当セクションに転記する（解析・整形はしない。ユーザー側で markdown 整形済みであることを期待する）。
+
+## ハードコードされた章立て
+
+issue body は以下の章立てで構築する。**順序は固定**で、変更しない:
+
+```markdown
+# Phase {{N}}: {{title}}
+
+## Cross-session handoff
+
+このセクションは新しいセッション/エージェントが本 issue を読んだだけで作業を引き継げるよう、必要な context を集約する。
+
+- **プロジェクト概要:** {{description}}
+- **参考実装:** {{refs (linked)}}
+- **やってはいけないこと:** {{donts (bulleted)}}
+
+## 決定事項
+
+{{decisions-file の内容、または "(TBD)"}}
+
+## タスク（PR ごと）
+
+{{tasks-file の内容、または "(TBD)"}}
+
+## Definition of Done
+
+{{dod (bulleted)}}
+
+## Phase {{N+1}} outlook
+
+{{outlook、または "(未定)"}}
+
+## 関連
+
+{{related (bulleted)}}
+```
+
+### セクションごとの整形ルール
+
+- **Cross-session handoff:**
+  - `--description` がない場合は `(未記入)` ではなく **行ごと省略**（bulleted item を出さない）
+  - `--refs` はカンマ区切りを bulleted list に展開し、`owner/repo` は `https://github.com/owner/repo` に linkify する
+  - `--donts` は改行区切りを bulleted list に展開する
+  - 3 項目すべてが空の場合、`## Cross-session handoff` セクション自体を省略する
+- **決定事項 / タスク（PR ごと）:** ファイルが指定されない場合、セクション本文を `(TBD)` とする（セクション自体は残す）。Phase issue で **決定事項とタスクは骨格** に当たるため、未記入でもプレースホルダーを残して後追いを促す
+- **DoD:** 改行区切りを `- [ ] item` 形式の checkbox list に展開する。空の場合 `(TBD)` とする
+- **Phase N+1 outlook:** 文字列をそのまま転記する。空の場合 `(未定)` とする
+- **関連:** 改行区切りを bulleted list に展開する。`#N` / `owner/repo#N` / URL いずれも許容（linkify はせず原文を保持）。空の場合セクションを省略する
+
+### マーカーブロック注記
+
+cross-session handoff の冒頭に以下の HTML コメントを必ず埋め込む。これは将来 phase-issue で再生成・更新する際の anchor として機能する:
+
+```markdown
+<!-- phase-issue:v1 phase=N -->
+```
+
+`v1` は本スキルが生成する body のフォーマットバージョン。schema を変える場合は bump する。
+
+## 手順
+
+### 1. 引数解析
+
+1. `<phase-number>` と `<title>` を取得する。どちらも必須。欠落時はエラーを表示して中断する
+2. オプションを解析する。同じオプションが複数回指定された場合は最後のものを採用する
+3. `--decisions-file` / `--tasks-file` が指定された場合、ファイルの存在と読み取り可否を確認する。失敗時はエラーを表示して中断する
+
+### 2. body 組み立て
+
+1. ハードコードされた章立てに従って body を組み立てる
+2. プレースホルダー `{{N}}` / `{{title}}` / `{{N+1}}` を実値で置換する
+3. 各セクションの整形ルールに従い、空セクションは省略 / TBD / 未定 を適切に出し分ける
+4. マーカーブロックを cross-session handoff の冒頭に挿入する
+
+### 3. 起票または stdout 出力
+
+- `--draft` 指定時:
+  - body を stdout に出力する
+  - `gh` コマンドは呼び出さない
+- `--draft` 未指定時:
+  - body を一時ファイルに書き出す
+  - `gh issue create --title "Phase {{N}}: {{title}}" --label "<label>" --body-file <tmp>` を実行する
+  - `--repo` が指定されていれば `--repo` 引数を gh に渡す
+  - 起票成功時は issue URL を表示する
+
+### 4. 完了報告
+
+```text
+phase-issue 完了:
+  タイトル: Phase <N>: <title>
+  起票先:    <repo>
+  Issue:    <URL>  (--draft 指定時は "(stdout に出力)")
+```
+
+## 注意事項
+
+- 引数で渡されない任意項目は body から省略するか TBD で埋める。Claude が想像で内容を補完しない
+- `gh` CLI が未認証の場合はエラーメッセージを表示して中断する
+- `--draft` モードでは外部副作用なし（ファイル書き込みも `gh` 呼び出しもない）
+- title は double quote でくくる前提。コマンド側のシェルエスケープは呼び出し元の責任
+- canonical SKILL.md は非対話前提。対話的に項目を集めたい場合は Claude Code companion を使う
+- **過去 issue からの style 学習はしない**: 章立ては SKILL.md 内に固定する（学習機構は実装複雑度に対し対価が小さい）
+- **Phase 番号の自動採番はしない**: `<phase-number>` は呼び出し元が明示する
+- **drive 連携はしない**: phase-issue は起票で完結する。生成された issue の分割・実装は別途 drive で回す

--- a/tests/phase-issue.test.mjs
+++ b/tests/phase-issue.test.mjs
@@ -1,0 +1,224 @@
+// Structural tests for the phase-issue skill.
+//
+// phase-issue is a documentation-driven skill (not a runnable script): the
+// canonical SKILL.md is read and executed by an agent. These tests therefore
+// assert on the document's *structure* — the contract Issue #62 pins down —
+// rather than on a runtime. They cover non-interactive behavior:
+//   1. canonical frontmatter is well-formed and adapter-eligible
+//   2. the hardcoded section skeleton is present and ordered
+//   3. CLI argument surface and `--draft` mode are documented
+//   4. Claude-Code-only behaviors stay in the companion (AskUserQuestion is
+//      *not* present in canonical SKILL.md, only in the companion)
+//   5. explicit out-of-scope items remain documented (no drive coupling, no
+//      auto-numbering, no style learning)
+//
+// If the skill ever grows a runnable adapter, replace these with
+// behavioural tests; until then, structural assertions are what protect us
+// from silent contract drift.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { ClaudeCodeAdapter } from "../scripts/adapters/claude-code.mjs";
+import { CodexCliAdapter } from "../scripts/adapters/codex-cli.mjs";
+import { GeminiCliAdapter } from "../scripts/adapters/gemini-cli.mjs";
+import { assertRequiredFields, parseSkillDocument } from "../scripts/lib/frontmatter.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SKILL_DIR = join(ROOT, "src", "skills", "phase-issue");
+const CANONICAL = join(SKILL_DIR, "SKILL.md");
+const COMPANION = join(SKILL_DIR, "SKILL.claude-code.md");
+
+async function loadCanonical() {
+  const raw = await readFile(CANONICAL, "utf8");
+  const { frontmatter, body } = parseSkillDocument(raw, "src/skills/phase-issue/SKILL.md");
+  return { frontmatter, body, raw };
+}
+
+async function loadCompanion() {
+  const raw = await readFile(COMPANION, "utf8");
+  const { frontmatter, body } = parseSkillDocument(
+    raw,
+    "src/skills/phase-issue/SKILL.claude-code.md",
+  );
+  return { frontmatter, body, raw };
+}
+
+test("phase-issue canonical SKILL.md has required frontmatter", async () => {
+  const { frontmatter } = await loadCanonical();
+  assertRequiredFields(frontmatter, ["name", "description"], "phase-issue SKILL.md");
+  assert.equal(frontmatter.name, "phase-issue", "name must be phase-issue (not 'epic')");
+  assert.ok(
+    frontmatter.description.length > 0,
+    "description must be non-empty for adapter validation",
+  );
+});
+
+test("phase-issue companion SKILL.claude-code.md has required frontmatter", async () => {
+  const { frontmatter } = await loadCompanion();
+  assertRequiredFields(frontmatter, ["description"], "phase-issue SKILL.claude-code.md");
+  // Companion frontmatter must declare AskUserQuestion in allowed-tools so
+  // the interactive flow can run.
+  assert.match(
+    frontmatter["allowed-tools"] ?? "",
+    /AskUserQuestion/,
+    "companion must allow AskUserQuestion (interactive flow)",
+  );
+  assert.equal(
+    frontmatter["disable-model-invocation"],
+    "true",
+    "skill must be user-invoked, not model-invoked",
+  );
+});
+
+test("phase-issue canonical SKILL.md hardcodes the section skeleton in order", async () => {
+  const { body } = await loadCanonical();
+
+  // The Issue #62 acceptance criteria pin the section list. Order matters:
+  // it is the contract for cross-session handoff. We grep for the literal
+  // section headings used in the section-by-section formatting rules so
+  // accidental rename / removal trips the test.
+  const expectedSections = [
+    "Cross-session handoff",
+    "決定事項",
+    "タスク（PR ごと）",
+    "Definition of Done",
+    "Phase {{N+1}} outlook",
+    "関連",
+  ];
+
+  let cursor = 0;
+  for (const heading of expectedSections) {
+    const idx = body.indexOf(heading, cursor);
+    assert.notEqual(idx, -1, `section heading missing or out of order: "${heading}"`);
+    cursor = idx + heading.length;
+  }
+});
+
+test("phase-issue canonical SKILL.md documents the CLI argument surface", async () => {
+  const { body } = await loadCanonical();
+
+  // Required positional args.
+  assert.match(body, /<phase-number>/, "phase-number positional arg must be documented");
+  assert.match(body, /<title>/, "title positional arg must be documented");
+
+  // Optional flags from acceptance criteria.
+  const requiredFlags = [
+    "--description",
+    "--refs",
+    "--donts",
+    "--decisions-file",
+    "--tasks-file",
+    "--dod",
+    "--outlook",
+    "--related",
+    "--label",
+    "--repo",
+    "--draft",
+  ];
+  for (const flag of requiredFlags) {
+    assert.match(body, new RegExp(flag.replace(/-/g, "\\-")), `flag ${flag} must be documented`);
+  }
+});
+
+test("phase-issue --draft mode is documented as stdout-only with no side effects", async () => {
+  const { body } = await loadCanonical();
+  assert.match(body, /--draft/, "--draft must be documented");
+  assert.match(
+    body,
+    /stdout/,
+    "--draft must be documented as stdout output (acceptance criterion 4)",
+  );
+  assert.match(
+    body,
+    /外部副作用なし|gh.*呼び出さない|gh.*呼び出しもない/,
+    "--draft mode must explicitly state no gh side effects",
+  );
+});
+
+test("phase-issue canonical body marks non-interactive behavior", async () => {
+  const { body } = await loadCanonical();
+  // Acceptance criterion 1: canonical SKILL.md is non-interactive.
+  // AskUserQuestion belongs in the companion, not here.
+  assert.doesNotMatch(
+    body,
+    /AskUserQuestion/,
+    "canonical SKILL.md must NOT reference AskUserQuestion (acceptance criterion 1: non-interactive)",
+  );
+  assert.match(
+    body,
+    /非対話/,
+    "canonical SKILL.md must explicitly document its non-interactive contract",
+  );
+});
+
+test("phase-issue companion delegates to AskUserQuestion for interactive collection", async () => {
+  const { body } = await loadCompanion();
+  // Acceptance criterion 2: Claude Code companion uses AskUserQuestion.
+  assert.match(
+    body,
+    /AskUserQuestion/,
+    "companion must use AskUserQuestion for interactive input collection",
+  );
+});
+
+test("phase-issue documents explicit out-of-scope items from Issue #62", async () => {
+  const { body } = await loadCanonical();
+  // Issue #62 explicitly excludes drive coupling, auto-numbering, and style
+  // learning. These must remain documented as out-of-scope so future edits
+  // can't silently expand the contract.
+  assert.match(body, /drive\s*連携/, "out-of-scope: drive coupling must be documented");
+  assert.match(body, /自動採番/, "out-of-scope: phase number auto-numbering must be documented");
+  assert.match(
+    body,
+    /style\s*学習|過去\s*issue/,
+    "out-of-scope: style learning must be documented",
+  );
+});
+
+test("phase-issue body embeds a versioned marker block for future regeneration", async () => {
+  const { body } = await loadCanonical();
+  // The issue body emits a `<!-- phase-issue:v1 phase=N -->` anchor so
+  // a future re-run can find and update the same issue. This contract
+  // must stay documented.
+  assert.match(
+    body,
+    /<!--\s*phase-issue:v\d+/,
+    "marker block (phase-issue:vN) must be documented for re-generation anchor",
+  );
+});
+
+test("phase-issue is wired into all four adapter outputs (build pipeline integration)", async () => {
+  const { frontmatter, body, raw } = await loadCanonical();
+  const companion = await loadCompanion();
+
+  const skill = {
+    name: "phase-issue",
+    description: frontmatter.description,
+    frontmatter,
+    body,
+    raw,
+    claudeCodeCompanion: companion,
+  };
+
+  const claude = await new ClaudeCodeAdapter().generate([skill]);
+  assert.ok(
+    claude.find((o) => o.relativePath === ".claude/skills/phase-issue/SKILL.md"),
+    "Claude Code adapter must emit phase-issue",
+  );
+
+  // Codex CLI and Gemini CLI both ship a shared `AGENTS.md.snippet` listing
+  // every skill by name. The skill must appear in that snippet so consumers
+  // see it in their AGENTS.md.
+  const codex = await new CodexCliAdapter().generate([skill]);
+  const codexSnippet = codex.find((o) => o.relativePath === "AGENTS.md.snippet");
+  assert.ok(codexSnippet, "Codex CLI adapter must emit AGENTS.md.snippet");
+  assert.match(codexSnippet.content, /phase-issue/, "Codex CLI snippet must list phase-issue");
+
+  const gemini = await new GeminiCliAdapter().generate([skill]);
+  const geminiSnippet = gemini.find((o) => o.relativePath === "AGENTS.md.snippet");
+  assert.ok(geminiSnippet, "Gemini CLI adapter must emit AGENTS.md.snippet");
+  assert.match(geminiSnippet.content, /phase-issue/, "Gemini CLI snippet must list phase-issue");
+});


### PR DESCRIPTION
## Summary

- Adds `src/skills/phase-issue/` (canonical SKILL.md + SKILL.claude-code.md companion) so Phase-N tracking issues stop being hand-written from scratch every time.
- Canonical SKILL.md hardcodes the section skeleton (Cross-session handoff / 決定事項 / タスク / DoD / Phase N+1 outlook / 関連) and the CLI surface (positional `<phase-number>` `<title>` plus optional flags incl. `--draft` for stdout-only output).
- Claude Code companion uses `AskUserQuestion` to fill missing fields interactively; canonical stays non-interactive so it works under codex / gemini / copilot adapters.
- Embeds `<!-- phase-issue:v1 phase=N -->` marker block on body so the same issue can be regenerated later without losing anchor.

## Out of scope (per Issue #62)

- drive 連携 — phase-issue ends at issue creation; humans split it and feed `/drive`
- Phase 番号自動採番 — caller must pass `<phase-number>` explicitly
- 過去 issue からの style 学習 — section skeleton is hardcoded in SKILL.md

## Test plan

- [x] `pnpm run build` — phase-issue is the 12th skill, all four adapters emit it
- [x] `pnpm test` — 83 tests pass (10 new structural tests under `tests/phase-issue.test.mjs`)
- [x] `pnpm run lint` — biome clean
- [x] `pnpm run lint:md` — markdownlint clean across 168 files

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)