### PR TITLE
fix(drive): apply parent worktree drift fix to SSOT and rebuild dist

### DIFF
--- a/.agents/skills/drive/SKILL.md
+++ b/.agents/skills/drive/SKILL.md
@@ -222,7 +222,7 @@ wave を順に実行する。
 
 集約レポートを出力する前に、**親 worktree の整合性を確認する**。subagent が共有 git directory 経由で親の `HEAD` / `index` を汚染するケースに備えるための fail-safe（[Issue #66](https://github.com/ozzy-labs/skills/issues/66) 由来）。
 
-1. `git rev-parse HEAD` と `git rev-parse $(git symbolic-ref HEAD)` が一致するか（HEAD が想定 branch を指しているか）
+1. `git rev-parse HEAD` と `git rev-parse $(git symbolic-ref HEAD)` が一致するか（HEAD が detached でないこと）
 2. `git diff HEAD --stat` が空か（index が HEAD と乖離していないか）
 3. `git status --short` が空か（working tree が clean か）
 4. 親のベースブランチ（通常 `main`）が `git rev-parse origin/<base-branch>` と一致するか、または `--merge` で merged された PR の SHA を含むか

--- a/dist/.agents/skills/drive/SKILL.md
+++ b/dist/.agents/skills/drive/SKILL.md
@@ -168,6 +168,7 @@ wave を順に実行する。
 
 - **隔離:** worktree 隔離で起動する（必須。並列実行時の作業ディレクトリ衝突防止）
 - **委譲粒度:** subagent には `.agents/skills/drive/SKILL.md` を Read させ、target #N について単一モードのワークフロー（Phase 1-5）を実行するよう指示する。slash command は subagent からは呼べないため、SKILL.md を直接実行する
+- **main への checkout 禁止:** subagent は自 worktree branch で完結する。`git checkout main` / `git switch main` / `git checkout HEAD~` 等で worktree の HEAD を移動させない。worktree は親の Phase Final で削除されるため、main へ戻す必要はない。共有 git directory 経由で親 worktree の `HEAD` / `index` が汚染されるリスクを避けるため、自 branch 以外を触らないこと
 - **ベースブランチ:**
   - 依存元 wave がない target → main からブランチを作る
   - 依存元 wave がある target → 依存元 PR の `headRefName` をベースにブランチを作る（stacked PR）。`--merge` 指定時は依存元がマージ済みのため main をベースにできるが、未指定時はこの stacked 構造が必須
@@ -218,6 +219,29 @@ wave を順に実行する。
 - 独立した（依存関係のない）他 task には影響させない
 
 ### Phase Final: 集約レポート
+
+集約レポートを出力する前に、**親 worktree の整合性を確認する**。subagent が共有 git directory 経由で親の `HEAD` / `index` を汚染するケースに備えるための fail-safe（[Issue #66](https://github.com/ozzy-labs/skills/issues/66) 由来）。
+
+1. `git rev-parse HEAD` と `git rev-parse $(git symbolic-ref HEAD)` が一致するか（HEAD が detached でないこと）
+2. `git diff HEAD --stat` が空か（index が HEAD と乖離していないか）
+3. `git status --short` が空か（working tree が clean か）
+4. 親のベースブランチ（通常 `main`）が `git rev-parse origin/<base-branch>` と一致するか、または `--merge` で merged された PR の SHA を含むか
+
+いずれかが不一致なら、集約レポート末尾に warning を出す:
+
+```text
+⚠️ Parent worktree drift detected:
+  HEAD:          <sha> (expected branch: <branch>)
+  index diff:    <files>
+  working tree:  <files>
+  Recovery:
+    git checkout HEAD -- .
+    git reset HEAD
+    # または変更を捨ててよい場合:
+    git reset --hard origin/main
+```
+
+整合性チェックが通った場合は、通常どおり集約レポートを出力する:
 
 ```text
 drive 完了 (3/5 merged, 1 merge-ready, 1 skipped):

--- a/dist/claude-code/.claude/skills/drive/SKILL.md
+++ b/dist/claude-code/.claude/skills/drive/SKILL.md
@@ -37,6 +37,7 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUser
 - **isolation:** `"worktree"`（必須）
 - **subagent_type:** `general-purpose`
 - **prompt:** subagent から slash command は呼べないため、`.agents/skills/drive/SKILL.md` を Read させ、target #N について単一モードのワークフロー（Phase 1-5）を実行するよう指示する。`--merge` 指定時は Phase 4 まで完了し、自 PR の merged まで polling して終了させる。最終結果は JSON で返させる
+- **main への checkout 禁止（必ず prompt に明記）:** subagent は自 worktree branch で完結する。`git checkout main` / `git switch main` / `git checkout HEAD~` 等で HEAD を移動させない。worktree は親側で削除されるため main へ戻す必要はない。これを怠ると共有 git directory 経由で親 worktree の `HEAD` / `index` が汚染される（[Issue #66](https://github.com/ozzy-labs/skills/issues/66) 参照）
 - **依存元 wave がある場合のベースブランチ:**
   - `--merge` 指定 + 依存元が merged → main から作成
   - `--merge` 指定 + 依存元が auto-merge enabled（未マージ）→ main を pull してから作成（取り込まれていれば main ベース、未取り込みなら依存元 headRefName ベース）

--- a/dist/codex-cli/.agents/skills/drive/SKILL.md
+++ b/dist/codex-cli/.agents/skills/drive/SKILL.md
@@ -168,6 +168,7 @@ wave を順に実行する。
 
 - **隔離:** worktree 隔離で起動する（必須。並列実行時の作業ディレクトリ衝突防止）
 - **委譲粒度:** subagent には `.agents/skills/drive/SKILL.md` を Read させ、target #N について単一モードのワークフロー（Phase 1-5）を実行するよう指示する。slash command は subagent からは呼べないため、SKILL.md を直接実行する
+- **main への checkout 禁止:** subagent は自 worktree branch で完結する。`git checkout main` / `git switch main` / `git checkout HEAD~` 等で worktree の HEAD を移動させない。worktree は親の Phase Final で削除されるため、main へ戻す必要はない。共有 git directory 経由で親 worktree の `HEAD` / `index` が汚染されるリスクを避けるため、自 branch 以外を触らないこと
 - **ベースブランチ:**
   - 依存元 wave がない target → main からブランチを作る
   - 依存元 wave がある target → 依存元 PR の `headRefName` をベースにブランチを作る（stacked PR）。`--merge` 指定時は依存元がマージ済みのため main をベースにできるが、未指定時はこの stacked 構造が必須
@@ -218,6 +219,29 @@ wave を順に実行する。
 - 独立した（依存関係のない）他 task には影響させない
 
 ### Phase Final: 集約レポート
+
+集約レポートを出力する前に、**親 worktree の整合性を確認する**。subagent が共有 git directory 経由で親の `HEAD` / `index` を汚染するケースに備えるための fail-safe（[Issue #66](https://github.com/ozzy-labs/skills/issues/66) 由来）。
+
+1. `git rev-parse HEAD` と `git rev-parse $(git symbolic-ref HEAD)` が一致するか（HEAD が detached でないこと）
+2. `git diff HEAD --stat` が空か（index が HEAD と乖離していないか）
+3. `git status --short` が空か（working tree が clean か）
+4. 親のベースブランチ（通常 `main`）が `git rev-parse origin/<base-branch>` と一致するか、または `--merge` で merged された PR の SHA を含むか
+
+いずれかが不一致なら、集約レポート末尾に warning を出す:
+
+```text
+⚠️ Parent worktree drift detected:
+  HEAD:          <sha> (expected branch: <branch>)
+  index diff:    <files>
+  working tree:  <files>
+  Recovery:
+    git checkout HEAD -- .
+    git reset HEAD
+    # または変更を捨ててよい場合:
+    git reset --hard origin/main
+```
+
+整合性チェックが通った場合は、通常どおり集約レポートを出力する:
 
 ```text
 drive 完了 (3/5 merged, 1 merge-ready, 1 skipped):

--- a/src/skills/drive/SKILL.claude-code.md
+++ b/src/skills/drive/SKILL.claude-code.md
@@ -37,6 +37,7 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUser
 - **isolation:** `"worktree"`（必須）
 - **subagent_type:** `general-purpose`
 - **prompt:** subagent から slash command は呼べないため、`.agents/skills/drive/SKILL.md` を Read させ、target #N について単一モードのワークフロー（Phase 1-5）を実行するよう指示する。`--merge` 指定時は Phase 4 まで完了し、自 PR の merged まで polling して終了させる。最終結果は JSON で返させる
+- **main への checkout 禁止（必ず prompt に明記）:** subagent は自 worktree branch で完結する。`git checkout main` / `git switch main` / `git checkout HEAD~` 等で HEAD を移動させない。worktree は親側で削除されるため main へ戻す必要はない。これを怠ると共有 git directory 経由で親 worktree の `HEAD` / `index` が汚染される（[Issue #66](https://github.com/ozzy-labs/skills/issues/66) 参照）
 - **依存元 wave がある場合のベースブランチ:**
   - `--merge` 指定 + 依存元が merged → main から作成
   - `--merge` 指定 + 依存元が auto-merge enabled（未マージ）→ main を pull してから作成（取り込まれていれば main ベース、未取り込みなら依存元 headRefName ベース）

--- a/src/skills/drive/SKILL.md
+++ b/src/skills/drive/SKILL.md
@@ -168,6 +168,7 @@ wave を順に実行する。
 
 - **隔離:** worktree 隔離で起動する（必須。並列実行時の作業ディレクトリ衝突防止）
 - **委譲粒度:** subagent には `.agents/skills/drive/SKILL.md` を Read させ、target #N について単一モードのワークフロー（Phase 1-5）を実行するよう指示する。slash command は subagent からは呼べないため、SKILL.md を直接実行する
+- **main への checkout 禁止:** subagent は自 worktree branch で完結する。`git checkout main` / `git switch main` / `git checkout HEAD~` 等で worktree の HEAD を移動させない。worktree は親の Phase Final で削除されるため、main へ戻す必要はない。共有 git directory 経由で親 worktree の `HEAD` / `index` が汚染されるリスクを避けるため、自 branch 以外を触らないこと
 - **ベースブランチ:**
   - 依存元 wave がない target → main からブランチを作る
   - 依存元 wave がある target → 依存元 PR の `headRefName` をベースにブランチを作る（stacked PR）。`--merge` 指定時は依存元がマージ済みのため main をベースにできるが、未指定時はこの stacked 構造が必須
@@ -218,6 +219,29 @@ wave を順に実行する。
 - 独立した（依存関係のない）他 task には影響させない
 
 ### Phase Final: 集約レポート
+
+集約レポートを出力する前に、**親 worktree の整合性を確認する**。subagent が共有 git directory 経由で親の `HEAD` / `index` を汚染するケースに備えるための fail-safe（[Issue #66](https://github.com/ozzy-labs/skills/issues/66) 由来）。
+
+1. `git rev-parse HEAD` と `git rev-parse $(git symbolic-ref HEAD)` が一致するか（HEAD が detached でないこと）
+2. `git diff HEAD --stat` が空か（index が HEAD と乖離していないか）
+3. `git status --short` が空か（working tree が clean か）
+4. 親のベースブランチ（通常 `main`）が `git rev-parse origin/<base-branch>` と一致するか、または `--merge` で merged された PR の SHA を含むか
+
+いずれかが不一致なら、集約レポート末尾に warning を出す:
+
+```text
+⚠️ Parent worktree drift detected:
+  HEAD:          <sha> (expected branch: <branch>)
+  index diff:    <files>
+  working tree:  <files>
+  Recovery:
+    git checkout HEAD -- .
+    git reset HEAD
+    # または変更を捨ててよい場合:
+    git reset --hard origin/main
+```
+
+整合性チェックが通った場合は、通常どおり集約レポートを出力する:
 
 ```text
 drive 完了 (3/5 merged, 1 merge-ready, 1 skipped):


### PR DESCRIPTION
## Summary

Follow-up to #67. That PR fixed the symptom in the consumer-side dogfood copies (`.agents/`, `.claude/`) but missed the SSOT under `src/skills/drive/`. The next `pnpm build` would have silently undone PR #67's content, and the change never reached the four adapter outputs in `dist/`, so Renovate consumers wouldn't get the fix either.

This PR:

- Moves the "main への checkout 禁止" rule into `src/skills/drive/SKILL.md` and `src/skills/drive/SKILL.claude-code.md` so it survives builds and propagates to all four adapters (claude-code, codex-cli, gemini-cli, copilot).
- Moves the Phase Final parent worktree integrity check into `src/skills/drive/SKILL.md`.
- Addresses the Info from PR #67's review (https://github.com/ozzy-labs/skills/pull/67#issuecomment-4469522787): the integrity check's step 1 (`git rev-parse HEAD` vs `git rev-parse $(git symbolic-ref HEAD)`) is tautological for non-detached HEAD, so the annotation is tightened from "HEAD が想定 branch を指しているか" to "HEAD が detached でないこと" to match what the check actually detects.
- Regenerates `dist/` via `pnpm build` so Renovate consumers receive the fix on the next sync.

## Test plan

- [x] `pnpm build` regenerates `dist/.agents/skills/drive/SKILL.md`, `dist/claude-code/.claude/skills/drive/SKILL.md`, and `dist/codex-cli/.agents/skills/drive/SKILL.md` with the new content.
- [x] markdownlint passes on all six modified files (pre-commit verified).
- [ ] After merge, run `commons/sync-skills.sh` against the 13 consumer repos to propagate the fix and confirm each consumer's `.agents/skills/drive/SKILL.md` and `.claude/skills/drive/SKILL.md` reflect the new rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)