### PR TITLE
docs(drive): recovery シーケンスで subagent branch 名を変数に保存する形に補強

### DIFF
--- a/.agents/skills/drive/SKILL.md
+++ b/.agents/skills/drive/SKILL.md
@@ -255,7 +255,10 @@ subagent が共有 git directory 経由で親の `HEAD` / `index` / `refs/heads/
   working tree:         <files>
   Recovery (push 前の汚染に対する確実な回復シーケンス):
 
-    # 1. 現状把握 (1 メッセージで全部出す)
+    # 1. 現状把握 + subagent branch 名を保存
+    #    step 3 で HEAD を main に切替えると `git symbolic-ref HEAD` は main を返すため、
+    #    step 5 で参照する branch 名はここで変数に保存しておく必要がある
+    SUBAGENT_BRANCH=$(git symbolic-ref --short HEAD)
     git rev-parse HEAD
     git rev-parse refs/heads/main
     git rev-parse origin/main
@@ -272,8 +275,8 @@ subagent が共有 git directory 経由で親の `HEAD` / `index` / `refs/heads/
     # 4. index + working tree を HEAD (= origin/main) と同期
     git reset --hard HEAD
 
-    # 5. subagent stuck branch を削除 (HEAD だったため deletable に変わる)
-    git branch -D <subagent-branch>
+    # 5. subagent stuck branch を削除 (HEAD だったため deletable に変わる。step 1 で保存した変数を使う)
+    git branch -D "$SUBAGENT_BRANCH"
 ```
 
 `git checkout main` 系は意図的に使わない（親 worktree が main を握っているため `fatal: 'main' is already used by worktree at ...` で失敗する）。`git update-ref refs/heads/main` を **先に**実行する点が load-bearing — 後にすると `reset --hard origin/main` が subagent branch を target にしてしまい、main ref が古い SHA で stuck したまま残る。

--- a/dist/.agents/skills/drive/SKILL.md
+++ b/dist/.agents/skills/drive/SKILL.md
@@ -255,7 +255,10 @@ subagent が共有 git directory 経由で親の `HEAD` / `index` / `refs/heads/
   working tree:         <files>
   Recovery (push 前の汚染に対する確実な回復シーケンス):
 
-    # 1. 現状把握 (1 メッセージで全部出す)
+    # 1. 現状把握 + subagent branch 名を保存
+    #    step 3 で HEAD を main に切替えると `git symbolic-ref HEAD` は main を返すため、
+    #    step 5 で参照する branch 名はここで変数に保存しておく必要がある
+    SUBAGENT_BRANCH=$(git symbolic-ref --short HEAD)
     git rev-parse HEAD
     git rev-parse refs/heads/main
     git rev-parse origin/main
@@ -272,8 +275,8 @@ subagent が共有 git directory 経由で親の `HEAD` / `index` / `refs/heads/
     # 4. index + working tree を HEAD (= origin/main) と同期
     git reset --hard HEAD
 
-    # 5. subagent stuck branch を削除 (HEAD だったため deletable に変わる)
-    git branch -D <subagent-branch>
+    # 5. subagent stuck branch を削除 (HEAD だったため deletable に変わる。step 1 で保存した変数を使う)
+    git branch -D "$SUBAGENT_BRANCH"
 ```
 
 `git checkout main` 系は意図的に使わない（親 worktree が main を握っているため `fatal: 'main' is already used by worktree at ...` で失敗する）。`git update-ref refs/heads/main` を **先に**実行する点が load-bearing — 後にすると `reset --hard origin/main` が subagent branch を target にしてしまい、main ref が古い SHA で stuck したまま残る。

--- a/dist/codex-cli/.agents/skills/drive/SKILL.md
+++ b/dist/codex-cli/.agents/skills/drive/SKILL.md
@@ -255,7 +255,10 @@ subagent が共有 git directory 経由で親の `HEAD` / `index` / `refs/heads/
   working tree:         <files>
   Recovery (push 前の汚染に対する確実な回復シーケンス):
 
-    # 1. 現状把握 (1 メッセージで全部出す)
+    # 1. 現状把握 + subagent branch 名を保存
+    #    step 3 で HEAD を main に切替えると `git symbolic-ref HEAD` は main を返すため、
+    #    step 5 で参照する branch 名はここで変数に保存しておく必要がある
+    SUBAGENT_BRANCH=$(git symbolic-ref --short HEAD)
     git rev-parse HEAD
     git rev-parse refs/heads/main
     git rev-parse origin/main
@@ -272,8 +275,8 @@ subagent が共有 git directory 経由で親の `HEAD` / `index` / `refs/heads/
     # 4. index + working tree を HEAD (= origin/main) と同期
     git reset --hard HEAD
 
-    # 5. subagent stuck branch を削除 (HEAD だったため deletable に変わる)
-    git branch -D <subagent-branch>
+    # 5. subagent stuck branch を削除 (HEAD だったため deletable に変わる。step 1 で保存した変数を使う)
+    git branch -D "$SUBAGENT_BRANCH"
 ```
 
 `git checkout main` 系は意図的に使わない（親 worktree が main を握っているため `fatal: 'main' is already used by worktree at ...` で失敗する）。`git update-ref refs/heads/main` を **先に**実行する点が load-bearing — 後にすると `reset --hard origin/main` が subagent branch を target にしてしまい、main ref が古い SHA で stuck したまま残る。

--- a/src/skills/drive/SKILL.md
+++ b/src/skills/drive/SKILL.md
@@ -255,7 +255,10 @@ subagent が共有 git directory 経由で親の `HEAD` / `index` / `refs/heads/
   working tree:         <files>
   Recovery (push 前の汚染に対する確実な回復シーケンス):
 
-    # 1. 現状把握 (1 メッセージで全部出す)
+    # 1. 現状把握 + subagent branch 名を保存
+    #    step 3 で HEAD を main に切替えると `git symbolic-ref HEAD` は main を返すため、
+    #    step 5 で参照する branch 名はここで変数に保存しておく必要がある
+    SUBAGENT_BRANCH=$(git symbolic-ref --short HEAD)
     git rev-parse HEAD
     git rev-parse refs/heads/main
     git rev-parse origin/main
@@ -272,8 +275,8 @@ subagent が共有 git directory 経由で親の `HEAD` / `index` / `refs/heads/
     # 4. index + working tree を HEAD (= origin/main) と同期
     git reset --hard HEAD
 
-    # 5. subagent stuck branch を削除 (HEAD だったため deletable に変わる)
-    git branch -D <subagent-branch>
+    # 5. subagent stuck branch を削除 (HEAD だったため deletable に変わる。step 1 で保存した変数を使う)
+    git branch -D "$SUBAGENT_BRANCH"
 ```
 
 `git checkout main` 系は意図的に使わない（親 worktree が main を握っているため `fatal: 'main' is already used by worktree at ...` で失敗する）。`git update-ref refs/heads/main` を **先に**実行する点が load-bearing — 後にすると `reset --hard origin/main` が subagent branch を target にしてしまい、main ref が古い SHA で stuck したまま残る。


### PR DESCRIPTION
## Summary

PR #78 のセルフレビューで Info として挙がった指摘の follow-up。Phase Final-1 recovery シーケンス step 5 の `<subagent-branch>` placeholder の取得元を明示する。

## 背景

旧シーケンス:

\`\`\`bash
# 1. 現状把握
git symbolic-ref HEAD   # → subagent branch を返す
...
# 3. HEAD を main に切替
git symbolic-ref HEAD refs/heads/main
...
# 5. subagent stuck branch を削除
git branch -D <subagent-branch>   # ← この時点で symbolic-ref HEAD は main を返すため取得不能
\`\`\`

step 3 で HEAD を main に切替えてしまうと、step 5 直前に `git symbolic-ref HEAD` を実行しても main を返すため、利用者が `<subagent-branch>` の値を取得できない。

## 変更

- step 1 で `SUBAGENT_BRANCH=$(git symbolic-ref --short HEAD)` を実行して変数に保存
- step 5 で `git branch -D "$SUBAGENT_BRANCH"` を参照
- 両 step のコメントに「ここで保存しておく」「step 1 で保存した変数を使う」の意図を補記

## Refs

- PR #78 のセルフレビュー Info を反映 (関連 issue: #77)

## Test plan

- [x] markdownlint pass
- [x] pnpm build 成功 (SSOT 修正が dist/.agents, dist/codex-cli/.agents に反映、Claude Code 系は recovery 記述を持たないため変更なし)
- [x] pnpm test 全 105 件 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)