### PR TITLE
feat(sync): sync-targets.yaml schema と 14 entry を skills 側に実装

### DIFF
--- a/schemas/sync-targets.schema.json
+++ b/schemas/sync-targets.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/ozzy-labs/skills/main/schemas/sync-targets.schema.json",
+  "title": "sync-targets.yaml schema (skills)",
+  "description": "Schema for sync-targets.yaml that drives the push-based /sync-consumers skill. See issue #80 / sub-issue #81 / plan structured-nibbling-harbor.md. The commons-side variant (source: commons) lives in the commons repo.",
+  "type": "object",
+  "required": ["version", "owner", "source", "targets"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "description": "Schema version. Bumped on breaking change.",
+      "const": 1
+    },
+    "owner": {
+      "description": "GitHub org that owns the target repos. Currently fixed to ozzy-labs.",
+      "type": "string",
+      "minLength": 1
+    },
+    "source": {
+      "description": "Source repo identifier. The skills-side file MUST declare 'skills'.",
+      "enum": ["skills"]
+    },
+    "defaults": {
+      "description": "Default per-target policy. Each target entry can override these.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "branch_prefix": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Branch name prefix for the sync PR (final form: <prefix>-<short-sha>)."
+        },
+        "base_branch": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Base branch to checkout when cloning the consumer."
+        },
+        "auto_merge": {
+          "type": "boolean",
+          "description": "If true, attempt `gh pr merge --auto --squash` on the sync PR."
+        },
+        "merge_method": {
+          "enum": ["squash", "merge", "rebase"],
+          "description": "Merge strategy used when auto_merge is true."
+        },
+        "reuse_open_pr": {
+          "type": "boolean",
+          "description": "If true, force-update an existing open PR instead of closing and recreating it."
+        },
+        "tolerate_existing_branch": {
+          "type": "boolean",
+          "description": "If false, a pre-existing remote branch with the same name aborts the sync (treated as a signal that a previous run was interrupted)."
+        }
+      }
+    },
+    "targets": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "description": "List of consumer repo targets. NOTE: uniqueItems catches identical entries via deep equality. Duplicate `repo` values with different overrides (e.g. same repo, different note) cannot be expressed in standard JSON Schema and MUST be enforced by the loader/skill at runtime.",
+      "items": {
+        "$ref": "#/$defs/target"
+      }
+    }
+  },
+  "$defs": {
+    "target": {
+      "type": "object",
+      "required": ["repo"],
+      "additionalProperties": false,
+      "properties": {
+        "repo": {
+          "type": "string",
+          "pattern": "^ozzy-labs/[a-z0-9._-]+$",
+          "description": "<owner>/<repo>. Owner scope is locked to ozzy-labs."
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, this target is skipped and a warning is reported."
+        },
+        "disabled_reason": {
+          "type": "string",
+          "description": "Human-readable reason why this target is disabled. Required (non-empty) when disabled is true."
+        },
+        "note": {
+          "type": "string",
+          "description": "Free-form context surfaced in the sync PR description."
+        },
+        "branch_prefix": {
+          "type": "string",
+          "minLength": 1
+        },
+        "base_branch": {
+          "type": "string",
+          "minLength": 1
+        },
+        "auto_merge": {
+          "type": "boolean"
+        },
+        "merge_method": {
+          "enum": ["squash", "merge", "rebase"]
+        },
+        "reuse_open_pr": {
+          "type": "boolean"
+        },
+        "tolerate_existing_branch": {
+          "type": "boolean"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "disabled": {
+                "const": true
+              }
+            },
+            "required": ["disabled"]
+          },
+          "then": {
+            "required": ["disabled_reason"],
+            "properties": {
+              "disabled_reason": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/sync-targets.yaml
+++ b/sync-targets.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ozzy-labs/skills/main/schemas/sync-targets.schema.json
+# Targets for the push-based /sync-consumers skill (skills side).
+# See issue #80 / sub-issue #81 and plan structured-nibbling-harbor.md.
+# amazon-quick-feedradar is intentionally excluded (no .commons/sync.yaml).
+version: 1
+owner: ozzy-labs
+source: skills
+defaults:
+  branch_prefix: chore/sync-skills
+  base_branch: main
+  auto_merge: true
+  merge_method: squash
+  reuse_open_pr: true
+  tolerate_existing_branch: false
+targets:
+  - repo: ozzy-labs/agentyard
+  - repo: ozzy-labs/feedradar
+  - repo: ozzy-labs/handbook
+  - repo: ozzy-labs/create-agentic-app
+  - repo: ozzy-labs/create-agentic-aws
+  - repo: ozzy-labs/gh-tasks
+  - repo: ozzy-labs/mcp-server-knowledge
+  - repo: ozzy-labs/opshub
+  - repo: ozzy-labs/ozzylabs.com
+  - repo: ozzy-labs/presets
+  - repo: ozzy-labs/road
+  - repo: ozzy-labs/starlight-theme
+  - repo: ozzy-labs/tech-notes
+  - repo: ozzy-labs/writing-studio


### PR DESCRIPTION
## Summary

Parent epic: #80
Sub-issue: closes #81
Approved plan: `/home/ozzy/.claude/plans/structured-nibbling-harbor.md`

push 型 `/sync-consumers` skill が読む `sync-targets.yaml` の schema (JSON Schema draft-2020-12) と、skills 側の 14 consumer entry を新規追加する。

### 追加ファイル

- `schemas/sync-targets.schema.json` (JSON Schema draft-2020-12)
- `sync-targets.yaml` (14 consumer entry、`source: skills`)

### Schema 仕様 (主要点)

- `version` は `const: 1`
- `source` は `enum: ["skills"]` のみ許容 (file 取り違え検出)
- `targets[].repo` は `^ozzy-labs/[a-z0-9._-]+$` (owner scope 縛り)
- `additionalProperties: false` (strict / 未知 field を fail)
- `targets` に `uniqueItems: true` (entry の完全重複を検出)
- `disabled: true` の場合 `disabled_reason` を if-then で必須化
- `defaults` で repo 横断の policy を宣言、各 `targets[]` で per-target override 可能

### 注記: targets[].repo の重複検出

JSON Schema 標準では「同じ `repo` 値 + 異なる override」の重複は `uniqueItems` ではキャッチできない (entry が deep-equal でないため)。loader/skill (sub-issue #82 以降) が実行時に補完する設計とし、schema 内にコメントで明記した。

### commons 側は別 PR

`commons/schemas/sync-targets.schema.json` と `commons/sync-targets.yaml` は **別 repo に位置するため本 drive run では touchable でない**。commons 側は別 PR (commons repo の drive) で実装予定。issue #81 にも別途コメントする。

## Verification

- [x] `pnpm dlx ajv-cli@5 validate -s schemas/sync-targets.schema.json -d sync-targets.yaml --strict=true --spec=draft2020` → `sync-targets.yaml valid`
- [x] negative case が全て fail することを確認:
  - `disabled: true` + `disabled_reason` 欠落 → `must have required property 'disabled_reason'`
  - `source: commons` (skills 側 file) → `must be equal to one of the allowed values`
  - `targets[].repo` の deep-equal 重複 → `must NOT have duplicate items`
  - 未知 top-level field → `must NOT have additional properties`
  - `repo` が `^ozzy-labs/` で始まらない → `must match pattern`
  - `version: 2` → `must be equal to constant`
- [x] 14 consumer entry が全て validate を pass (amazon-quick-feedradar 除外確認)
- [x] `yaml-language-server` コメントを `sync-targets.yaml` 先頭に追加
- [x] `pnpm build` で `dist/` が clean のまま保たれることを確認
- [x] `pnpm run lint:yaml` pass
- 検証手段: 上記 `pnpm dlx ajv-cli@5 validate ...` を実行 (network 経由で fetch)

## Acceptance criteria (issue #81)

- [x] `schemas/sync-targets.schema.json` 新規作成
- [x] `sync-targets.yaml` 新規作成 (14 entry)
- [x] `version == 1` 強制
- [x] `source: skills` のみ許容
- [x] `targets[].repo` のユニーク性 (deep-equal レベル、override 違い重複は loader 側で補完)
- [x] `disabled: true` の場合 `disabled_reason` 必須
- [x] `targets[].repo` は `^ozzy-labs/[a-z0-9._-]+$`
- [x] `additionalProperties: false`
- [x] `yaml-language-server` コメント追加

## Related issues

- Parent epic: #80
- This PR closes: #81
- Follow-up: #82 (ajv devDeps / lefthook hook / CI check), #83, #84, #85, #86

## Test plan

- [x] `pnpm dlx ajv-cli@5 validate ...` で positive / negative 全てを手動確認
- [x] `pnpm build` で dist 整合を確認
- [x] `pnpm run lint:yaml` pass