### PR TITLE
docs(readme): consumer setup を user skills only に統一

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,14 +11,14 @@
 
 ## プロジェクト概要
 
-`@ozzylabs/skills`: OzzyLabs 全リポジトリで共有する正準スキルバンドル。`src/skills/{name}/SKILL.md` を SSOT として `dist/{adapter-id}/` 配下に agent 別出力を生成し、push 型 `/sync-consumers` skill（[issue #80](https://github.com/ozzy-labs/skills/issues/80)）で各 consumer リポへ配信する。consumer は `.commons/sync.yaml` に `skills_commit` + `skills_adapters` を pin して opt-in する。
+`@ozzylabs/skills`: OzzyLabs 全リポジトリで共有する正準スキルバンドル。`src/skills/{name}/SKILL.md` を SSOT として `dist/{adapter-id}/` 配下に agent 別出力を生成し、npm package + CLI installer（`npx @ozzylabs/skills install`）で end user のマシンに **user skills** として install する（例: `~/.claude/skills/`）。consumer リポ配下への project skills 配信は廃止。
 
 ## Tech Stack
 
 - Runtime: Node.js (ESM)
 - Package manager: pnpm
 - Version management: mise (`.mise.toml`)
-- Distribution: push 型 `/sync-consumers` skill（[issue #80](https://github.com/ozzy-labs/skills/issues/80)）。consumer の `.commons/sync.yaml` を起点にした pin/opt-in モデル。npm publish も提供
+- Distribution: npm package + CLI installer（`npx @ozzylabs/skills install`）のみ。user skills only モデル（handbook ADR-0027 にて整理予定）。push 型 `/sync-consumers` フローおよび Renovate preset は廃止
 
 ## 主要コマンド
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@
 
 ## Available Skills
 
+- `/drive` などの汎用 skill は **user skills** (`~/.claude/skills/`) として配置されることを想定。エンドユーザーは `npx @ozzylabs/skills install` で installation する
+- skills / commons リポ内部 (本リポ等) では project skills として `.claude/skills/` 配下に置かれている (build pipeline で SSOT から生成)
 - `/implement` — Issue または指示をもとに、ブランチ作成・実装
 - `/lint` — 全リンターを自動修正付きで実行
 - `/test` — ビルド・テスト・型チェックを実行
@@ -18,7 +20,7 @@
 - `/drive` — implement + ship + review loop（Issue から merge-ready な PR まで自律駆動）。`--review=quick|final-deep|deep` で review モード切替（既定 quick）
 - `/health` — リポジトリ状態と skill catalog 整合性を 16 領域確認し、推奨アクションを inline 表示（`--deep` で `要確認` 項目を追加調査）
 - `/topics` — research-driven な GitHub topics 設定（ozzy-labs scope）。候補を公式制約検証 → 人気度測定（session キャッシュ）→ broad+narrow / 単数複数比較 → ozzy-labs 慣行ハードコードで選定し、`--apply` で `gh repo edit --add-topic` を実行、`--dry-run` で分析のみ
-- `/sync-consumers` — skills / commons の更新を `sync-targets.yaml` の 14 consumer リポへ並列に push（PR auto-merge まで）。drive 派生として subagent worktree 隔離 + Phase Final-1/2 を踏襲する
+- `/sync-consumers` — skills / commons リポ内部運用向け。skills / commons の更新を `sync-targets.yaml` の 14 consumer リポへ並列に push（PR auto-merge まで）。drive 派生として subagent worktree 隔離 + Phase Final-1/2 を踏襲する
 
 ## Skills の共通ルール
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ English | [日本語](docs/README.ja.md)
 
 Canonical OzzyLabs agent skill bundle for Claude Code, GitHub Copilot, Gemini CLI, and Codex CLI.
 
-`src/skills/{name}/SKILL.md` is the single source of truth. `pnpm build` produces per-agent outputs under `dist/{adapter-id}/` (`claude-code`, `codex-cli`, `gemini-cli`, `copilot`). Consumer repositories pull these in via the push-mode `/sync-consumers` flow (or, optionally, via `npm install`).
+`src/skills/{name}/SKILL.md` is the single source of truth. `pnpm build` produces per-agent outputs under `dist/{adapter-id}/` (`claude-code`, `codex-cli`, `gemini-cli`, `copilot`). End users install these skills as **user skills** (e.g. `~/.claude/skills/`) via the CLI installer shipped in the npm package.
 
-This package backs the [OzzyLabs handbook ADR-0016](https://github.com/ozzy-labs/handbook/blob/main/adr/0016-create-skills-repo.md) decision to extract skills out of the `commons` repository into their own SSOT, while preserving the [ADR-0002](https://github.com/ozzy-labs/handbook/blob/main/adr/0002-skills-distribution-via-renovate.md) Renovate-based distribution model.
+This package backs the [OzzyLabs handbook ADR-0016](https://github.com/ozzy-labs/handbook/blob/main/adr/0016-create-skills-repo.md) decision to extract skills out of the `commons` repository into their own SSOT. Distribution is **user skills only** (see handbook ADR-0027, in preparation): consumers install via `npx @ozzylabs/skills install`, and project-scope skills (`.claude/skills/` under each consumer repo) are no longer pushed. Project-scope skills remain in use only inside the `skills` / `commons` repos themselves for dogfooding, where the build pipeline emits them from the SSOT.
 
 ## Skills in v0.x
 
@@ -32,53 +32,47 @@ Repo-specific skills (e.g. `road`'s `improve-loop` / `road-repo-context`) are in
 
 ## Consumer setup
 
-Track the upstream digest in `.commons/sync.yaml`:
-
-```yaml
-skills_commit: <40-char SHA from main>
-skills_adapters:
-  - claude-code
-  - codex-cli
-  - gemini-cli
-  - copilot
-```
-
-Updates are pushed from `ozzy-labs/skills` via the `/sync-consumers` skill (see [issue #80](https://github.com/ozzy-labs/skills/issues/80)). When this repo's `main` advances, a maintainer runs `/sync-consumers --source=skills --auto-merge`, which opens one sync PR per consumer (driven by `commons/scripts/sync-consumers.sh`). The PR bumps `skills_commit` in `.commons/sync.yaml` and runs `sync-skills.sh -y` (from [ozzy-labs/commons](https://github.com/ozzy-labs/commons)) to copy the opted-in adapter outputs (`dist/{adapter-id}/`) from this repository into the consumer.
-
-### Adapter opt-in (per-agent outputs)
-
-To consume per-agent adapter outputs (`dist/{adapter-id}/`), list the adapter ids in `skills_adapters` (shown above). Adapter ids and the corresponding output paths:
-
-| Adapter id | Adapter output |
-| --- | --- |
-| `claude-code` | `dist/claude-code/.claude/skills/{name}/SKILL.md` |
-| `codex-cli` | `dist/codex-cli/.agents/skills/{name}/SKILL.md` + `AGENTS.md.snippet` |
-| `gemini-cli` | `dist/gemini-cli/.gemini/settings.json` + `AGENTS.md.snippet` |
-| `copilot` | `dist/copilot/.github/copilot-instructions.md.snippet` |
-
-Adapter opt-in is non-breaking and additive — list only the adapters you actually sync. The file copy on the consumer side is driven by `commons/sync-skills.sh` per consumer's `skills_adapters` declaration.
-
-### Legacy Renovate preset (removed)
-
-Earlier versions of this repo shipped a `skills-sync/` Renovate preset (`extends: ["github>ozzy-labs/skills//skills-sync"]`). The preset was removed in [issue #80](https://github.com/ozzy-labs/skills/issues/80) Step 4 in favor of the push-mode `/sync-consumers` flow described above. Existing consumers should remove the `extends` reference from their `renovate.json` (see Step 3 of the transition for the consumer-side cleanup PRs).
-
-### Snippet sync helper
-
-`dist/sync/replace-snippet.sh` is shipped as a drop-in helper for downstream sync workflows that merge snippet files (`AGENTS.md.snippet`, `copilot-instructions.md.snippet`) into consumer-owned files:
+Install the skills as **user skills** with a single command:
 
 ```bash
-.sync-skills/dist/sync/replace-snippet.sh \
-  AGENTS.md \
-  .sync-skills/dist/codex-cli/AGENTS.md.snippet
+npx @ozzylabs/skills install
 ```
 
-Behavior:
+This drops the canonical skills into your user-scope skill directory (e.g. `~/.claude/skills/{name}/SKILL.md` for Claude Code) so every project on the machine can use them without per-repo configuration.
 
-- Target contains the begin marker → replace the marker block (begin..end inclusive) with the snippet contents.
-- Target is missing the marker (e.g. another sync — typically `commons` — overwrote the file and stripped the managed region) → append the snippet to the end of the file. The snippet itself carries the markers, so the next run resumes in-place replacement.
-- Target file does not exist → create it from the snippet.
+### Adapter opt-in
 
-This auto-recovery removes the need for downstream workflows to carry their own marker-handling logic and avoids hard failures when ownership of a shared file like `.github/copilot-instructions.md` shifts between sync sources.
+By default the installer writes the Claude Code adapter output. Pass `--adapter` (repeatable) to opt into additional agents:
+
+```bash
+npx @ozzylabs/skills install --adapter claude-code --adapter codex-cli
+```
+
+| Adapter id | User-scope install target |
+| --- | --- |
+| `claude-code` | `~/.claude/skills/{name}/SKILL.md` |
+| `codex-cli` | `~/.codex/agents/skills/{name}/SKILL.md` + `AGENTS.md.snippet` merge |
+| `gemini-cli` | `~/.gemini/settings.json` merge + `AGENTS.md.snippet` merge |
+| `copilot` | `~/.github/copilot-instructions.md` snippet merge |
+
+See `npx @ozzylabs/skills install --help` for the full list of options and the exact target paths.
+
+### Using the skills in CI
+
+A reusable GitHub Action that runs `npx @ozzylabs/skills install` on the runner is planned (see [issue #101](https://github.com/ozzy-labs/skills/issues/101)). Until it lands, invoke the CLI directly from a step:
+
+```yaml
+- name: Install OzzyLabs skills
+  run: npx --yes @ozzylabs/skills install --adapter claude-code
+```
+
+### Migrating from the legacy push-mode flow
+
+Consumers that previously consumed skills as **project skills** via the push-mode `/sync-consumers` flow (`dist/{adapter-id}/` copied into `.claude/skills/` etc.) need to migrate to user skills only. A migration guide and a pilot rollout are planned in [issue #100](https://github.com/ozzy-labs/skills/issues/100); the short version is:
+
+1. Remove `.claude/skills/`, `.agents/skills/`, and equivalent in-repo skill mirrors.
+2. Drop `skills_commit` / `skills_adapters` from `.commons/sync.yaml`.
+3. Have each contributor run `npx @ozzylabs/skills install` once on their machine.
 
 ## Adapter outputs
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -4,9 +4,9 @@
 
 Claude Code / GitHub Copilot / Gemini CLI / Codex CLI 向けの OzzyLabs 正準エージェントスキルバンドル。
 
-`src/skills/{name}/SKILL.md` を SSOT とし、`pnpm build` で `dist/{adapter-id}/` 配下に各 agent 向けの出力を生成する。consumer リポは `/sync-consumers` 経由の push で取り込む（npm install による参照も可能）。
+`src/skills/{name}/SKILL.md` を SSOT とし、`pnpm build` で `dist/{adapter-id}/` 配下に各 agent 向けの出力を生成する。エンドユーザーは npm package に同梱された CLI installer 経由で **user skills**（例: `~/.claude/skills/`）として install する。
 
-[OzzyLabs handbook ADR-0016](https://github.com/ozzy-labs/handbook/blob/main/adr/0016-create-skills-repo.md) で決定された、skills を `commons` から切り出して専用リポでバージョニングする方針の実装。配布機構は [ADR-0002](https://github.com/ozzy-labs/handbook/blob/main/adr/0002-skills-distribution-via-renovate.md) の Renovate 同期を継承する。
+[OzzyLabs handbook ADR-0016](https://github.com/ozzy-labs/handbook/blob/main/adr/0016-create-skills-repo.md) で決定された、skills を `commons` から切り出して専用リポでバージョニングする方針の実装。配布形態は **user skills only**（handbook ADR-0027 にて整理予定）に統一されており、consumer は `npx @ozzylabs/skills install` で導入する。各 consumer リポ配下への project skills (`.claude/skills/`) 配信は廃止し、project skills は `skills` / `commons` リポ自身の dogfood 用途のみ残す（build pipeline が SSOT から生成）。
 
 ## v0.x 同梱スキル
 
@@ -32,53 +32,47 @@ OzzyLabs 全リポジトリ共通の 13 件:
 
 ## Consumer セットアップ
 
-`.commons/sync.yaml` に upstream digest と opt-in adapter を記録:
-
-```yaml
-skills_commit: <40-char SHA from main>
-skills_adapters:
-  - claude-code
-  - codex-cli
-  - gemini-cli
-  - copilot
-```
-
-更新は `ozzy-labs/skills` 側から `/sync-consumers` skill 経由で push される（[issue #80](https://github.com/ozzy-labs/skills/issues/80) 参照）。本リポの `main` が進んだとき、maintainer が `/sync-consumers --source=skills --auto-merge` を実行すると、各 consumer に 1 件ずつ sync PR が作成される（内部的に `commons/scripts/sync-consumers.sh` が driver）。PR は `.commons/sync.yaml` の `skills_commit` を bump し、[ozzy-labs/commons](https://github.com/ozzy-labs/commons) の `sync-skills.sh -y` で opt-in した adapter 出力（`dist/{adapter-id}/`）を consumer へコピーする。
-
-### Adapter opt-in（agent 別出力の取り込み）
-
-agent 別 adapter 出力（`dist/{adapter-id}/`）を取り込む場合は、`skills_adapters` に adapter id を列挙する（上記サンプル参照）。adapter id と出力パスの対応:
-
-| Adapter id | Adapter 出力 |
-| --- | --- |
-| `claude-code` | `dist/claude-code/.claude/skills/{name}/SKILL.md` |
-| `codex-cli` | `dist/codex-cli/.agents/skills/{name}/SKILL.md` + `AGENTS.md.snippet` |
-| `gemini-cli` | `dist/gemini-cli/.gemini/settings.json` + `AGENTS.md.snippet` |
-| `copilot` | `dist/copilot/.github/copilot-instructions.md.snippet` |
-
-Adapter opt-in は非破壊・加算的で、実際に sync する adapter のみ列挙すればよい。consumer 側のファイルコピーは `commons/sync-skills.sh` が `skills_adapters` の宣言に従って実行する。
-
-### 旧 Renovate preset（削除済み）
-
-旧版では `skills-sync/` Renovate preset（`extends: ["github>ozzy-labs/skills//skills-sync"]`）を提供していた。本 preset は [issue #80](https://github.com/ozzy-labs/skills/issues/80) Step 4 で削除し、上記の push 型 `/sync-consumers` フローに置換した。既存 consumer は `renovate.json` から `extends` 参照を削除する必要がある（transition の Step 3 で consumer 側 cleanup PR を配信予定）。
-
-### Snippet sync ヘルパー
-
-`dist/sync/replace-snippet.sh` は、snippet ファイル（`AGENTS.md.snippet` / `copilot-instructions.md.snippet`）を consumer 所有ファイルへマージする下流 sync workflow 向けのドロップインヘルパーとして配布される:
+skills を **user skills** として 1 コマンドで install する:
 
 ```bash
-.sync-skills/dist/sync/replace-snippet.sh \
-  AGENTS.md \
-  .sync-skills/dist/codex-cli/AGENTS.md.snippet
+npx @ozzylabs/skills install
 ```
 
-挙動:
+このコマンドは canonical skills を user-scope の skill ディレクトリ（Claude Code なら `~/.claude/skills/{name}/SKILL.md`）に配置する。マシン上の全プロジェクトが per-repo 設定なしで skills を利用できる。
 
-- ターゲットに begin マーカーがある場合 → マーカーブロック（begin..end 包括）を snippet 内容で置換する
-- マーカーが欠落している場合（別 sync — 典型的には `commons` — がファイルを上書きしてマネージド領域を消した場合）→ ファイル末尾に snippet を append する。snippet 自体がマーカーを含むため、次回以降は in-place 置換に戻る
-- ターゲットファイルが存在しない場合 → snippet から新規作成する
+### Adapter opt-in
 
-この自動復旧により、下流 workflow がマーカー処理ロジックを自前で持つ必要がなくなり、`.github/copilot-instructions.md` のような共有ファイルの所有権が複数の sync 元にまたがる場合でも hard failure を回避できる。
+既定では Claude Code 向け adapter 出力のみ書き出される。他の agent 向け出力を追加で取り込む場合は `--adapter` を繰り返し指定する:
+
+```bash
+npx @ozzylabs/skills install --adapter claude-code --adapter codex-cli
+```
+
+| Adapter id | User-scope install target |
+| --- | --- |
+| `claude-code` | `~/.claude/skills/{name}/SKILL.md` |
+| `codex-cli` | `~/.codex/agents/skills/{name}/SKILL.md` + `AGENTS.md.snippet` のマージ |
+| `gemini-cli` | `~/.gemini/settings.json` のマージ + `AGENTS.md.snippet` のマージ |
+| `copilot` | `~/.github/copilot-instructions.md` への snippet マージ |
+
+オプション・install target の詳細は `npx @ozzylabs/skills install --help` を参照。
+
+### CI で利用する場合
+
+CI runner 上で `npx @ozzylabs/skills install` を実行する再利用可能な GitHub Action を別途整備予定（[issue #101](https://github.com/ozzy-labs/skills/issues/101) を参照）。Action 提供までは step から直接 CLI を呼び出す:
+
+```yaml
+- name: Install OzzyLabs skills
+  run: npx --yes @ozzylabs/skills install --adapter claude-code
+```
+
+### 旧 push 型フローからの移行
+
+以前は push 型 `/sync-consumers` 経由で skills を **project skills** として配信していた（`dist/{adapter-id}/` を consumer リポの `.claude/skills/` 等にコピー）。本方針変更により全 consumer が user skills only への移行対象となる。移行ガイドと pilot rollout は [issue #100](https://github.com/ozzy-labs/skills/issues/100) で整備予定。概要は以下:
+
+1. `.claude/skills/` / `.agents/skills/` 等、in-repo skill ミラーを削除する。
+2. `.commons/sync.yaml` から `skills_commit` / `skills_adapters` を取り除く。
+3. 各 contributor が自分のマシンで `npx @ozzylabs/skills install` を 1 度実行する。
 
 ## Adapter 出力
 


### PR DESCRIPTION
## Summary

epic #96 / sub-issue #99 (skills repo portion) — Consumer 向けの skill 配布を **user skills only** に統一する公式宣言を README / AGENTS / CLAUDE に反映する。

本 PR は **skills repo portion** のみで、handbook ADR portion (ADR-0016 を Superseded + ADR-0027 新規) は別 PR (handbook repo) で対応予定。両 PR の merge をもって #99 をクローズする。

### Changes

- **`README.md` / `docs/README.ja.md` (Consumer setup)**
  - 冒頭を `npx @ozzylabs/skills install` ベースに書き換え (唯一の配信経路)
  - `--adapter` opt-in による per-agent 出力を表で記述
  - CI で使う場合の link (sub-issue #101, 予定)
  - 旧 push 型 `/sync-consumers` 配信からの migration ガイドへの link (sub-issue #100, 予定)
- **削除した記述**
  - 「`.commons/sync.yaml` に `skills_commit` / `skills_adapters` を pin して project skills として取り込む」フロー全文
  - 「Legacy Renovate preset (removed)」セクション (epic #80 で既に preset 自体は削除済み、説明文も本 PR で簡潔化)
  - 「Snippet sync helper」(sync-consumers 向け下流 helper のため、user skills only モデルでは不要)
  - 両対応の trade-off 説明
- **`AGENTS.md`**
  - 「プロジェクト概要」「Tech Stack > Distribution」を「npm package + CLI installer のみ」に統一
  - push 型 `/sync-consumers` および Renovate preset の言及を「廃止」と明記
- **`CLAUDE.md`**
  - Available Skills の冒頭に「`/drive` 等の汎用 skill は user skills として配置」「`npx @ozzylabs/skills install` で installation」を併記
  - 「skills / commons リポ内部 (本リポ等) では project skills として `.claude/skills/` 配下に置かれている」旨を明記
  - `/sync-consumers` 説明に「skills / commons リポ内部運用向け」のスコープ注記を追加

### Out of scope (別 PR で対応)

- handbook `adr/0016-create-skills-repo.md` の Status を **Superseded** に変更
- handbook `adr/0027-skill-distribution-user-only.md` (新規) を Accepted で追加
- 上記 2 つは handbook repo の別 PR で実施 (本 PR では close keyword を立てない)

### Refs

- Parent epic: #96
- Sub-issue: #99 (skills portion)
- Blocked by: #97 (PR #103 merged)
- 並列可能: #98 (sub-issue B)
- 後続: #100 (D, migration ガイド), #101 (E, setup-skills action)

## Test plan

- [x] `pnpm build` — 14 skill / 1 agent 全 build success (dist は SSOT 由来で変化なし、README/AGENTS/CLAUDE は dist に伝播しない設計)
- [x] `pnpm test` — 119 tests pass
- [x] `pnpm lint:all` — biome / markdownlint / yamllint / gitleaks クリーン (既存の biome config schema info / yamllint warning は本 PR 由来ではない)
- [x] lefthook pre-commit (markdownlint / gitleaks / trivy) pass
- [x] commitlint pass
- [ ] CI workflow が全 pass することを確認 (PR 作成後)

🤖 Generated with [Claude Code](https://claude.com/claude-code)