### PR TITLE
feat(cli): npx @ozzylabs/skills install と migrate を実装

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,18 @@ pnpm run lint              # Biome
 pnpm run lint:all          # Biome + markdownlint + yamllint + gitleaks
 ```
 
+## CLI Installer (user scope)
+
+`npx @ozzylabs/skills install` で canonical skill バンドルを user-scope（`$HOME` 配下）に install できる。`migrate` subcommand は旧 project-scope レイアウト（汎用 10 件の `.claude/skills/` / `.agents/skills/` と `.commons/sync.yaml` の `skills_adapters` / `skills_commit`）を片付ける:
+
+```bash
+npx @ozzylabs/skills install --adapter=claude-code --skills=drive,review
+npx @ozzylabs/skills install --adapter=codex-cli --upgrade
+npx @ozzylabs/skills migrate --dry-run
+```
+
+詳細は `README.md` の「CLI installer (user-scoped)」セクションを参照。
+
 ## 検証（必須）
 
 コード変更後、報告前に以下を通すこと:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,3 +24,15 @@
 
 - スキル完了時のネクストアクション提案には `AskUserQuestion` を使用する
 - ネクストアクションはユーザーの確認なく実行しない
+
+## CLI Installer (user scope)
+
+各 skill を自分の `$HOME` に user-scope で install したい場合は npm 経由の CLI を使う:
+
+```bash
+npx @ozzylabs/skills install --adapter=claude-code             # 全 skill を ~/.claude/skills/ に
+npx @ozzylabs/skills install --skills=drive,review --dry-run   # JSON で計画のみ
+npx @ozzylabs/skills migrate --dry-run                         # 旧 project-scope 配信の片付け
+```
+
+詳細は `README.md` の「CLI installer (user-scoped)」を参照。

--- a/README.md
+++ b/README.md
@@ -30,6 +30,45 @@ The 13 common skills shared across all OzzyLabs repositories:
 
 Repo-specific skills (e.g. `road`'s `improve-loop` / `road-repo-context`) are intentionally not included in this package.
 
+## CLI installer (user-scoped)
+
+The `@ozzylabs/skills` package ships a CLI that installs the canonical skill bundle into the user-scoped skills directory (always under `$HOME` — there is intentionally no project-scoped target):
+
+```bash
+# Install every skill into ~/.claude/skills/ (Claude Code, default adapter)
+npx @ozzylabs/skills install
+
+# Install a subset into ~/.agents/skills/ (Codex CLI)
+npx @ozzylabs/skills install --adapter=codex-cli --skills=drive,review
+
+# Dry-run: print the JSON plan and do nothing
+npx @ozzylabs/skills install --skills=drive --dry-run
+
+# Overwrite skills that are already installed
+npx @ozzylabs/skills install --upgrade
+
+# Skip the interactive overwrite prompt (e.g. CI)
+npx @ozzylabs/skills install --force
+```
+
+Supported adapters: `claude-code` (default), `codex-cli`, `gemini-cli`, `copilot`. The output path mirrors what the build pipeline writes under `dist/{adapter-id}/`, transplanted onto `$HOME`. Project-scoped install flags (`--target` etc.) are not supported and never will be — use the `/sync-consumers` flow if you need per-repo mirrors.
+
+### Migrating off the legacy project-scoped layout
+
+For repos that previously consumed the generic skills via the Renovate-based `/sync-consumers` flow, the migrate subcommand removes the now-redundant project-scoped copies:
+
+```bash
+# Preview the cleanup plan
+npx @ozzylabs/skills migrate --dry-run
+
+# Apply the cleanup (removes the 10 generic skills under .claude/skills/ and
+# .agents/skills/, and strips skills_adapters / skills_commit from
+# .commons/sync.yaml). Pass --keep-sync-yaml to leave the YAML untouched.
+npx @ozzylabs/skills migrate --force
+```
+
+Repo-local skills (anything outside the documented generic 10) are left untouched.
+
 ## Consumer setup
 
 Track the upstream digest in `.commons/sync.yaml`:

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -1,14 +1,54 @@
 #!/usr/bin/env node
-// @ozzylabs/skills CLI installer — placeholder.
+// @ozzylabs/skills CLI entry point — dispatcher for `install` and `migrate`.
 //
-// The real installer (adapter detection, payload copy into consumer repos)
-// is tracked in ozzy-labs/skills sub-issue B (#98). Until then this binary
-// only emits an informational message and exits 0 so packaging / dry-run
-// remain green.
+// Usage:
+//   npx @ozzylabs/skills install [options]
+//   npx @ozzylabs/skills migrate [options]
 //
-// Refs:
-//   - sub-issue A (this PR): #97 — package.json publish setup + payload slim
-//   - sub-issue B           : #98 — CLI installer body
+// The installer writes user-scoped skill files (always under the user's HOME
+// directory — never project-scoped). The migrate command removes the legacy
+// project-scoped skill copies left over by the older Renovate-based sync flow.
+//
+// See ozzy-labs/skills#96 (parent epic) and #98 (this sub-issue) for the
+// design discussion.
 
-console.log("install: see ozzy-labs/skills#98 (sub-issue B)");
-process.exit(0);
+import { runInstall } from "./lib/install.mjs";
+import { runMigrate } from "./lib/migrate.mjs";
+
+const TOP_LEVEL_HELP = `npx @ozzylabs/skills <subcommand> [options]
+
+Subcommands:
+  install   Install canonical skills into the user-scoped skills directory
+            (~/.claude/skills/, ~/.agents/skills/, etc.) for the chosen adapter.
+  migrate   Remove the legacy project-scoped skill copies and the related
+            .commons/sync.yaml entries (skills_adapters / skills_commit).
+
+Run 'npx @ozzylabs/skills <subcommand> --help' for subcommand-specific options.
+`;
+
+async function main(argv) {
+  const subcommand = argv[0];
+  const rest = argv.slice(1);
+
+  if (!subcommand || subcommand === "-h" || subcommand === "--help") {
+    process.stdout.write(TOP_LEVEL_HELP);
+    return 0;
+  }
+
+  if (subcommand === "install") {
+    return await runInstall(rest);
+  }
+  if (subcommand === "migrate") {
+    return await runMigrate(rest);
+  }
+
+  process.stderr.write(`Unknown subcommand: ${subcommand}\n\n${TOP_LEVEL_HELP}`);
+  return 1;
+}
+
+main(process.argv.slice(2))
+  .then((code) => process.exit(code ?? 0))
+  .catch((err) => {
+    process.stderr.write(`error: ${err?.stack ?? err}\n`);
+    process.exit(1);
+  });

--- a/bin/lib/args.mjs
+++ b/bin/lib/args.mjs
@@ -1,0 +1,96 @@
+// Shared argument parsing helpers for the @ozzylabs/skills CLI.
+//
+// The CLI deliberately avoids any third-party dependency (commander, yargs,
+// etc.) so `npx @ozzylabs/skills` stays small. The shapes we need to parse are
+// trivial: a positional subcommand (handled by the dispatcher) plus a flat
+// list of `--flag` / `--flag=value` style options.
+
+/**
+ * Parse a flat list of `--flag` / `--flag=value` / `--flag value` style
+ * arguments against a tiny schema.
+ *
+ * @param {string[]} argv The arguments past the subcommand (e.g.
+ *   `["--skills=drive,review", "--dry-run"]`).
+ * @param {Record<string, "boolean" | "string">} schema Map of flag name (without
+ *   the leading `--`) to the expected type. A boolean flag consumes no value.
+ *   A string flag accepts either `--flag=value` or `--flag value`.
+ * @param {Record<string, string>} [aliases] Map of short flag (e.g. `h`) to
+ *   the canonical long flag name. Aliases inherit the schema entry of their
+ *   target.
+ * @returns {{ values: Record<string, unknown>, rejected: string[] }}
+ *   `rejected` carries any unknown flags so callers can surface a clear error.
+ */
+export function parseFlags(argv, schema, aliases = {}) {
+  const values = {};
+  const rejected = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith("-")) {
+      rejected.push(arg);
+      continue;
+    }
+
+    // Strip leading dashes and split `--flag=value`.
+    const trimmed = arg.replace(/^-+/, "");
+    const eq = trimmed.indexOf("=");
+    const rawName = eq === -1 ? trimmed : trimmed.slice(0, eq);
+    const inlineValue = eq === -1 ? null : trimmed.slice(eq + 1);
+
+    const name = aliases[rawName] ?? rawName;
+    const type = schema[name];
+    if (!type) {
+      rejected.push(arg);
+      continue;
+    }
+
+    if (type === "boolean") {
+      values[name] = true;
+      continue;
+    }
+
+    if (inlineValue !== null) {
+      values[name] = inlineValue;
+      continue;
+    }
+
+    // Consume the next argv as the value, unless the next argv looks like
+    // another flag.
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("-")) {
+      throw new Error(`flag --${name} requires a value`);
+    }
+    values[name] = next;
+    i += 1;
+  }
+
+  return { values, rejected };
+}
+
+/**
+ * Detect `--target`, `--from`, `--to`, etc. — flags that the sub-issue B
+ * acceptance criteria explicitly forbid. Throwing here keeps the error message
+ * close to the user input so the help text stays the source of truth.
+ *
+ * @param {string[]} argv
+ */
+export function assertNoForbiddenFlags(argv) {
+  const forbidden = new Set([
+    "--target",
+    "--target-dir",
+    "--target=",
+    "--from",
+    "--to",
+    "--project",
+  ]);
+  for (const arg of argv) {
+    // Allow `--target-something-else` to slip through; we only block exact
+    // matches and the `--target=...` form.
+    const head = arg.split("=")[0];
+    if (forbidden.has(arg) || forbidden.has(head) || forbidden.has(`${head}=`)) {
+      throw new Error(
+        `flag ${arg.split("=")[0]} is not supported — @ozzylabs/skills installs into the user-scoped skills directory only. See 'npx @ozzylabs/skills install --help'.`,
+      );
+    }
+  }
+}

--- a/bin/lib/install.mjs
+++ b/bin/lib/install.mjs
@@ -1,0 +1,403 @@
+// `npx @ozzylabs/skills install` implementation.
+//
+// The installer copies canonical skill payloads from the package's `dist/`
+// directory into the user-scoped skills directory (always under HOME — never
+// project-scoped). Adapter layouts mirror what the build pipeline writes
+// under `dist/{adapter-id}/`:
+//
+//   claude-code → ~/.claude/skills/{name}/SKILL.md  (+ extras)
+//   codex-cli   → ~/.agents/skills/{name}/SKILL.md  (+ extras + AGENTS.md.snippet)
+//   gemini-cli  → ~/.gemini/settings.json + ~/AGENTS.md.snippet (no per-skill files)
+//   copilot     → ~/.github/copilot-instructions.md.snippet     (no per-skill files)
+//
+// `--dry-run` reports the plan as JSON on stdout without touching the disk.
+
+import { existsSync } from "node:fs";
+import { copyFile, mkdir, readdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { assertNoForbiddenFlags, parseFlags } from "./args.mjs";
+
+const HELP = `npx @ozzylabs/skills install [options]
+
+Install canonical OzzyLabs skills into the user-scoped skills directory.
+
+Options:
+  --skills=<list>      Comma-separated skill names (default: install all).
+  --adapter=<id>       Adapter id: claude-code (default), codex-cli,
+                       gemini-cli, copilot.
+  --dry-run            Print the install plan as JSON and exit. No files are
+                       written.
+  --upgrade            Overwrite skills that are already installed.
+  --force              Skip the interactive confirmation prompt (non-TTY
+                       sessions skip the prompt automatically).
+  -h, --help           Show this help.
+
+Note: @ozzylabs/skills installs into the user-scoped skills directory only —
+i.e. under \$HOME. Project-scoped install paths (e.g. \`--target\`) are not
+supported and never will be. Use the legacy \`/sync-consumers\` flow if you
+need per-repo skill mirrors.
+`;
+
+const SUPPORTED_ADAPTERS = ["claude-code", "codex-cli", "gemini-cli", "copilot"];
+
+const SCHEMA = {
+  skills: "string",
+  adapter: "string",
+  "dry-run": "boolean",
+  upgrade: "boolean",
+  force: "boolean",
+  help: "boolean",
+};
+
+const ALIASES = { h: "help" };
+
+// Per-adapter description of how to walk the dist tree and map it onto
+// the user HOME directory. Each adapter declares:
+//   - skillsRoot:  the dist-relative path containing per-skill folders (or
+//                  null if the adapter does not ship per-skill folders).
+//   - distSubtree: the dist-relative directory rooted at the user HOME image
+//                  (i.e. everything below this directory is copied to
+//                  `<HOME>/<rest-of-path>`).
+const ADAPTER_LAYOUT = {
+  "claude-code": {
+    skillsRoot: ".claude/skills",
+    distSubtree: ".",
+  },
+  "codex-cli": {
+    skillsRoot: ".agents/skills",
+    distSubtree: ".",
+  },
+  "gemini-cli": {
+    skillsRoot: null,
+    distSubtree: ".",
+  },
+  copilot: {
+    skillsRoot: null,
+    distSubtree: ".",
+  },
+};
+
+/**
+ * Walk a directory tree and return every file path relative to `root`.
+ *
+ * @param {string} root
+ * @returns {Promise<string[]>}
+ */
+async function listFiles(root) {
+  const out = [];
+  async function walk(dir) {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (entry.isFile()) {
+        out.push(relative(root, full));
+      }
+    }
+  }
+  await walk(root);
+  out.sort();
+  return out;
+}
+
+/**
+ * Read a directory's immediate subdirectory names. Returns [] if missing.
+ *
+ * @param {string} dir
+ * @returns {Promise<string[]>}
+ */
+async function listSubdirs(dir) {
+  if (!existsSync(dir)) return [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  return entries
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+}
+
+/**
+ * Locate the @ozzylabs/skills package root (the directory that contains
+ * `dist/` and `package.json`). Walks up from this module's location, which
+ * works both inside the installed npm package and inside the source repo.
+ *
+ * @returns {Promise<string>}
+ */
+async function findPackageRoot() {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 6; i++) {
+    if (existsSync(join(dir, "package.json")) && existsSync(join(dir, "dist"))) {
+      return dir;
+    }
+    dir = dirname(dir);
+  }
+  throw new Error(
+    "could not locate the @ozzylabs/skills package root (missing dist/ next to package.json)",
+  );
+}
+
+/**
+ * Confirm an interactive overwrite. Returns true when stdin is a TTY and the
+ * user types "y"/"yes", or when `force` is set. Non-TTY sessions return
+ * false (i.e. skip the skill) so unattended runs never block on prompts.
+ *
+ * @param {string} message
+ * @param {boolean} force
+ * @returns {Promise<boolean>}
+ */
+async function confirm(message, force) {
+  if (force) return true;
+  if (!process.stdin.isTTY) return false;
+  process.stdout.write(`${message} [y/N] `);
+  return await new Promise((resolve) => {
+    let buf = "";
+    const onData = (chunk) => {
+      buf += chunk.toString();
+      if (buf.includes("\n")) {
+        process.stdin.off("data", onData);
+        process.stdin.pause();
+        const answer = buf.trim().toLowerCase();
+        resolve(answer === "y" || answer === "yes");
+      }
+    };
+    process.stdin.resume();
+    process.stdin.on("data", onData);
+  });
+}
+
+/**
+ * Plan a single install run. Pure: takes inputs and returns the action plan
+ * without touching the filesystem. The caller is responsible for printing
+ * the plan (`--dry-run`) or executing it.
+ *
+ * @param {object} args
+ * @param {string} args.packageRoot
+ * @param {string} args.home
+ * @param {string} args.adapter
+ * @param {string[] | null} args.skillsFilter
+ * @returns {Promise<{ adapter: string, target_dir: string, files: Array<{ source: string, dest: string, skill: string | null }>, skills_available: string[] }>}
+ */
+export async function planInstall({ packageRoot, home, adapter, skillsFilter }) {
+  if (!SUPPORTED_ADAPTERS.includes(adapter)) {
+    throw new Error(
+      `unsupported adapter '${adapter}' — choose from: ${SUPPORTED_ADAPTERS.join(", ")}`,
+    );
+  }
+  const layout = ADAPTER_LAYOUT[adapter];
+  const distAdapterRoot = join(packageRoot, "dist", adapter);
+  if (!existsSync(distAdapterRoot)) {
+    throw new Error(`missing adapter payload at ${distAdapterRoot} — run \`pnpm build\` first?`);
+  }
+
+  const skillsAvailable = layout.skillsRoot
+    ? await listSubdirs(join(distAdapterRoot, layout.skillsRoot))
+    : [];
+
+  // Validate the requested skill list against what the payload actually
+  // ships. We accept an empty filter (= install everything) but reject
+  // typos eagerly.
+  if (skillsFilter && layout.skillsRoot) {
+    const unknown = skillsFilter.filter((s) => !skillsAvailable.includes(s));
+    if (unknown.length > 0) {
+      throw new Error(
+        `unknown skill(s) for adapter '${adapter}': ${unknown.join(", ")} (available: ${skillsAvailable.join(", ") || "<none>"})`,
+      );
+    }
+  }
+  if (skillsFilter && !layout.skillsRoot) {
+    throw new Error(
+      `adapter '${adapter}' does not ship per-skill files; --skills is only meaningful for adapters that do (claude-code, codex-cli)`,
+    );
+  }
+
+  const allFiles = await listFiles(distAdapterRoot);
+  const files = [];
+  for (const relPath of allFiles) {
+    let skillName = null;
+    if (layout.skillsRoot && relPath.startsWith(`${layout.skillsRoot}/`)) {
+      const tail = relPath.slice(layout.skillsRoot.length + 1);
+      skillName = tail.split("/")[0];
+      if (skillsFilter && !skillsFilter.includes(skillName)) continue;
+    } else if (skillsFilter) {
+      // When the caller restricted to specific skills, skip the
+      // adapter-level snippet files (e.g. AGENTS.md.snippet) because they
+      // embed the full skill catalog and would not match the filter.
+      continue;
+    }
+    files.push({
+      source: join(distAdapterRoot, relPath),
+      dest: join(home, relPath),
+      skill: skillName,
+    });
+  }
+
+  return {
+    adapter,
+    target_dir: home,
+    files,
+    skills_available: skillsAvailable,
+  };
+}
+
+/**
+ * Execute an install plan against the real filesystem. Mutates disk.
+ *
+ * @param {Awaited<ReturnType<typeof planInstall>>} plan
+ * @param {object} options
+ * @param {boolean} options.upgrade
+ * @param {boolean} options.force
+ * @returns {Promise<{ installed: string[], upgraded: string[], skipped: string[] }>}
+ */
+export async function executeInstall(plan, options) {
+  const installed = new Set();
+  const upgraded = new Set();
+  const skipped = new Set();
+
+  // Group files by skill so the prompt asks once per skill (not per file).
+  const bySkill = new Map();
+  for (const file of plan.files) {
+    const key = file.skill ?? "__adapter__";
+    if (!bySkill.has(key)) bySkill.set(key, []);
+    bySkill.get(key).push(file);
+  }
+
+  for (const [skillKey, files] of bySkill) {
+    const skillLabel = skillKey === "__adapter__" ? "(adapter-wide files)" : skillKey;
+
+    // Determine whether anything in this group already exists.
+    let hasExisting = false;
+    for (const file of files) {
+      if (existsSync(file.dest)) {
+        hasExisting = true;
+        break;
+      }
+    }
+
+    if (hasExisting) {
+      if (options.upgrade || options.force) {
+        // proceed and mark as upgraded
+      } else {
+        const yes = await confirm(
+          `Skill '${skillLabel}' is already installed at ${plan.target_dir}. Overwrite?`,
+          false,
+        );
+        if (!yes) {
+          if (skillKey !== "__adapter__") skipped.add(skillKey);
+          continue;
+        }
+      }
+    }
+
+    for (const file of files) {
+      await mkdir(dirname(file.dest), { recursive: true });
+      await copyFile(file.source, file.dest);
+    }
+    if (skillKey === "__adapter__") continue;
+    if (hasExisting) upgraded.add(skillKey);
+    else installed.add(skillKey);
+  }
+
+  return {
+    installed: [...installed].sort(),
+    upgraded: [...upgraded].sort(),
+    skipped: [...skipped].sort(),
+  };
+}
+
+/**
+ * Run the `install` subcommand from CLI argv. Returns a process exit code.
+ *
+ * @param {string[]} argv The args after the `install` subcommand keyword.
+ * @returns {Promise<number>}
+ */
+export async function runInstall(argv) {
+  try {
+    assertNoForbiddenFlags(argv);
+  } catch (err) {
+    process.stderr.write(`error: ${err.message}\n\n${HELP}`);
+    return 1;
+  }
+
+  let parsed;
+  try {
+    parsed = parseFlags(argv, SCHEMA, ALIASES);
+  } catch (err) {
+    process.stderr.write(`error: ${err.message}\n\n${HELP}`);
+    return 1;
+  }
+
+  if (parsed.values.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  if (parsed.rejected.length > 0) {
+    process.stderr.write(`error: unknown argument(s): ${parsed.rejected.join(", ")}\n\n${HELP}`);
+    return 1;
+  }
+
+  const adapter = parsed.values.adapter ?? "claude-code";
+  const skillsFilter = parsed.values.skills
+    ? parsed.values.skills.split(",").map((s) => s.trim()).filter(Boolean)
+    : null;
+  const dryRun = Boolean(parsed.values["dry-run"]);
+  const upgrade = Boolean(parsed.values.upgrade);
+  const force = Boolean(parsed.values.force);
+
+  const packageRoot = await findPackageRoot();
+  const home = process.env.OZZYLABS_SKILLS_HOME ?? homedir();
+
+  let plan;
+  try {
+    plan = await planInstall({ packageRoot, home, adapter, skillsFilter });
+  } catch (err) {
+    process.stderr.write(`error: ${err.message}\n`);
+    return 1;
+  }
+
+  if (dryRun) {
+    const summary = await summarizePlan(plan, home);
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+    return 0;
+  }
+
+  const result = await executeInstall(plan, { upgrade, force });
+  const summary = {
+    target_dir: plan.target_dir,
+    adapter: plan.adapter,
+    installed: result.installed,
+    upgraded: result.upgraded,
+    skipped: result.skipped,
+  };
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  return 0;
+}
+
+/**
+ * Compute a dry-run summary that mirrors `executeInstall`'s result shape so
+ * downstream tooling can rely on the same JSON contract.
+ *
+ * @param {Awaited<ReturnType<typeof planInstall>>} plan
+ * @param {string} home
+ */
+async function summarizePlan(plan, _home) {
+  const installed = new Set();
+  const upgraded = new Set();
+  const skipped = new Set();
+  for (const file of plan.files) {
+    if (!file.skill) continue;
+    if (existsSync(file.dest)) upgraded.add(file.skill);
+    else installed.add(file.skill);
+  }
+  return {
+    target_dir: plan.target_dir,
+    adapter: plan.adapter,
+    installed: [...installed].sort(),
+    upgraded: [...upgraded].sort(),
+    skipped: [...skipped].sort(),
+    files: plan.files.map((f) => ({ source: f.source, dest: f.dest, skill: f.skill })),
+  };
+}
+
+export { SUPPORTED_ADAPTERS, ADAPTER_LAYOUT, HELP };

--- a/bin/lib/install.mjs
+++ b/bin/lib/install.mjs
@@ -15,7 +15,7 @@
 import { existsSync } from "node:fs";
 import { copyFile, mkdir, readdir } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join, relative } from "node:path";
+import { dirname, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { assertNoForbiddenFlags, parseFlags } from "./args.mjs";
 
@@ -81,6 +81,8 @@ const ADAPTER_LAYOUT = {
 
 /**
  * Walk a directory tree and return every file path relative to `root`.
+ * Paths are normalized to forward-slash separators so the internal layout
+ * comparisons (e.g. matching `".claude/skills/"`) work on Windows too.
  *
  * @param {string} root
  * @returns {Promise<string[]>}
@@ -94,7 +96,7 @@ async function listFiles(root) {
       if (entry.isDirectory()) {
         await walk(full);
       } else if (entry.isFile()) {
-        out.push(relative(root, full));
+        out.push(relative(root, full).split(sep).join("/"));
       }
     }
   }
@@ -266,7 +268,11 @@ export async function executeInstall(plan, options) {
   for (const [skillKey, files] of bySkill) {
     const skillLabel = skillKey === "__adapter__" ? "(adapter-wide files)" : skillKey;
 
-    // Determine whether anything in this group already exists.
+    // Determine whether anything in this group already exists. Snippet-only
+    // adapters (gemini-cli, copilot) flow through the `__adapter__` group and
+    // can overwrite the user's hand-edited ~/.gemini/settings.json or
+    // ~/AGENTS.md.snippet, so they MUST prompt unless --upgrade / --force is
+    // set just like skill groups do.
     let hasExisting = false;
     for (const file of files) {
       if (existsSync(file.dest)) {
@@ -280,7 +286,7 @@ export async function executeInstall(plan, options) {
         // proceed and mark as upgraded
       } else {
         const yes = await confirm(
-          `Skill '${skillLabel}' is already installed at ${plan.target_dir}. Overwrite?`,
+          `'${skillLabel}' is already installed at ${plan.target_dir}. Overwrite?`,
           false,
         );
         if (!yes) {

--- a/bin/lib/migrate.mjs
+++ b/bin/lib/migrate.mjs
@@ -1,0 +1,273 @@
+// `npx @ozzylabs/skills migrate` implementation.
+//
+// Removes the legacy project-scoped skill copies that the old Renovate-based
+// `/sync-consumers` flow left behind, plus the related `.commons/sync.yaml`
+// entries (`skills_adapters` / `skills_commit`). The new world is user-scoped
+// install via `npx @ozzylabs/skills install`, so the project-scoped tree is
+// dead weight.
+//
+// The list of skill names is intentionally hard-coded — these are the ten
+// generic skills shipped from `@ozzylabs/skills`. Repo-local skills (anything
+// else) are left in place.
+
+import { existsSync } from "node:fs";
+import { readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { assertNoForbiddenFlags, parseFlags } from "./args.mjs";
+
+const HELP = `npx @ozzylabs/skills migrate [options]
+
+Remove the legacy project-scoped skill copies and the related .commons/sync.yaml
+entries that the old Renovate-based /sync-consumers flow left behind.
+
+Options:
+  --dry-run            Print the migrate plan as JSON and exit. No files are
+                       touched.
+  --keep-sync-yaml     Leave the .commons/sync.yaml entries (skills_adapters,
+                       skills_commit) in place. Default is to remove them.
+  --force              Skip the interactive confirmation prompt (non-TTY
+                       sessions skip the prompt automatically).
+  -h, --help           Show this help.
+`;
+
+// The ten generic skills shipped from @ozzylabs/skills. Other skill names
+// under .claude/skills/ or .agents/skills/ are treated as repo-local and left
+// untouched.
+export const GENERIC_SKILLS = Object.freeze([
+  "commit",
+  "commit-conventions",
+  "drive",
+  "implement",
+  "lint",
+  "lint-rules",
+  "pr",
+  "review",
+  "ship",
+  "test",
+]);
+
+// Directory roots that the legacy sync flow wrote into.
+const SKILL_DIRS = [".claude/skills", ".agents/skills"];
+
+const SYNC_YAML_PATH = ".commons/sync.yaml";
+
+const SCHEMA = {
+  "dry-run": "boolean",
+  "keep-sync-yaml": "boolean",
+  force: "boolean",
+  help: "boolean",
+};
+
+const ALIASES = { h: "help" };
+
+/**
+ * Plan a migrate run for `cwd`. Pure: takes inputs and returns the action
+ * plan without touching the filesystem.
+ *
+ * @param {object} args
+ * @param {string} args.cwd
+ * @param {boolean} args.keepSyncYaml
+ * @returns {Promise<{ cwd: string, skill_dirs_to_remove: string[], sync_yaml: { path: string | null, will_modify: boolean, before: string | null, after: string | null } }>}
+ */
+export async function planMigrate({ cwd, keepSyncYaml }) {
+  const skillDirsToRemove = [];
+  for (const root of SKILL_DIRS) {
+    const rootPath = join(cwd, root);
+    if (!existsSync(rootPath)) continue;
+    let entries;
+    try {
+      entries = await readdir(rootPath, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (GENERIC_SKILLS.includes(entry.name)) {
+        skillDirsToRemove.push(join(root, entry.name));
+      }
+    }
+  }
+  skillDirsToRemove.sort();
+
+  const syncYamlPath = join(cwd, SYNC_YAML_PATH);
+  let syncPlan = { path: null, will_modify: false, before: null, after: null };
+  if (!keepSyncYaml && existsSync(syncYamlPath)) {
+    const before = await readFile(syncYamlPath, "utf8");
+    const after = stripSyncYamlEntries(before);
+    syncPlan = {
+      path: SYNC_YAML_PATH,
+      will_modify: after !== before,
+      before,
+      after,
+    };
+  }
+
+  return {
+    cwd,
+    skill_dirs_to_remove: skillDirsToRemove,
+    sync_yaml: syncPlan,
+  };
+}
+
+/**
+ * Strip `skills_adapters` and `skills_commit` blocks from a YAML document.
+ *
+ * The format we touch is a hand-written `.commons/sync.yaml` so a full YAML
+ * round-trip would lose comments and reorder keys. We work at the line level:
+ * lines that start at column 0 with `skills_adapters:` or `skills_commit:` are
+ * removed, plus any immediately-following list / scalar continuation lines
+ * (indented two or more spaces).
+ *
+ * @param {string} content
+ * @returns {string}
+ */
+export function stripSyncYamlEntries(content) {
+  const lines = content.split("\n");
+  const out = [];
+  let stripping = false;
+  for (const line of lines) {
+    if (stripping) {
+      // Continuation lines are indented; stop stripping when we hit a
+      // non-indented line (next top-level key or blank line).
+      if (/^[ \t]/.test(line)) {
+        continue;
+      }
+      stripping = false;
+    }
+    if (/^skills_adapters\s*:/.test(line) || /^skills_commit\s*:/.test(line)) {
+      stripping = true;
+      continue;
+    }
+    out.push(line);
+  }
+  return out.join("\n");
+}
+
+/**
+ * Execute a migrate plan against the real filesystem. Mutates disk.
+ *
+ * @param {Awaited<ReturnType<typeof planMigrate>>} plan
+ * @returns {Promise<{ removed: string[], sync_yaml_updated: boolean }>}
+ */
+export async function executeMigrate(plan) {
+  const removed = [];
+  for (const rel of plan.skill_dirs_to_remove) {
+    const full = join(plan.cwd, rel);
+    await rm(full, { recursive: true, force: true });
+    removed.push(rel);
+  }
+  let syncYamlUpdated = false;
+  if (plan.sync_yaml.will_modify && plan.sync_yaml.path) {
+    await writeFile(join(plan.cwd, plan.sync_yaml.path), plan.sync_yaml.after);
+    syncYamlUpdated = true;
+  }
+  return { removed, sync_yaml_updated: syncYamlUpdated };
+}
+
+/**
+ * Confirm an interactive destructive operation. See install.mjs#confirm for
+ * the TTY semantics — the contract is identical so behavior stays consistent
+ * across subcommands.
+ */
+async function confirm(message, force) {
+  if (force) return true;
+  if (!process.stdin.isTTY) return false;
+  process.stdout.write(`${message} [y/N] `);
+  return await new Promise((resolve) => {
+    let buf = "";
+    const onData = (chunk) => {
+      buf += chunk.toString();
+      if (buf.includes("\n")) {
+        process.stdin.off("data", onData);
+        process.stdin.pause();
+        const answer = buf.trim().toLowerCase();
+        resolve(answer === "y" || answer === "yes");
+      }
+    };
+    process.stdin.resume();
+    process.stdin.on("data", onData);
+  });
+}
+
+/**
+ * Run the `migrate` subcommand from CLI argv. Returns a process exit code.
+ *
+ * @param {string[]} argv The args after the `migrate` subcommand keyword.
+ * @returns {Promise<number>}
+ */
+export async function runMigrate(argv) {
+  try {
+    assertNoForbiddenFlags(argv);
+  } catch (err) {
+    process.stderr.write(`error: ${err.message}\n\n${HELP}`);
+    return 1;
+  }
+
+  let parsed;
+  try {
+    parsed = parseFlags(argv, SCHEMA, ALIASES);
+  } catch (err) {
+    process.stderr.write(`error: ${err.message}\n\n${HELP}`);
+    return 1;
+  }
+
+  if (parsed.values.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  if (parsed.rejected.length > 0) {
+    process.stderr.write(`error: unknown argument(s): ${parsed.rejected.join(", ")}\n\n${HELP}`);
+    return 1;
+  }
+
+  const dryRun = Boolean(parsed.values["dry-run"]);
+  const keepSyncYaml = Boolean(parsed.values["keep-sync-yaml"]);
+  const force = Boolean(parsed.values.force);
+
+  const cwd = process.env.OZZYLABS_SKILLS_CWD ?? process.cwd();
+  const plan = await planMigrate({ cwd, keepSyncYaml });
+
+  if (dryRun) {
+    const summary = {
+      cwd: plan.cwd,
+      will_remove: plan.skill_dirs_to_remove,
+      sync_yaml: {
+        path: plan.sync_yaml.path,
+        will_modify: plan.sync_yaml.will_modify,
+      },
+    };
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+    return 0;
+  }
+
+  const hasWork =
+    plan.skill_dirs_to_remove.length > 0 || plan.sync_yaml.will_modify;
+  if (!hasWork) {
+    process.stdout.write(
+      `${JSON.stringify({ cwd: plan.cwd, removed: [], sync_yaml_updated: false, note: "nothing to migrate" }, null, 2)}\n`,
+    );
+    return 0;
+  }
+
+  if (!force) {
+    const yes = await confirm(
+      `About to remove ${plan.skill_dirs_to_remove.length} skill director${plan.skill_dirs_to_remove.length === 1 ? "y" : "ies"} and ${plan.sync_yaml.will_modify ? "update" : "leave"} .commons/sync.yaml in ${plan.cwd}. Proceed?`,
+      false,
+    );
+    if (!yes) {
+      process.stderr.write("aborted: user declined\n");
+      return 1;
+    }
+  }
+
+  const result = await executeMigrate(plan);
+  const summary = {
+    cwd: plan.cwd,
+    removed: result.removed,
+    sync_yaml_updated: result.sync_yaml_updated,
+  };
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  return 0;
+}
+
+export { HELP };

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -30,6 +30,45 @@ OzzyLabs 全リポジトリ共通の 13 件:
 
 リポ固有スキル（例: `road` の `improve-loop` / `road-repo-context`）は本パッケージには含まない。
 
+## CLI installer (user scope)
+
+`@ozzylabs/skills` パッケージは canonical な skill バンドルを user-scope の skills ディレクトリへインストールする CLI を同梱する。出力先は常に `$HOME` 配下（project-scope 配信は意図的に未サポート）:
+
+```bash
+# 全 skill を ~/.claude/skills/ に install (Claude Code、default adapter)
+npx @ozzylabs/skills install
+
+# 一部の skill を ~/.agents/skills/ に install (Codex CLI)
+npx @ozzylabs/skills install --adapter=codex-cli --skills=drive,review
+
+# dry-run: JSON で計画のみ出力し、実コピーなし
+npx @ozzylabs/skills install --skills=drive --dry-run
+
+# 既存 install を上書き
+npx @ozzylabs/skills install --upgrade
+
+# 対話 prompt を skip (CI 等)
+npx @ozzylabs/skills install --force
+```
+
+対応 adapter: `claude-code`（default）、`codex-cli`、`gemini-cli`、`copilot`。出力 path は build pipeline が `dist/{adapter-id}/` 配下に書く構造をそのまま `$HOME` に転写する。`--target` などの project-scope 用 flag は意図的に未サポート — repo ごとの mirror が必要な場合は `/sync-consumers` flow を使う。
+
+### 旧 project-scope レイアウトからの移行
+
+旧 Renovate-based `/sync-consumers` flow で配信した汎用 skill コピーを project から取り除くには migrate subcommand を使う:
+
+```bash
+# 削除計画の確認
+npx @ozzylabs/skills migrate --dry-run
+
+# 実適用 (汎用 10 skill を .claude/skills/ と .agents/skills/ から削除し、
+# .commons/sync.yaml の skills_adapters / skills_commit も削除する。
+# --keep-sync-yaml で YAML 更新を skip 可能)
+npx @ozzylabs/skills migrate --force
+```
+
+リポ固有の skill（汎用 10 件以外）はそのまま残す。
+
 ## Consumer セットアップ
 
 `.commons/sync.yaml` に upstream digest と opt-in adapter を記録:

--- a/tests/cli-e2e.test.mjs
+++ b/tests/cli-e2e.test.mjs
@@ -1,0 +1,119 @@
+// End-to-end tests for `npx @ozzylabs/skills install`.
+//
+// These run the actual `bin/install.mjs` entry point as a child process with
+// a temporary HOME (via `OZZYLABS_SKILLS_HOME`) and assert that files land
+// where we expect them. They exercise the install path that ships to users.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const BIN = join(ROOT, "bin", "install.mjs");
+
+function runCli(args, options = {}) {
+  return spawnSync("node", [BIN, ...args], {
+    cwd: options.cwd ?? ROOT,
+    env: {
+      ...process.env,
+      ...(options.home ? { OZZYLABS_SKILLS_HOME: options.home } : {}),
+    },
+    encoding: "utf8",
+  });
+}
+
+test("e2e: install --adapter=claude-code --skills=drive writes ~/.claude/skills/drive/SKILL.md", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    const result = runCli(["install", "--adapter=claude-code", "--skills=drive", "--force"], {
+      home,
+    });
+    assert.equal(result.status, 0, `cli failed: ${result.stderr}`);
+    const target = join(home, ".claude", "skills", "drive", "SKILL.md");
+    assert.ok(existsSync(target), `expected SKILL.md at ${target}`);
+    const content = readFileSync(target, "utf8");
+    assert.match(content, /^---\n/, "SKILL.md should start with YAML frontmatter");
+    assert.match(
+      content,
+      /description:/,
+      "SKILL.md should declare a description in the frontmatter",
+    );
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: install --adapter=codex-cli --skills=drive writes ~/.agents/skills/drive/SKILL.md", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    const result = runCli(["install", "--adapter=codex-cli", "--skills=drive", "--force"], {
+      home,
+    });
+    assert.equal(result.status, 0, `cli failed: ${result.stderr}`);
+    const target = join(home, ".agents", "skills", "drive", "SKILL.md");
+    assert.ok(existsSync(target), `expected SKILL.md at ${target}`);
+    const content = readFileSync(target, "utf8");
+    assert.match(content, /name:\s*drive/);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: install --dry-run does not touch the filesystem", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    const result = runCli(["install", "--adapter=claude-code", "--skills=drive", "--dry-run"], {
+      home,
+    });
+    assert.equal(result.status, 0, `cli failed: ${result.stderr}`);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.adapter, "claude-code");
+    assert.equal(payload.target_dir, home);
+    assert.deepEqual(payload.installed, ["drive"]);
+    // No files should be written.
+    const target = join(home, ".claude", "skills", "drive", "SKILL.md");
+    assert.ok(!existsSync(target), `dry-run wrote ${target} unexpectedly`);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: install rejects --target with the user-only error message", () => {
+  const result = runCli(["install", "--target=/tmp/foo"]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /not supported/);
+  assert.match(result.stderr, /user-scoped skills directory only/);
+});
+
+test("e2e: install --upgrade overwrites an existing SKILL.md", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    // First install populates the target.
+    const first = runCli(["install", "--adapter=claude-code", "--skills=drive", "--force"], {
+      home,
+    });
+    assert.equal(first.status, 0, `first install failed: ${first.stderr}`);
+
+    // Corrupt the installed file so we can detect the overwrite.
+    const target = join(home, ".claude", "skills", "drive", "SKILL.md");
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(target, "tampered\n");
+    assert.equal(readFileSync(target, "utf8"), "tampered\n");
+
+    // --upgrade should rewrite the file from dist/.
+    const second = runCli(["install", "--adapter=claude-code", "--skills=drive", "--upgrade"], {
+      home,
+    });
+    assert.equal(second.status, 0, `upgrade install failed: ${second.stderr}`);
+    assert.notEqual(readFileSync(target, "utf8"), "tampered\n");
+    const payload = JSON.parse(second.stdout);
+    assert.deepEqual(payload.upgraded, ["drive"]);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});

--- a/tests/cli-install.test.mjs
+++ b/tests/cli-install.test.mjs
@@ -1,0 +1,183 @@
+// Unit tests for `npx @ozzylabs/skills install`.
+//
+// These exercise the pure planner (`planInstall`) plus argument parsing
+// (`runInstall` via stdout capture). Filesystem-touching scenarios live in
+// `cli-e2e.test.mjs`.
+
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { assertNoForbiddenFlags, parseFlags } from "../bin/lib/args.mjs";
+import { planInstall, SUPPORTED_ADAPTERS } from "../bin/lib/install.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+test("planInstall returns target_dir under user HOME for claude-code adapter", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-install-"));
+  try {
+    const plan = await planInstall({
+      packageRoot: ROOT,
+      home,
+      adapter: "claude-code",
+      skillsFilter: ["drive"],
+    });
+    assert.equal(plan.target_dir, home);
+    assert.equal(plan.adapter, "claude-code");
+    assert.ok(plan.files.length > 0, "plan should include at least one file");
+    for (const file of plan.files) {
+      assert.ok(file.dest.startsWith(home), `file.dest must live under HOME: ${file.dest}`);
+      assert.ok(
+        file.source.includes(join("dist", "claude-code")),
+        `file.source must come from dist/claude-code/: ${file.source}`,
+      );
+    }
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("planInstall switches to .agents/skills for codex-cli adapter", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-install-"));
+  try {
+    const plan = await planInstall({
+      packageRoot: ROOT,
+      home,
+      adapter: "codex-cli",
+      skillsFilter: ["drive"],
+    });
+    const skillFile = plan.files.find((f) => f.skill === "drive");
+    assert.ok(skillFile, "expected drive SKILL.md in plan");
+    assert.ok(
+      skillFile.dest.startsWith(join(home, ".agents", "skills", "drive")),
+      `codex-cli adapter must write under ~/.agents/skills/, got: ${skillFile.dest}`,
+    );
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("planInstall rejects unknown skill names with the available list in the error", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-install-"));
+  try {
+    await assert.rejects(
+      () =>
+        planInstall({
+          packageRoot: ROOT,
+          home,
+          adapter: "claude-code",
+          skillsFilter: ["this-skill-does-not-exist"],
+        }),
+      (err) => {
+        assert.match(err.message, /this-skill-does-not-exist/);
+        assert.match(err.message, /available:/);
+        return true;
+      },
+    );
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("planInstall rejects unsupported adapters with a list of valid ids", async () => {
+  await assert.rejects(
+    () =>
+      planInstall({
+        packageRoot: ROOT,
+        home: tmpdir(),
+        adapter: "vscode",
+        skillsFilter: null,
+      }),
+    (err) => {
+      assert.match(err.message, /unsupported adapter 'vscode'/);
+      for (const id of SUPPORTED_ADAPTERS) {
+        assert.match(err.message, new RegExp(id.replace(/-/g, "\\-")));
+      }
+      return true;
+    },
+  );
+});
+
+test("planInstall installs every available skill when no filter is supplied", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-install-"));
+  try {
+    const plan = await planInstall({
+      packageRoot: ROOT,
+      home,
+      adapter: "claude-code",
+      skillsFilter: null,
+    });
+    const skillSet = new Set(plan.files.map((f) => f.skill).filter(Boolean));
+    assert.ok(skillSet.size > 1, "expected the catalog to ship more than one skill");
+    assert.ok(skillSet.has("drive"));
+    assert.ok(skillSet.has("review"));
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("planInstall handles multi-skill filters", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-install-"));
+  try {
+    const plan = await planInstall({
+      packageRoot: ROOT,
+      home,
+      adapter: "claude-code",
+      skillsFilter: ["drive", "review"],
+    });
+    const skillSet = new Set(plan.files.map((f) => f.skill).filter(Boolean));
+    assert.deepEqual([...skillSet].sort(), ["drive", "review"]);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("parseFlags handles --flag=value and --flag value forms identically", () => {
+  const a = parseFlags(["--skills=drive,review"], {
+    skills: "string",
+  });
+  const b = parseFlags(["--skills", "drive,review"], {
+    skills: "string",
+  });
+  assert.equal(a.values.skills, "drive,review");
+  assert.equal(b.values.skills, "drive,review");
+});
+
+test("parseFlags routes -h to --help via the aliases table", () => {
+  const { values } = parseFlags(["-h"], { help: "boolean" }, { h: "help" });
+  assert.equal(values.help, true);
+});
+
+test("parseFlags surfaces unknown flags in the rejected array", () => {
+  const { rejected } = parseFlags(["--bogus"], { skills: "string" });
+  assert.deepEqual(rejected, ["--bogus"]);
+});
+
+test("assertNoForbiddenFlags blocks --target= and --target value", () => {
+  assert.throws(() => assertNoForbiddenFlags(["--target=/tmp"]), /not supported/);
+  assert.throws(() => assertNoForbiddenFlags(["--target", "/tmp"]), /not supported/);
+  assert.throws(() => assertNoForbiddenFlags(["--from=foo"]), /not supported/);
+  assert.throws(() => assertNoForbiddenFlags(["--to=foo"]), /not supported/);
+});
+
+test("planInstall with --skills filter includes only the named skill files", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-install-"));
+  try {
+    const plan = await planInstall({
+      packageRoot: ROOT,
+      home,
+      adapter: "claude-code",
+      skillsFilter: ["drive"],
+    });
+    for (const file of plan.files) {
+      // Skill files for drive should be the only per-skill entries.
+      if (file.skill) {
+        assert.equal(file.skill, "drive");
+      }
+    }
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});

--- a/tests/cli-migrate.test.mjs
+++ b/tests/cli-migrate.test.mjs
@@ -1,0 +1,175 @@
+// Unit + e2e tests for `npx @ozzylabs/skills migrate`.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { GENERIC_SKILLS, planMigrate, stripSyncYamlEntries } from "../bin/lib/migrate.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const BIN = join(ROOT, "bin", "install.mjs");
+
+/**
+ * Stage a fake consumer repo under `dir` so we can exercise migrate against
+ * a realistic layout. Returns nothing — callers assert on `dir` directly.
+ */
+async function stageConsumer(dir, opts = {}) {
+  const skills = opts.skills ?? ["drive", "review"];
+  for (const skill of skills) {
+    const claudeDir = join(dir, ".claude", "skills", skill);
+    const agentsDir = join(dir, ".agents", "skills", skill);
+    await mkdir(claudeDir, { recursive: true });
+    await mkdir(agentsDir, { recursive: true });
+    await writeFile(join(claudeDir, "SKILL.md"), `---\nname: ${skill}\n---\n`);
+    await writeFile(join(agentsDir, "SKILL.md"), `---\nname: ${skill}\n---\n`);
+  }
+  // Also seed a repo-local skill that migrate should NOT touch.
+  if (opts.repoLocal !== false) {
+    const local = join(dir, ".claude", "skills", "improve-loop");
+    await mkdir(local, { recursive: true });
+    await writeFile(join(local, "SKILL.md"), "---\nname: improve-loop\n---\n");
+  }
+  if (opts.syncYaml ?? true) {
+    await mkdir(join(dir, ".commons"), { recursive: true });
+    await writeFile(
+      join(dir, ".commons", "sync.yaml"),
+      [
+        "# leading comment",
+        "skills_commit: 0123456789abcdef0123456789abcdef01234567",
+        "skills_adapters:",
+        "  - claude-code",
+        "  - codex-cli",
+        "commons_commit: fedcba9876543210fedcba9876543210fedcba98",
+        "",
+      ].join("\n"),
+    );
+  }
+}
+
+function runCli(args, opts = {}) {
+  return spawnSync("node", [BIN, ...args], {
+    cwd: opts.cwd ?? ROOT,
+    env: {
+      ...process.env,
+      ...(opts.cwd ? { OZZYLABS_SKILLS_CWD: opts.cwd } : {}),
+    },
+    encoding: "utf8",
+  });
+}
+
+test("migrate --dry-run lists the generic skill dirs and reports sync.yaml change", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "skills-migrate-"));
+  try {
+    await stageConsumer(dir);
+    const result = runCli(["migrate", "--dry-run"], { cwd: dir });
+    assert.equal(result.status, 0, `cli failed: ${result.stderr}`);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.cwd, dir);
+    // drive + review staged under both .claude/skills/ and .agents/skills/
+    assert.equal(payload.will_remove.length, 4);
+    assert.ok(payload.will_remove.includes(".claude/skills/drive"));
+    assert.ok(payload.will_remove.includes(".claude/skills/review"));
+    assert.ok(payload.will_remove.includes(".agents/skills/drive"));
+    assert.ok(payload.will_remove.includes(".agents/skills/review"));
+    assert.equal(payload.sync_yaml.path, ".commons/sync.yaml");
+    assert.equal(payload.sync_yaml.will_modify, true);
+    // dry-run must not touch the disk
+    assert.ok(existsSync(join(dir, ".claude", "skills", "drive")));
+    assert.ok(existsSync(join(dir, ".agents", "skills", "drive")));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("migrate removes generic skill dirs but leaves repo-local skills intact", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "skills-migrate-"));
+  try {
+    await stageConsumer(dir);
+    const result = runCli(["migrate", "--force"], { cwd: dir });
+    assert.equal(result.status, 0, `cli failed: ${result.stderr}`);
+    // Generic skills gone.
+    assert.ok(!existsSync(join(dir, ".claude", "skills", "drive")));
+    assert.ok(!existsSync(join(dir, ".claude", "skills", "review")));
+    assert.ok(!existsSync(join(dir, ".agents", "skills", "drive")));
+    assert.ok(!existsSync(join(dir, ".agents", "skills", "review")));
+    // Repo-local skill remains.
+    assert.ok(existsSync(join(dir, ".claude", "skills", "improve-loop")));
+    // sync.yaml updated
+    const updated = readFileSync(join(dir, ".commons", "sync.yaml"), "utf8");
+    assert.doesNotMatch(updated, /skills_adapters\s*:/);
+    assert.doesNotMatch(updated, /skills_commit\s*:/);
+    // Unrelated keys preserved.
+    assert.match(updated, /commons_commit:/);
+    assert.match(updated, /# leading comment/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("migrate --keep-sync-yaml leaves .commons/sync.yaml untouched", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "skills-migrate-"));
+  try {
+    await stageConsumer(dir);
+    const original = readFileSync(join(dir, ".commons", "sync.yaml"), "utf8");
+    const result = runCli(["migrate", "--keep-sync-yaml", "--force"], { cwd: dir });
+    assert.equal(result.status, 0, `cli failed: ${result.stderr}`);
+    const after = readFileSync(join(dir, ".commons", "sync.yaml"), "utf8");
+    assert.equal(after, original);
+    // But the skill dirs were still removed.
+    assert.ok(!existsSync(join(dir, ".claude", "skills", "drive")));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("stripSyncYamlEntries removes both keys and their list continuations", () => {
+  const input = [
+    "skills_commit: abc",
+    "skills_adapters:",
+    "  - claude-code",
+    "  - codex-cli",
+    "commons_commit: def",
+    "",
+  ].join("\n");
+  const out = stripSyncYamlEntries(input);
+  assert.doesNotMatch(out, /skills_adapters/);
+  assert.doesNotMatch(out, /skills_commit/);
+  assert.match(out, /commons_commit: def/);
+});
+
+test("stripSyncYamlEntries is a no-op when keys are absent", () => {
+  const input = "commons_commit: deadbeef\n";
+  assert.equal(stripSyncYamlEntries(input), input);
+});
+
+test("GENERIC_SKILLS lists exactly the 10 documented generic skills", () => {
+  assert.deepEqual([...GENERIC_SKILLS].sort(), [
+    "commit",
+    "commit-conventions",
+    "drive",
+    "implement",
+    "lint",
+    "lint-rules",
+    "pr",
+    "review",
+    "ship",
+    "test",
+  ]);
+});
+
+test("planMigrate returns sane defaults when nothing matches", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "skills-migrate-"));
+  try {
+    const plan = await planMigrate({ cwd: dir, keepSyncYaml: false });
+    assert.equal(plan.cwd, dir);
+    assert.deepEqual(plan.skill_dirs_to_remove, []);
+    assert.equal(plan.sync_yaml.path, null);
+    assert.equal(plan.sync_yaml.will_modify, false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Wave 1 で merged された placeholder (`bin/install.mjs`) を本物の CLI dispatcher に置き換え、`install` と `migrate` の 2 サブコマンドを実装した。adapter ごとの出力 path は `scripts/adapters/{adapter-id}.mjs` の logic 由来の `dist/{adapter-id}/` ツリーをそのまま user HOME に転写する形で再利用している (重複実装なし)。

### install サブコマンド

```text
npx @ozzylabs/skills install [options]

Options:
  --skills=<list>      対象 skill (カンマ区切り、未指定で全 skill)
  --adapter=<id>       adapter id (claude-code / codex-cli / gemini-cli / copilot、default: claude-code)
  --dry-run            実コピーなし、JSON で計画のみ出力
  --upgrade            既存 install を上書き
  --force              確認 prompt をスキップ (非 TTY は自動 skip)
  -h, --help           ヘルプ表示
```

- 出力先は **常に user-scope** (`~/.claude/skills/<name>/`、`~/.agents/skills/<name>/` 等)
- `--target` / `--from` / `--to` / `--target-dir` / `--project` は意図的に拒否し、help と error message で user-only である旨を明記
- `--dry-run` 出力: `{target_dir, adapter, installed, upgraded, skipped, files}`

### migrate サブコマンド

```text
npx @ozzylabs/skills migrate [options]

Options:
  --dry-run            実操作なし、JSON で計画のみ出力
  --keep-sync-yaml     .commons/sync.yaml の skills_adapters / skills_commit を残す (default: 削除)
  --force              確認 prompt をスキップ (非 TTY は自動 skip)
  -h, --help           ヘルプ表示
```

- `cwd` 配下の `.claude/skills/` / `.agents/skills/` から汎用 10 skill (`commit` / `commit-conventions` / `drive` / `implement` / `lint` / `lint-rules` / `pr` / `review` / `ship` / `test`) を削除
- `.commons/sync.yaml` の `skills_adapters` / `skills_commit` ブロックを strip (継続行も含めて除去)
- リポ固有 skill (汎用 10 件以外) は touch しない

### 実装メモ

- `bin/install.mjs` を dispatcher に変更し、実装は `bin/lib/{args,install,migrate}.mjs` に分離した。`package.json#files` で `bin/` ディレクトリが npm payload に含まれるため、`bin/lib/` も自動的に同梱される。
- `--target` 等の禁止フラグは `assertNoForbiddenFlags()` で argv 解析前に検出し、専用エラーメッセージで案内する。
- CLI から `findPackageRoot()` で package root を辿るため、npx 経由でも skills repo の dev install でも同じコードが動く (`existsSync(package.json && dist)` の最初の親を採用)。

### Tests

新規 22 件、全 pass (`pnpm test` 全 142 件 pass)。

- `tests/cli-install.test.mjs` — planner / 引数解析 (11 件)
- `tests/cli-e2e.test.mjs` — `bin/install.mjs` を spawn し、`OZZYLABS_SKILLS_HOME` で隔離した一時 HOME に実 install (5 件)
- `tests/cli-migrate.test.mjs` — `bin/install.mjs migrate` を spawn し、`OZZYLABS_SKILLS_CWD` で隔離した consumer dir 模擬で実行 (6 件)

### Docs

- README.md / docs/README.ja.md に「CLI installer (user-scoped)」セクション追加
- AGENTS.md / CLAUDE.md に installer 例を追記

## Test plan

- [ ] `pnpm install --frozen-lockfile` が clean
- [ ] `pnpm test` の 142 件全 pass
- [ ] `pnpm run lint:all` warnings のみ (既存 yamllint 警告のみ)
- [ ] `npm pack --dry-run --json --ignore-scripts` で `bin/install.mjs` と `bin/lib/*.mjs` が payload に含まれる
- [ ] CI green

Refs: #96 (parent epic)
Closes #98