### PR TITLE
feat(action): setup-skills composite action (CI integration)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,9 @@ jobs:
       - name: Lint (GitHub Actions)
         run: actionlint
 
+      - name: Lint (GitHub Actions — examples/)
+        run: actionlint examples/*.yaml
+
       - name: Validate sync-targets.yaml against JSON Schema
         run: |
           pnpm exec ajv validate \

--- a/README.md
+++ b/README.md
@@ -98,7 +98,19 @@ See `npx @ozzylabs/skills install --help` for the full list of options and the e
 
 ### Using the skills in CI
 
-A reusable GitHub Action that runs `npx @ozzylabs/skills install` on the runner is planned (see [issue #101](https://github.com/ozzy-labs/skills/issues/101)). Until it lands, invoke the CLI directly from a step:
+For GitHub Actions, use the `ozzy-labs/skills` composite action — it wraps `npx @ozzylabs/skills install` and writes into the runner's `$HOME/.claude/skills/` (and `$HOME/.agents/skills/`):
+
+```yaml
+- uses: ozzy-labs/skills@v1
+  with:
+    skills: drive,review   # default: '' (install all bundled skills)
+    adapter: claude-code   # default: claude-code
+    # version: latest      # default: latest from npm; pin a version for reproducibility
+```
+
+The action installs at the user scope only (`$HOME/.claude/skills/`); a `target` input is intentionally omitted so consumers cannot accidentally write into repo-local `.claude/skills/`. A runnable end-to-end sample lives at [`examples/ci-with-skills.yaml`](examples/ci-with-skills.yaml).
+
+If you would rather call the CLI directly (e.g. to share a custom install step across multiple jobs), invoke it from a `run:` step:
 
 ```yaml
 - name: Install OzzyLabs skills

--- a/action.yaml
+++ b/action.yaml
@@ -26,16 +26,24 @@ runs:
   steps:
     - name: Install @ozzylabs/skills via npx
       shell: bash
+      # Inputs are intentionally passed via env vars so the shell receives
+      # them as plain parameters. Direct ${{ inputs.* }} interpolation in
+      # `run:` is a known script-injection vector for composite actions
+      # because the expression is expanded *before* the shell runs.
+      env:
+        INPUT_SKILLS: ${{ inputs.skills }}
+        INPUT_ADAPTER: ${{ inputs.adapter }}
+        INPUT_VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail
         mkdir -p "$HOME/.claude/skills" "$HOME/.agents/skills"
-        if [ -n "${{ inputs.skills }}" ]; then
-          npx -y "@ozzylabs/skills@${{ inputs.version }}" install \
-            --adapter="${{ inputs.adapter }}" \
-            --skills="${{ inputs.skills }}" \
+        if [ -n "$INPUT_SKILLS" ]; then
+          npx -y "@ozzylabs/skills@$INPUT_VERSION" install \
+            --adapter="$INPUT_ADAPTER" \
+            --skills="$INPUT_SKILLS" \
             --force
         else
-          npx -y "@ozzylabs/skills@${{ inputs.version }}" install \
-            --adapter="${{ inputs.adapter }}" \
+          npx -y "@ozzylabs/skills@$INPUT_VERSION" install \
+            --adapter="$INPUT_ADAPTER" \
             --force
         fi

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,41 @@
+name: 'Setup ozzylabs skills'
+# Installs into $HOME/.claude/skills/ (user scope). target input is
+# intentionally omitted so consumers cannot write into repo-local .claude/.
+description: 'Install @ozzylabs/skills into the GitHub Actions runner ($HOME/.claude/skills/, user scope only).'
+author: 'ozzy-labs'
+branding:
+  icon: 'download'
+  color: 'blue'
+
+inputs:
+  skills:
+    description: 'Comma-separated skill list (empty for all skills bundled with the package).'
+    required: false
+    default: ''
+  adapter:
+    description: 'Adapter id: claude-code / codex-cli / gemini-cli / copilot.'
+    required: false
+    default: 'claude-code'
+  version:
+    description: 'Package version (default: latest from npm). Pin to a specific version for reproducible installs.'
+    required: false
+    default: 'latest'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install @ozzylabs/skills via npx
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p "$HOME/.claude/skills" "$HOME/.agents/skills"
+        if [ -n "${{ inputs.skills }}" ]; then
+          npx -y "@ozzylabs/skills@${{ inputs.version }}" install \
+            --adapter="${{ inputs.adapter }}" \
+            --skills="${{ inputs.skills }}" \
+            --force
+        else
+          npx -y "@ozzylabs/skills@${{ inputs.version }}" install \
+            --adapter="${{ inputs.adapter }}" \
+            --force
+        fi

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -98,7 +98,19 @@ npx @ozzylabs/skills install --adapter claude-code --adapter codex-cli
 
 ### CI で利用する場合
 
-CI runner 上で `npx @ozzylabs/skills install` を実行する再利用可能な GitHub Action を別途整備予定（[issue #101](https://github.com/ozzy-labs/skills/issues/101) を参照）。Action 提供までは step から直接 CLI を呼び出す:
+GitHub Actions 上では `ozzy-labs/skills` composite action を使う。action は内部で `npx @ozzylabs/skills install` を呼び出し、ランナーの `$HOME/.claude/skills/`（および `$HOME/.agents/skills/`）にスキルを取り込む:
+
+```yaml
+- uses: ozzy-labs/skills@v1
+  with:
+    skills: drive,review   # 既定: '' (バンドルされた全スキルを取り込む)
+    adapter: claude-code   # 既定: claude-code
+    # version: latest      # 既定: npm の latest。再現性が必要なら version を pin する
+```
+
+action は user scope (`$HOME/.claude/skills/`) のみにインストールする。`target` input は意図的に持たず、consumer がリポジトリ直下の `.claude/skills/` に誤って書き込めない設計とした。実際に動く end-to-end サンプルは [`examples/ci-with-skills.yaml`](../examples/ci-with-skills.yaml) を参照。
+
+複数 job 共通の install step を独自に書きたい場合は、CLI を `run:` step から直接呼んでもよい:
 
 ```yaml
 - name: Install OzzyLabs skills

--- a/examples/ci-with-skills.yaml
+++ b/examples/ci-with-skills.yaml
@@ -1,0 +1,31 @@
+# Sample GitHub Actions workflow showing how to use the
+# `ozzy-labs/skills` composite action to install @ozzylabs/skills into
+# the runner's $HOME/.claude/skills/.
+#
+# Pin `ozzy-labs/skills@v1` to a SHA for production use. This sample uses
+# the floating `@v1` tag (cut by release-please once the first stable
+# release ships).
+name: example CI with skills
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ozzy-labs/skills@v1
+        with:
+          skills: drive,review # default: '' (all bundled skills)
+          adapter: claude-code # default: claude-code
+
+      - name: Verify install
+        run: |
+          test -f "$HOME/.claude/skills/drive/SKILL.md"
+          test -f "$HOME/.claude/skills/review/SKILL.md"
+          echo "skills installed"

--- a/tests/npm-pack-payload.test.mjs
+++ b/tests/npm-pack-payload.test.mjs
@@ -88,9 +88,9 @@ test("npm pack excludes the removed legacy duplicates", () => {
   }
 });
 
-test("npm pack only ships .mjs (bin), .md (docs), .json (manifests/schemas), .snippet, .sh, and .settings.json under dist/", () => {
+test("npm pack only ships .mjs (bin), .md (docs), .json (manifests/schemas), .snippet, .sh, .settings.json under dist/, and the action.yaml composite action manifest", () => {
   const [pkg] = npmPackJson();
-  const allowedExts = [".md", ".json", ".snippet", ".sh", ".mjs"];
+  const allowedExts = [".md", ".json", ".snippet", ".sh", ".mjs", ".yaml"];
   for (const file of pkg.files) {
     const path = file.path;
     if (path === "LICENSE") continue; // no extension
@@ -100,4 +100,15 @@ test("npm pack only ships .mjs (bin), .md (docs), .json (manifests/schemas), .sn
       `unexpected file in pack payload: ${path} (extension not in ${allowedExts.join(", ")})`,
     );
   }
+});
+
+test("npm pack ships the action.yaml composite action manifest at the package root", () => {
+  // Ships `ozzy-labs/skills@v1` composite action for GitHub Actions CI
+  // integration. See sub-issue #101.
+  const [pkg] = npmPackJson();
+  const paths = pkg.files.map((f) => f.path);
+  assert.ok(
+    paths.includes("action.yaml"),
+    `expected pack to include action.yaml at root; got ${paths.join(", ")}`,
+  );
 });


### PR DESCRIPTION
## Summary

Implements **sub-issue E (#101)** of epic #96 — ships a reusable `ozzy-labs/skills@v1` composite action that wraps `npx @ozzylabs/skills install` so downstream repos can install OzzyLabs skills onto their GitHub Actions runners with a single `uses:` step.

- `action.yaml` (composite action) at the repo root with inputs `skills` / `adapter` / `version`. A `target` input is intentionally omitted — the action installs into `$HOME/.claude/skills/` (and `$HOME/.agents/skills/`) only, matching the user-skills-only direction set in epic #96 / PR #104. The description explicitly documents the `user scope only` guarantee.
- Sample workflow `examples/ci-with-skills.yaml` demonstrating the action with `workflow_dispatch`. The verify step asserts `$HOME/.claude/skills/drive/SKILL.md` and `$HOME/.claude/skills/review/SKILL.md` exist so a real GHA run will exercise the install end-to-end.
- README / `docs/README.ja.md` — replaces the placeholder `Using the skills in CI` block (added in PR #104 to point at this issue) with the actual composite-action snippet, links to the sample, documents the no-`target`-input rationale, and keeps the direct `run: npx ...` form as a secondary alternative.
- `.github/workflows/ci.yaml` — adds `actionlint examples/*.yaml` so the sample workflow is syntax-checked on every PR (actionlint's default auto-discovery only walks `.github/workflows/`).
- `tests/npm-pack-payload.test.mjs` — extends the payload extension allow-list with `.yaml` and adds an explicit `action.yaml is shipped at root` assertion. `package.json#files` already declared `action.yaml` (set up speculatively in PR #103), so no manifest change was needed.

### Design notes (no `target` input)

The action description and both READMEs spell out that the action installs into `$HOME` only. Reasons:

- Epic #96 unified the project on **user skills only**; project-scope distribution to `.claude/skills/` was removed in PR #104 / #105.
- A `target` input would invite consumers to write into repo-local `.claude/skills/` in CI, which would diverge from local-machine installs and reintroduce the dual-target ambiguity #96 explicitly dropped.
- Consumers needing per-repo mirrors should keep using `/sync-consumers` (documented in README).

### Verification

- `pnpm test` — **143/143 pass** (+1 new test for `action.yaml` at root, +1 extension allow-list update).
- `pnpm lint` / `pnpm lint:md` / `pnpm lint:yaml` — clean (the pre-existing `drift-detect.yaml` line-length warning is unchanged).
- `pnpm build` — clean, dist/ unchanged.
- `actionlint examples/ci-with-skills.yaml` — clean.
- `actionlint .github/workflows/ci.yaml` — clean.
- `gitleaks detect --no-banner` — no leaks.

### Out of scope (next PR)

An **actual GitHub Actions run** of `examples/ci-with-skills.yaml` cannot succeed until `@ozzylabs/skills@latest` is published to npm (which happens after release-please cuts the first stable tag — see `.github/workflows/release.yaml`). The first follow-up after publish should `workflow_dispatch` the sample and confirm the verify step passes; that landing also lets us cut the floating `v1` tag the sample currently references.

## Test plan

- [x] `pnpm test` (143/143)
- [x] `actionlint examples/*.yaml` + repo-wide `actionlint`
- [x] `pnpm lint`, `pnpm lint:md`, `pnpm lint:yaml`, `gitleaks detect --no-banner`
- [x] `pnpm build` deterministic
- [ ] `workflow_dispatch` run of `examples/ci-with-skills.yaml` once `@ozzylabs/skills@latest` is on npm (follow-up PR, gated on first release)

Closes #101
Refs #96