### PR TITLE
chore: ignore Claude Code runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ Thumbs.db
 
 # Dependencies
 node_modules/
+
+# Claude Code runtime artifacts
+.claude/scheduled_tasks.lock
+.claude/worktrees/


### PR DESCRIPTION
## 概要

Claude Code のマルチセッション / オーケストレーション運用で生成される runtime artifact を `.gitignore` に追加する。

- `.claude/scheduled_tasks.lock` — routines のロックファイル（マルチセッション監査 2026-06-07 で untracked 残留を観測）
- `.claude/worktrees/` — Agent 隔離用 worktree（本 PR 作業中にも untracked で出現することを実証済み）

Closes #110

## 検証

- `git status --short` で `.claude/worktrees/` が untracked 表示されること（変更前）→ 変更後は非表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)