### PR TITLE
ci: exempt bot branch prefixes from branch-name check

### DIFF
--- a/.commons/sync.yaml
+++ b/.commons/sync.yaml
@@ -11,7 +11,6 @@ pinned:
   - biome.json
   - renovate.json
   - .gitignore
-  - .github/workflows/pr-check.yaml
   - .github/workflows/sync-commons.yaml
   - .agents/skills/README.md
   - .agents/skills/commit-conventions/SKILL.md

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -40,10 +40,30 @@ jobs:
         with:
           script: |
             const branch = context.payload.pull_request.head.ref;
+            const actor = context.payload.pull_request.user?.login ?? '';
             const pattern = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore)\/.+/;
 
             if (branch === 'main') {
               core.info('Branch is main, skipping check');
+              return;
+            }
+
+            if (branch.startsWith('release-please--')) {
+              core.info('Branch is a release-please auto PR, skipping check');
+              return;
+            }
+
+            if (actor === 'dependabot[bot]' || branch.startsWith('dependabot/')) {
+              core.info(`Branch is managed by Dependabot (${branch}), skipping check`);
+              return;
+            }
+
+            // Claude Code's GitHub app creates PRs from branches like
+            // `claude/<slug>-<id>`. The naming is bot-controlled and does
+            // not match the type/description convention; skip the check
+            // for those PRs the same way Dependabot is exempted.
+            if (branch.startsWith('claude/')) {
+              core.info(`Branch is managed by Claude Code (${branch}), skipping check`);
               return;
             }
 


### PR DESCRIPTION
## 背景

Claude mobile app / web (claude.ai/code) は実装 PR を `claude/<slug>` ブランチから開くが、この prefix は **bot 制御で設定変更不可**（cloud セッションに branch-prefix 設定が無い／feature request #25902・#27403・#42365 オープン中）。一方 `pr-check.yaml` の `branch-name-check` は `^(feat|fix|…)\/.+` のみ許可するため、mobile 由来 PR がこのジョブで落ちていた。

## 変更

`ozzy-labs/commons` の SSOT `pr-check.yaml` は **PR #123 (2026-05-08) で既に `claude/`・`dependabot/`・`release-please--` を exempt 済み**。しかし本 repo は `.github/workflows/pr-check.yaml` を `.commons/sync.yaml` の `pinned`（= sync 除外）に登録していたため、#123 以前の古い copy で凍結されていた。

- `.commons/sync.yaml`: `pinned` から `.github/workflows/pr-check.yaml` を削除（以後 commons 追従）
- `.github/workflows/pr-check.yaml`: commons SSOT のロジックに同期（`claude/`・`dependabot/`・`release-please--` を skip）

squash merge 運用のため、ブランチ名は main 履歴に残らず squash commit には PR タイトル（Conventional Commits 検証は維持）が使われる。よって bot 生成ブランチの exempt は履歴の清潔さを損なわない。

## 検証

- `actionlint` / `yamllint -c .yamllint.yaml`: OK
- 変更後の `pr-check.yaml` 本文が commons SSOT と一致（次回 `Sync commons` で drift PR が出ない）
- `biome check` / build drift なし / `node --test`: 151 pass

## フォローアップ（本 PR 対象外）

- consumer repo（`pr-check.yaml` を pin していない repo）は次回 `Sync commons`（毎週月曜 cron）or `gh workflow run "Sync commons"` で本修正が自動反映される
- Renovate は default `renovate/` prefix のため commons の exempt に未含。bot prefix exempt を完全化するなら commons 側に `renovate/` skip を別途追加検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)