### PR TITLE
feat(build): add per-skill adapter gating

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,9 +56,9 @@ npx @ozzylabs/skills sync-project --target=./my-repo --skills=drive,implement,sh
 
 ## ディレクトリ構成
 
-- `src/skills/{name}/SKILL.md` — 正準スキル（編集はここ）
+- `src/skills/{name}/SKILL.md` — 正準スキル（編集はここ）。frontmatter `adapters`（カンマ区切り文字列・任意）で配信先アダプタを限定できる（例: `adapters: claude-code`）。未指定は全アダプタ配信。詳細は README.md「Adapter gating」を参照
 - `src/skills/{name}/SKILL.claude-code.md` — Claude Code 固有 wrapper（任意）。companion 仕様は README.md を参照
-- `src/skills/{name}/<extra>.md` — 任意の skill 内アセット（例: `review/perspectives/<axis>.md`）。`SKILL.md` / `SKILL.{adapter}.md` 以外のファイルは全配信先（`.claude/skills/{name}/<extra>.md`, `.agents/skills/{name}/<extra>.md` 等）に verbatim でコピーされる
+- `src/skills/{name}/<extra>.md` — 任意の skill 内アセット（例: `review/perspectives/<axis>.md`）。`SKILL.md` / `SKILL.{adapter}.md` 以外のファイルは、その skill が配信される各先（`.claude/skills/{name}/<extra>.md`, `.agents/skills/{name}/<extra>.md` 等）に verbatim でコピーされる（`adapters` で限定された skill は限定先のみ）
 - `src/agents/{name}.md` — Claude Code 専用 agent（[ADR-0026](https://github.com/ozzy-labs/handbook/blob/main/adr/0026-agent-distribution-via-skills-sync.md)）。`dist/claude-code/.claude/agents/{name}.md` のみに出力される
 - `dist/{adapter-id}/` — agent 別 adapter 出力（`claude-code` / `codex-cli` / `gemini-cli` / `copilot`）。これが npm payload の正準ペイロード
 - `.agents/skills/{name}/SKILL.md` / `.claude/skills/{name}/SKILL.md` — skills repo 自身が dogfood するための in-repo mirror（npm payload には含めない。`package.json#files` で除外）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@
 
 - `/drive` などの汎用 skill は **user skills** (`~/.claude/skills/`) として配置されることを想定。エンドユーザーは `npx @ozzylabs/skills install` で installation する
 - skills / commons リポ内部 (本リポ等) では project skills として `.claude/skills/` 配下に置かれている (build pipeline で SSOT から生成)
+- 特定アダプタ限定の skill は SSOT 側 frontmatter `adapters`（カンマ区切り・例 `adapters: claude-code`）で配信先を絞れる (詳細は AGENTS.md / README.md「Adapter gating」)
 - `/implement` — Issue または指示をもとに、ブランチ作成・実装
 - `/lint` — 全リンターを自動修正付きで実行
 - `/test` — ビルド・テスト・型チェックを実行

--- a/README.md
+++ b/README.md
@@ -172,6 +172,19 @@ Companion frontmatter contract:
 
 `name` is derived from the directory and must not appear in companion frontmatter.
 
+### Adapter gating
+
+A skill may restrict which adapters emit it via an optional `adapters` frontmatter field — the per-skill counterpart of `src/agents/` being Claude Code only. This is for skills that depend on a single agent's runtime (e.g. `usage-guard` needs Claude Code's OAuth usage endpoint + `ScheduleWakeup`) and must not ship to the others.
+
+Because the SKILL.md frontmatter parser is a flat, string-only subset of YAML (no arrays), `adapters` is a **comma-separated string**, not a YAML array:
+
+```yaml
+adapters: claude-code               # claude-code only
+adapters: claude-code, codex-cli    # both
+```
+
+When the field is absent, the skill is emitted by every adapter (the default). Known ids: `claude-code`, `codex-cli`, `gemini-cli`, `copilot`; an unknown id fails the build. Gating applies uniformly to per-skill outputs, the Gemini CLI / Copilot aggregate listings, the project-scope payload (`dist/claude-code-project/`), and the in-repo dogfood mirrors (an `adapters: claude-code` skill is kept out of `.agents/skills/`).
+
 ## Local development
 
 ```bash

--- a/scripts/adapters/claude-code.mjs
+++ b/scripts/adapters/claude-code.mjs
@@ -21,6 +21,7 @@
 // Reference: https://docs.claude.com/en/docs/claude-code/skills
 
 import { AdapterBase } from "../lib/adapter-base.mjs";
+import { filterSkillsForAdapter } from "../lib/adapter-gating.mjs";
 import { assertRequiredFields } from "../lib/frontmatter.mjs";
 
 /**
@@ -39,7 +40,8 @@ export class ClaudeCodeAdapter extends AdapterBase {
    * @returns {Promise<OutputFile[]>}
    */
   async generate(skills, options = {}) {
-    const sortedSkills = [...skills].sort((a, b) => a.name.localeCompare(b.name));
+    const allowed = filterSkillsForAdapter(skills, ClaudeCodeAdapter.id);
+    const sortedSkills = [...allowed].sort((a, b) => a.name.localeCompare(b.name));
     const outputs = [];
     for (const skill of sortedSkills) {
       const canonicalLabel = `src/skills/${skill.name}/SKILL.md`;

--- a/scripts/adapters/codex-cli.mjs
+++ b/scripts/adapters/codex-cli.mjs
@@ -11,6 +11,7 @@
 // skill's `.agents/skills/{name}/` directory.
 
 import { AdapterBase } from "../lib/adapter-base.mjs";
+import { filterSkillsForAdapter } from "../lib/adapter-gating.mjs";
 import { renderAgentsMdSnippet } from "../lib/agents-md-snippet.mjs";
 import { assertRequiredFields } from "../lib/frontmatter.mjs";
 
@@ -29,7 +30,8 @@ export class CodexCliAdapter extends AdapterBase {
    * @returns {Promise<OutputFile[]>}
    */
   async generate(skills, _options = {}) {
-    const sorted = [...skills].sort((a, b) => a.name.localeCompare(b.name));
+    const allowed = filterSkillsForAdapter(skills, CodexCliAdapter.id);
+    const sorted = [...allowed].sort((a, b) => a.name.localeCompare(b.name));
     const outputs = [];
     for (const skill of sorted) {
       const label = `src/skills/${skill.name}/SKILL.md`;

--- a/scripts/adapters/copilot.mjs
+++ b/scripts/adapters/copilot.mjs
@@ -9,6 +9,7 @@
 // Reference: https://docs.github.com/en/copilot/customizing-copilot
 
 import { AdapterBase } from "../lib/adapter-base.mjs";
+import { filterSkillsForAdapter } from "../lib/adapter-gating.mjs";
 import { wrapSnippet } from "../lib/snippet.mjs";
 
 /**
@@ -37,10 +38,11 @@ export class CopilotAdapter extends AdapterBase {
    * @returns {Promise<OutputFile[]>}
    */
   async generate(skills) {
+    const allowed = filterSkillsForAdapter(skills, CopilotAdapter.id);
     return [
       {
         relativePath: ".github/copilot-instructions.md.snippet",
-        content: renderCopilotSnippet(skills),
+        content: renderCopilotSnippet(allowed),
       },
     ];
   }

--- a/scripts/adapters/gemini-cli.mjs
+++ b/scripts/adapters/gemini-cli.mjs
@@ -10,6 +10,7 @@
 
 import prettier from "prettier";
 import { AdapterBase } from "../lib/adapter-base.mjs";
+import { filterSkillsForAdapter } from "../lib/adapter-gating.mjs";
 import { renderAgentsMdSnippet } from "../lib/agents-md-snippet.mjs";
 
 /**
@@ -46,7 +47,8 @@ export class GeminiCliAdapter extends AdapterBase {
    * @returns {Promise<OutputFile[]>}
    */
   async generate(skills) {
-    const sorted = [...skills].sort((a, b) => a.name.localeCompare(b.name));
+    const allowed = filterSkillsForAdapter(skills, GeminiCliAdapter.id);
+    const sorted = [...allowed].sort((a, b) => a.name.localeCompare(b.name));
     return [
       {
         relativePath: ".gemini/settings.json",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -33,6 +33,7 @@ import { ClaudeCodeAdapter } from "./adapters/claude-code.mjs";
 import { CodexCliAdapter } from "./adapters/codex-cli.mjs";
 import { CopilotAdapter } from "./adapters/copilot.mjs";
 import { GeminiCliAdapter } from "./adapters/gemini-cli.mjs";
+import { isAdapterAllowed, parseAdapters } from "./lib/adapter-gating.mjs";
 import { assertRequiredFields, parseSkillDocument } from "./lib/frontmatter.mjs";
 import { rewriteSkillRefsToUserScope } from "./lib/user-scope-refs.mjs";
 
@@ -47,7 +48,15 @@ const DIST = join(ROOT, "dist");
 // slash commands (e.g. `/drive`, `/lint`). They are NOT shipped to npm —
 // `package.json#files` only includes `dist/`, `bin/`, `schemas/`, etc.
 const CLAUDE_DOGFOOD_TARGET = join(ROOT, ".claude", "skills");
-const DOGFOOD_TARGETS = [join(ROOT, ".agents", "skills"), CLAUDE_DOGFOOD_TARGET];
+// Each dogfood target mirrors the canonical skills for the adapter(s) that
+// read from it: `.agents/skills/` feeds Codex CLI + Gemini CLI, `.claude/skills/`
+// feeds Claude Code. A skill restricted via frontmatter `adapters` is mirrored
+// into a target only when it is allowed for at least one of that target's
+// adapters (e.g. an `adapters: claude-code` skill is kept out of `.agents/skills/`).
+const DOGFOOD_TARGETS = [
+  { dir: join(ROOT, ".agents", "skills"), adapterIds: ["codex-cli", "gemini-cli"] },
+  { dir: CLAUDE_DOGFOOD_TARGET, adapterIds: ["claude-code"] },
+];
 
 // Internal-use skills are kept in src/skills/ for skills/commons repo's own
 // dogfooding (via DOGFOOD_TARGETS) but MUST NOT be shipped to npm consumers.
@@ -141,6 +150,9 @@ async function loadSkills() {
     }
     const claudeCodeCompanion = await loadCompanion(name, "claude-code", ["description"]);
     const extraFiles = await loadExtraFiles(name);
+    // Validate + normalize the optional `adapters` gate once at load time so a
+    // typo'd adapter id fails the build early (rather than per-adapter later).
+    const adapters = parseAdapters(frontmatter, label);
     skills.push({
       name,
       description: frontmatter.description,
@@ -149,6 +161,7 @@ async function loadSkills() {
       raw,
       claudeCodeCompanion,
       extraFiles,
+      adapters,
     });
   }
   return skills;
@@ -181,17 +194,22 @@ async function writeDogfoodTargets(skills) {
   // These are excluded from the npm payload by `package.json#files` but kept
   // in the repo so skills repo can use its own slash commands.
   for (const target of DOGFOOD_TARGETS) {
-    if (existsSync(target)) {
-      await rm(target, { recursive: true, force: true });
+    if (existsSync(target.dir)) {
+      await rm(target.dir, { recursive: true, force: true });
     }
-    await mkdir(target, { recursive: true });
+    await mkdir(target.dir, { recursive: true });
     // The in-repo .claude/skills/ mirror is what this repo loads when it
     // dogfoods its own skills. Use the Claude Code companion when present so
     // dogfood stays in sync with what the Claude Code adapter ships to
     // consumers.
-    const useCompanion = target === CLAUDE_DOGFOOD_TARGET;
-    for (const skill of skills) {
-      const destDir = join(target, skill.name);
+    const useCompanion = target.dir === CLAUDE_DOGFOOD_TARGET;
+    // Mirror a skill only when it is allowed for one of this target's adapters
+    // (adapter gating — keeps e.g. `adapters: claude-code` skills out of `.agents/skills/`).
+    const targetSkills = skills.filter((skill) =>
+      target.adapterIds.some((id) => isAdapterAllowed(skill, id)),
+    );
+    for (const skill of targetSkills) {
+      const destDir = join(target.dir, skill.name);
       await mkdir(destDir, { recursive: true });
       const content =
         useCompanion && skill.claudeCodeCompanion ? skill.claudeCodeCompanion.raw : skill.raw;
@@ -304,7 +322,7 @@ async function main() {
   console.log(`✓ Built ${skills.length} skill(s), ${agents.length} agent(s)`);
   console.log("In-repo dogfood (excluded from npm payload):");
   for (const target of DOGFOOD_TARGETS) {
-    console.log(`  ${target.replace(ROOT, "").replace(/^\//, "")}`);
+    console.log(`  ${target.dir.replace(ROOT, "").replace(/^\//, "")}`);
   }
   console.log(`Adapters (npm payload, ${publicSkills.length} public skill(s)):`);
   for (const adapter of ADAPTERS) {

--- a/scripts/lib/adapter-gating.mjs
+++ b/scripts/lib/adapter-gating.mjs
@@ -1,0 +1,93 @@
+// Per-skill adapter gating.
+//
+// A skill may restrict which adapters emit it via a frontmatter `adapters`
+// field. The SKILL.md frontmatter parser is a flat, string-only subset of
+// YAML (no arrays — see frontmatter.mjs), so `adapters` is a COMMA-SEPARATED
+// string, not a YAML array:
+//
+//   adapters: claude-code
+//   adapters: claude-code, codex-cli
+//
+// When the field is absent, the skill is emitted by every adapter (the
+// default — preserves pre-gating behavior). An id outside the known set is a
+// build error so typos fail loudly.
+//
+// This is the per-skill counterpart of `src/agents/` being Claude Code only
+// (ADR-0026): some skills depend on a single agent's runtime (e.g.
+// `usage-guard` needs Claude Code's OAuth token + ScheduleWakeup) and must
+// not ship to adapters that cannot run them.
+
+export const KNOWN_ADAPTER_IDS = ["claude-code", "codex-cli", "gemini-cli", "copilot"];
+
+/**
+ * Parse the `adapters` frontmatter value into a normalized id list.
+ *
+ * @param {Record<string, string>} frontmatter
+ * @param {string} fileLabel  Path used in error messages.
+ * @returns {string[] | null}  The allowed adapter ids, or null when the field
+ *   is absent/empty (no restriction).
+ */
+export function parseAdapters(frontmatter, fileLabel) {
+  const raw = frontmatter?.adapters;
+  if (raw === undefined || raw === null || String(raw).trim() === "") return null;
+  const ids = String(raw)
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (ids.length === 0) return null;
+  for (const id of ids) {
+    if (!KNOWN_ADAPTER_IDS.includes(id)) {
+      throw new Error(
+        `${fileLabel}: unknown adapter id '${id}' in 'adapters' (known: ${KNOWN_ADAPTER_IDS.join(", ")})`,
+      );
+    }
+  }
+  return ids;
+}
+
+/**
+ * The allowed adapter ids for a skill (null = no restriction).
+ *
+ * Prefers a precomputed `skill.adapters` (set once at load time in build.mjs);
+ * falls back to parsing `skill.frontmatter` so the helper also works on skill
+ * objects constructed directly in tests.
+ *
+ * @param {{ name?: string, adapters?: string[] | null, frontmatter?: Record<string, string> }} skill
+ * @returns {string[] | null}
+ */
+export function skillAdapterIds(skill) {
+  if (skill.adapters !== undefined) return skill.adapters;
+  return parseAdapters(skill.frontmatter ?? {}, `skill '${skill.name ?? "<unknown>"}'`);
+}
+
+/**
+ * Whether a skill should be emitted for the given adapter id. Skills without
+ * an `adapters` restriction are allowed everywhere.
+ *
+ * @param {object} skill
+ * @param {string} adapterId
+ * @returns {boolean}
+ */
+export function isAdapterAllowed(skill, adapterId) {
+  const ids = skillAdapterIds(skill);
+  return ids === null || ids.includes(adapterId);
+}
+
+/**
+ * Filter a skill list down to those an adapter is allowed to emit.
+ *
+ * Called at the top of every adapter's `generate()` so gating applies
+ * uniformly to per-skill outputs (Claude Code `.claude/skills/`, Codex CLI
+ * `.agents/skills/`) and to aggregate listings (Gemini CLI / Copilot
+ * snippets). Because the build orchestrator routes both `writeAdapterOutputs`
+ * and `writeProjectScopeOutput` through `generate()`, gating here covers both
+ * paths — there is no separate gate to keep in sync.
+ *
+ * @template {object} S
+ * @param {S[]} skills
+ * @param {string} adapterId
+ * @returns {S[]}
+ */
+export function filterSkillsForAdapter(skills, adapterId) {
+  return skills.filter((s) => isAdapterAllowed(s, adapterId));
+}

--- a/tests/adapter-gating.test.mjs
+++ b/tests/adapter-gating.test.mjs
@@ -1,0 +1,172 @@
+// Per-skill adapter gating (issue #120).
+//
+// A skill may restrict which adapters emit it via a comma-separated
+// `adapters` frontmatter field. These tests cover the parser (C1: the
+// frontmatter parser is string-only, so `adapters` is a comma string, not a
+// YAML array) and the gating behavior across all four adapters plus the
+// dogfood/project-scope write paths (C2: gating lives in each adapter's
+// generate(), so writeAdapterOutputs and writeProjectScopeOutput are both
+// covered; the dogfood mirrors use the same isAdapterAllowed predicate).
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { ClaudeCodeAdapter } from "../scripts/adapters/claude-code.mjs";
+import { CodexCliAdapter } from "../scripts/adapters/codex-cli.mjs";
+import { CopilotAdapter } from "../scripts/adapters/copilot.mjs";
+import { GeminiCliAdapter } from "../scripts/adapters/gemini-cli.mjs";
+import {
+  filterSkillsForAdapter,
+  isAdapterAllowed,
+  parseAdapters,
+} from "../scripts/lib/adapter-gating.mjs";
+
+// Build a skill object the way build-pipeline tests do: frontmatter carries
+// the `adapters` string and `skill.adapters` is left undefined so the adapters
+// exercise the parse-from-frontmatter fallback (the real build precomputes
+// skill.adapters; both paths are asserted separately below).
+function skill(name, { description = "d", adapters } = {}, extraFiles = []) {
+  const fm = { name, description };
+  if (adapters !== undefined) fm.adapters = adapters;
+  const fmText = Object.entries(fm)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join("\n");
+  const raw = `---\n${fmText}\n---\nbody\n`;
+  return { name, description, frontmatter: fm, body: "body\n", raw, extraFiles };
+}
+
+// --- C1: parseAdapters encoding ---------------------------------------------
+
+test("parseAdapters returns null when the field is absent", () => {
+  assert.equal(parseAdapters({}, "f.md"), null);
+  assert.equal(parseAdapters({ adapters: "" }, "f.md"), null);
+  assert.equal(parseAdapters({ adapters: "   " }, "f.md"), null);
+});
+
+test("parseAdapters parses a single comma-separated id", () => {
+  assert.deepEqual(parseAdapters({ adapters: "claude-code" }, "f.md"), ["claude-code"]);
+});
+
+test("parseAdapters parses + trims multiple comma-separated ids", () => {
+  assert.deepEqual(parseAdapters({ adapters: "claude-code, codex-cli" }, "f.md"), [
+    "claude-code",
+    "codex-cli",
+  ]);
+});
+
+test("parseAdapters throws on an unknown adapter id", () => {
+  assert.throws(
+    () => parseAdapters({ adapters: "claude-code, bogus" }, "f.md"),
+    /unknown adapter id 'bogus'/,
+  );
+});
+
+// --- predicate helpers ------------------------------------------------------
+
+test("isAdapterAllowed: ungated skill is allowed everywhere", () => {
+  const s = skill("foo");
+  for (const id of ["claude-code", "codex-cli", "gemini-cli", "copilot"]) {
+    assert.equal(isAdapterAllowed(s, id), true);
+  }
+});
+
+test("isAdapterAllowed: gated skill is allowed only for listed adapters", () => {
+  const s = skill("usage-guard", { adapters: "claude-code" });
+  assert.equal(isAdapterAllowed(s, "claude-code"), true);
+  assert.equal(isAdapterAllowed(s, "codex-cli"), false);
+  assert.equal(isAdapterAllowed(s, "gemini-cli"), false);
+  assert.equal(isAdapterAllowed(s, "copilot"), false);
+});
+
+test("isAdapterAllowed: precomputed skill.adapters takes precedence", () => {
+  const s = { name: "x", description: "d", frontmatter: {}, adapters: ["codex-cli"] };
+  assert.equal(isAdapterAllowed(s, "codex-cli"), true);
+  assert.equal(isAdapterAllowed(s, "claude-code"), false);
+});
+
+test("filterSkillsForAdapter keeps only allowed skills", () => {
+  const skills = [skill("a"), skill("guard", { adapters: "claude-code" })];
+  assert.deepEqual(
+    filterSkillsForAdapter(skills, "codex-cli").map((s) => s.name),
+    ["a"],
+  );
+  assert.deepEqual(
+    filterSkillsForAdapter(skills, "claude-code").map((s) => s.name),
+    ["a", "guard"],
+  );
+});
+
+// --- C2: gating across adapters ---------------------------------------------
+
+const SKILLS = [skill("review"), skill("usage-guard", { adapters: "claude-code" })];
+
+test("Claude Code adapter emits a claude-code-gated skill", async () => {
+  const out = await new ClaudeCodeAdapter().generate(SKILLS);
+  assert.ok(out.some((o) => o.relativePath === ".claude/skills/usage-guard/SKILL.md"));
+  assert.ok(out.some((o) => o.relativePath === ".claude/skills/review/SKILL.md"));
+});
+
+test("Codex CLI adapter excludes a claude-code-gated skill (dir + snippet)", async () => {
+  const out = await new CodexCliAdapter().generate(SKILLS);
+  assert.ok(
+    !out.some((o) => o.relativePath.startsWith(".agents/skills/usage-guard/")),
+    "gated skill must not get a .agents/skills/ directory",
+  );
+  assert.ok(out.some((o) => o.relativePath === ".agents/skills/review/SKILL.md"));
+  const snippet = out.find((o) => o.relativePath === "AGENTS.md.snippet").content;
+  assert.ok(
+    !snippet.includes("usage-guard"),
+    "gated skill must not be listed in AGENTS.md.snippet",
+  );
+  assert.ok(snippet.includes("review"));
+});
+
+test("Gemini CLI adapter excludes a claude-code-gated skill from the snippet", async () => {
+  const out = await new GeminiCliAdapter().generate(SKILLS);
+  const snippet = out.find((o) => o.relativePath === "AGENTS.md.snippet").content;
+  assert.ok(!snippet.includes("usage-guard"));
+  assert.ok(snippet.includes("review"));
+});
+
+test("Copilot adapter excludes a claude-code-gated skill from the snippet", async () => {
+  const out = await new CopilotAdapter().generate(SKILLS);
+  const snippet = out.find((o) =>
+    o.relativePath.endsWith(".github/copilot-instructions.md.snippet"),
+  ).content;
+  assert.ok(!snippet.includes("usage-guard"));
+  assert.ok(snippet.includes("review"));
+});
+
+test("ungated skills are unaffected (regression: all four adapters emit them)", async () => {
+  const only = [skill("review")];
+  const claude = await new ClaudeCodeAdapter().generate(only);
+  const codex = await new CodexCliAdapter().generate(only);
+  assert.ok(claude.some((o) => o.relativePath === ".claude/skills/review/SKILL.md"));
+  assert.ok(codex.some((o) => o.relativePath === ".agents/skills/review/SKILL.md"));
+});
+
+// --- C2: project-scope + dogfood write paths --------------------------------
+
+test("project-scope path excludes a gated skill from .agents/skills/ (Codex side)", async () => {
+  // writeProjectScopeOutput ships ClaudeCodeAdapter output + the Codex
+  // adapter's `.agents/skills/` files. A claude-code-gated skill must appear
+  // in the Claude wrapper output but not in the Codex `.agents/skills/` files.
+  const claude = await new ClaudeCodeAdapter().generate(SKILLS);
+  const codexAgentsFiles = (await new CodexCliAdapter().generate(SKILLS)).filter((o) =>
+    o.relativePath.startsWith(".agents/skills/"),
+  );
+  assert.ok(claude.some((o) => o.relativePath === ".claude/skills/usage-guard/SKILL.md"));
+  assert.ok(
+    !codexAgentsFiles.some((o) => o.relativePath.startsWith(".agents/skills/usage-guard/")),
+  );
+});
+
+test("dogfood predicate keeps a claude-code-gated skill out of .agents/skills/", () => {
+  // build.mjs mirrors a skill into a dogfood target when it is allowed for at
+  // least one of that target's adapters. `.agents/skills/` feeds codex-cli +
+  // gemini-cli; `.claude/skills/` feeds claude-code.
+  const guard = skill("usage-guard", { adapters: "claude-code" });
+  const agentsTargetAllows = ["codex-cli", "gemini-cli"].some((id) => isAdapterAllowed(guard, id));
+  const claudeTargetAllows = ["claude-code"].some((id) => isAdapterAllowed(guard, id));
+  assert.equal(agentsTargetAllows, false, "gated skill excluded from .agents/skills/ dogfood");
+  assert.equal(claudeTargetAllows, true, "gated skill kept in .claude/skills/ dogfood");
+});


### PR DESCRIPTION
## Summary

Sub-issue A of epic #119 (usage-guard). Adds **per-skill adapter gating** so a skill can be restricted to specific adapters via a frontmatter `adapters` field — the per-skill counterpart of `src/agents/` being Claude Code only. Unblocks `usage-guard` (#121) claude-code-only delivery.

## Design (review corrections folded in)

- **C1 — encoding**: the SKILL.md frontmatter parser is a flat, string-only subset of YAML (no arrays), so `adapters` is a **comma-separated string** (`adapters: claude-code`, or `adapters: claude-code, codex-cli`), split + validated at build time. The parser is unchanged.
- **C2 — gating placement**: the filter lives **inside each adapter's `generate()`** (`scripts/lib/adapter-gating.mjs` → `filterSkillsForAdapter`), so both `writeAdapterOutputs` and `writeProjectScopeOutput` (which calls adapters directly) are covered. The in-repo dogfood mirrors use the same `isAdapterAllowed` predicate, keyed per target (`.agents/skills/` ← codex-cli + gemini-cli, `.claude/skills/` ← claude-code).
- Unknown adapter ids fail the build at load time. Skills without the field are emitted everywhere → no regression (build output / dist / dogfood unchanged).

## Changes

- `scripts/lib/adapter-gating.mjs` (new) — `parseAdapters` / `isAdapterAllowed` / `filterSkillsForAdapter` + `KNOWN_ADAPTER_IDS`
- `scripts/adapters/{claude-code,codex-cli,gemini-cli,copilot}.mjs` — filter skills at the top of `generate()` (per-skill dirs for claude/codex; aggregate listings for gemini/copilot)
- `scripts/build.mjs` — validate + store `skill.adapters` at load; per-target dogfood filter
- `tests/adapter-gating.test.mjs` (new) — parser, predicates, all four adapters, project-scope + dogfood paths
- `README.md` / `AGENTS.md` / `CLAUDE.md` — document the `adapters` field

## Acceptance criteria (#120)

- [x] `adapters: claude-code` skill not emitted to `dist/codex-cli|gemini-cli|copilot`
- [x] same skill emitted to `dist/claude-code`
- [x] project-scope payload excludes gated skill from `.agents/skills/`
- [x] dogfood (`.agents/skills/`) excludes gated skill
- [x] ungated skills unchanged (no regression)
- [x] unknown adapter id fails the build
- [x] `pnpm test` (177 pass) + `pnpm lint:all` green

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)