### PR TITLE
feat(usage-guard): add Claude-only usage-guard skill (usage-check + pause/resume engine)

### DIFF
--- a/.claude/skills/usage-guard/SKILL.md
+++ b/.claude/skills/usage-guard/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: usage-guard
+description: Claude Code の Usage Limit（5 時間 = Current / 週次 = Weekly）を監視し、95% 超過で作業を一時停止、リセットで枠が回復したら自動再開する pause/resume エンジン。drive 等の caller が checkpoint で Read するエンジン形態と、`/usage-guard "<継続コマンド>"` で任意作業を guard する単体形態を同梱。Claude 専用（OAuth 使用率エンドポイント + ScheduleWakeup 依存）。
+adapters: claude-code
+user-invocable: true
+argument-hint: "<継続コマンド>（空欄で status 確認のみ）"
+disable-model-invocation: true
+---
+
+# usage-guard - Usage Limit pause/resume エンジン
+
+Claude Code の Usage Limit が 100% に達するとセッションが中断される。本スキルは 100% 手前（既定 95%）で作業を一時停止し、リセットで枠が回復したら自動再開する仕組みを提供する。
+
+> **Claude 専用**: OAuth 使用率エンドポイント（`~/.claude/.credentials.json` のトークン）と `ScheduleWakeup` に依存するため、`adapters: claude-code` で gate している（Codex / Gemini / Copilot には配信しない）。
+>
+> **自己完結ドキュメント**: 本 SKILL.md は他ファイル（`.agents/skills/...` の canonical）を Read しない。gate により codex adapter の `.agents/` 出力が存在しないため、本体手順をすべてここに内包している。
+
+## シグナル取得: usage-check スクリプト
+
+判定の決定論部分は `usage-check.mjs` が担う。skill ディレクトリ直下に同梱され、user-scope では `~/.claude/skills/usage-guard/usage-check.mjs`、dogfood では `.claude/skills/usage-guard/usage-check.mjs` に置かれる。**実行時は本 SKILL.md と同じディレクトリの `usage-check.mjs`** を Bash で実行する:
+
+```bash
+node ~/.claude/skills/usage-guard/usage-check.mjs
+```
+
+> dogfood（skills/commons リポ内）で動かす場合はリポルートの `.claude/skills/usage-guard/usage-check.mjs` を実行する。どちらの環境でも「本 SKILL.md と同じ階層の `usage-check.mjs`」を指す。
+
+### 振る舞い
+
+- `~/.claude/.credentials.json` の `claudeAiOauth.accessToken` を**毎回読み直す**（`expiresAt` 失効を考慮）
+- `GET https://api.anthropic.com/api/oauth/usage`（ヘッダ `Authorization: Bearer` / `anthropic-beta: oauth-2025-04-20` / `User-Agent: claude-code/<version>`）で `five_hour` / `seven_day` の `utilization` と `resets_at` を 1 回で取得
+- 30–60s のローカルキャッシュ（`~/.claude/usage-guard/cache.json`、`.claude/skills/` 配下に置かない）で連打を防止。`#123` の PreToolUse hook と同じキャッシュを共有する
+- endpoint 失敗時は `~/.claude/projects/*/*.jsonl` の per-message `usage` + timestamp から 5h / 7d window を推定する JSONL フォールバック
+- endpoint と JSONL の**両方が失敗したら fail-open**（`ok: true`）+ stderr に警告（ガードが自バグで hard-stop しない）
+
+### 出力 JSON
+
+```json
+{
+  "five_hour": { "utilization": 0, "resets_at": "..." },
+  "seven_day": { "utilization": 0, "resets_at": "..." },
+  "ok": true,
+  "wait_seconds": 0,
+  "resets_at": null,
+  "source": "endpoint"
+}
+```
+
+- `ok`: **両枠の `utilization` が閾値未満**なら `true`
+- `wait_seconds` / `resets_at`: 超過枠の `resets_at` の**最遅**（最も遅くリセットする枠）から算出。`ok` のときは `wait_seconds: 0` / `resets_at: null`
+- `source`: `endpoint` / `jsonl` / `cache` / `fail-open`
+
+### 閾値
+
+既定 95%。環境変数 `USAGE_GUARD_THRESHOLD` で上書き可能（例 `USAGE_GUARD_THRESHOLD=80`）。
+
+## 軽量 wait-loop（共通ロジック）
+
+両形態が共有する停止/再開の中核:
+
+1. `usage-check.mjs` を実行して JSON を得る
+2. `ok` なら**通常進行**（継続コマンドを実行 / caller は次の checkpoint へ）
+3. `ok` が `false` なら `ScheduleWakeup(min(wait_seconds, 3600))` で heartbeat を仕込み、**待機する**
+   - 上限 3600s は ScheduleWakeup 1 回の最大待機。`wait_seconds` がそれより長ければ複数回に分けて再チェックする
+   - **待機中は再入しない**（予算を一切消費しない）
+4. 起床したら再び `usage-check.mjs` を実行し、`ok` になるまで 3〜4 を繰り返す
+5. `ok` になったら継続コマンドへ進む
+
+> `wait_seconds` は `resets_at` から算出するため秒精度ではない。ScheduleWakeup の発火も下限 + オーバーヘッドで多少遅れる（実機で 60s 要求に対し ~110s）。reset 待ちには十分な精度。
+
+## 利用形態 1: エンジン形態（呼び出し側が Read）
+
+drive（#122）等の caller が **resumable unit の境界（checkpoint）** で本 SKILL.md を Read し、上記 wait-loop を実行する。
+
+### checkpoint 規約
+
+- 停止は**常にクリーンに再入できる境界**で行う。mid-implement（PR 作成前など）では止めない
+- caller は各 unit の**入口**で usage-check を実行し、`ok` でなければ wait-loop に入る
+- 継続コマンドは **caller が供給**する。drive は冪等 resume（既存 PR を検出して Phase 3 から再開）なので、待機後の再実行をそのまま再開機構に流用する（例: `/drive --usage-guard <args>`）
+- drive のオーケストレーションモードでは wave 境界の粒度で呼ぶ。走行中の worker 内の超過は `#123` の PreToolUse hook が mid-unit ceiling として捕捉する
+
+## 利用形態 2: 単体形態 `/usage-guard "<継続コマンド>"`
+
+drive 非依存で、任意の長い作業を auto pause/resume で guard する（user-invocable）。
+
+### 引数
+
+- `$ARGUMENTS` を**継続コマンド**として解釈する
+- **空欄なら status 確認のみ**: `usage-check.mjs` を実行して現在の `five_hour` / `seven_day` の `utilization` と `ok` / `wait_seconds` を表示して終了する
+
+### 手順
+
+1. `usage-check.mjs` を実行する
+2. **両枠 `ok`** なら、継続コマンドを実行する（通常進行）
+3. **超過**なら:
+   - `ScheduleWakeup(min(wait_seconds, 3600))` で待機する（待機中は再入しない）
+   - 起床（回復検知）したら **`/usage-guard "<継続コマンド>"` を自己再入**する
+   - `ok` になるまで heartbeat を繰り返し、`ok` で継続コマンドを実行する
+
+### 継続コマンドの冪等性
+
+継続コマンドは**冪等前提**で扱う。待機を挟んで再実行されても安全であること（重複副作用を生まない / 進捗を検出して途中から再開できる）がユーザーの責任。
+
+- drive は元来冪等（既存 PR / ブランチを検出して再開）なので、`/usage-guard "/drive --usage-guard #123"` のように安全に巻ける
+- 汎用の長い作業（ビルド・バッチ等）を巻く場合は、再実行で壊れない設計か自分で確認すること
+
+### 実行例
+
+```text
+/usage-guard "/drive --usage-guard #123"
+/usage-guard ""                 # status 確認のみ
+USAGE_GUARD_THRESHOLD=80 /usage-guard "<継続コマンド>"   # 閾値を一時的に 80% へ
+```
+
+## PreToolUse hook との併用（推奨）
+
+本スキルの停止粒度は resumable unit の境界。長い unit 内での超過に備え、全 tool 呼び出し前に効く PreToolUse hook（`#123`）を mid-unit ceiling として併用することを推奨する（hook は同じ `~/.claude/usage-guard/cache.json` を読む）。hook の有効化手順は `#123` 実装時に本節へ追記する。
+
+## 注意事項
+
+- ガードは**自バグで hard-stop しない**: シグナル取得が全滅したら fail-open で作業を継続する（`source: "fail-open"` + stderr 警告）
+- 待機中は予算を消費しない（再入しない・heartbeat のみ）
+- 長い待機は live セッションで吸収する前提（WSL + 常時起動）

--- a/.claude/skills/usage-guard/usage-check.mjs
+++ b/.claude/skills/usage-guard/usage-check.mjs
@@ -1,0 +1,429 @@
+#!/usr/bin/env node
+// usage-check — deterministic Claude Code budget signal for usage-guard.
+//
+// Reads the live OAuth usage utilization for the two limit windows Claude Code
+// enforces (5-hour "Current" and 7-day "Weekly") and decides whether work may
+// continue (both windows below the threshold) or must pause. Shipped verbatim
+// as a skill extra file alongside SKILL.md (user scope under HOME, dogfood under
+// the repo) — it is always resolved as the sibling of SKILL.md.
+//
+// M2 (path-literal note): the build's rewriteSkillRefsToUserScope rewrites
+// skill-dir path literals (the `agents`/`claude` skills dirs). The HOME-anchored
+// paths used here (the credentials file, the projects transcripts dir, and the
+// usage-guard cache file — all under ~/.claude/ but NOT under a skills dir) do
+// NOT match that pattern, so they survive the dist build intact. Crucially, no
+// functional path literal here is written in the rewritable skills-dir form.
+//
+// Output (stdout, single JSON line):
+//   { five_hour, seven_day, ok, wait_seconds, resets_at, source }
+//   - five_hour / seven_day: { utilization (0-100), resets_at (ISO|null) }
+//   - ok:           both windows' utilization < threshold (default 95)
+//   - wait_seconds: seconds until the LATEST resets_at among exceeded windows
+//                   (0 when ok). Derived from `resets_at` minus now.
+//   - resets_at:    that same latest exceeded resets_at (null when ok)
+//   - source:       "endpoint" | "jsonl" | "fail-open" | "cache"
+//
+// Fail-open: if the endpoint fails AND the JSONL fallback fails, emit
+// { ok: true, ... source: "fail-open" } and a warning on stderr so the guard
+// never hard-stops on its own bug.
+//
+// This is a plain .mjs (NOT a Workflow script): Date.now() / real fetch / real
+// fs are fine. Pure/injectable functions are exported for tests.
+
+import { readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const USAGE_ENDPOINT = "https://api.anthropic.com/api/oauth/usage";
+const OAUTH_BETA = "oauth-2025-04-20";
+const CLAUDE_CODE_VERSION = "2.0.0";
+const DEFAULT_THRESHOLD = 95;
+const DEFAULT_CACHE_TTL_MS = 45_000; // 30–60s window so the #123 hook can share it.
+const FIVE_HOUR_MS = 5 * 60 * 60 * 1000;
+const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1000;
+
+// HOME-anchored paths, built with path.join so no rewritable skills-dir literal
+// ever appears in source (M2).
+const CREDENTIALS_PATH = join(homedir(), ".claude", ".credentials.json");
+const PROJECTS_DIR = join(homedir(), ".claude", "projects");
+// Cache lives OUTSIDE any skills dir so the #123 PreToolUse hook can read the
+// same file (and so it is never wiped when the dogfood skills mirror is
+// rebuilt).
+const CACHE_PATH = join(homedir(), ".claude", "usage-guard", "cache.json");
+
+/**
+ * Resolve the threshold (env override → default).
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {number}
+ */
+export function resolveThreshold(env = process.env) {
+  const raw = env?.USAGE_GUARD_THRESHOLD;
+  if (raw === undefined || raw === null || String(raw).trim() === "") return DEFAULT_THRESHOLD;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : DEFAULT_THRESHOLD;
+}
+
+/**
+ * Read + parse the OAuth access token, honoring `expiresAt`.
+ *
+ * Re-reads the credentials file on EVERY call (no caching of the token) so a
+ * refreshed token is picked up immediately.
+ *
+ * @param {object} [deps]
+ * @param {(p: string, enc: string) => Promise<string>} [deps.readFileImpl]
+ * @param {string} [deps.credentialsPath]
+ * @param {() => number} [deps.now]
+ * @returns {Promise<string|null>} the access token, or null when missing/expired.
+ */
+export async function readAccessToken({
+  readFileImpl = readFile,
+  credentialsPath = CREDENTIALS_PATH,
+  now = Date.now,
+} = {}) {
+  let parsed;
+  try {
+    parsed = JSON.parse(await readFileImpl(credentialsPath, "utf8"));
+  } catch {
+    return null;
+  }
+  const oauth = parsed?.claudeAiOauth;
+  const token = oauth?.accessToken;
+  if (!token) return null;
+  // expiresAt is epoch milliseconds. Treat an expired token as absent so we
+  // fall through to the JSONL fallback rather than sending a dead Bearer.
+  if (typeof oauth.expiresAt === "number" && oauth.expiresAt <= now()) return null;
+  return token;
+}
+
+/**
+ * Normalize one raw usage window (`{ utilization, resets_at }`-ish) into a
+ * stable `{ utilization, resets_at }` shape. Tolerates missing fields and
+ * `utilization` expressed as a 0–1 fraction (scaled to 0–100).
+ *
+ * @param {any} raw
+ * @returns {{ utilization: number, resets_at: string|null }}
+ */
+export function normalizeWindow(raw) {
+  if (!raw || typeof raw !== "object") return { utilization: 0, resets_at: null };
+  let util = Number(raw.utilization);
+  if (!Number.isFinite(util)) util = 0;
+  if (util > 0 && util <= 1) util *= 100; // fraction → percent
+  const resetsAt = raw.resets_at ?? raw.resetsAt ?? null;
+  return { utilization: util, resets_at: typeof resetsAt === "string" ? resetsAt : null };
+}
+
+/**
+ * Normalize the endpoint payload into `{ five_hour, seven_day }`.
+ * @param {any} payload
+ * @returns {{ five_hour: {utilization:number,resets_at:string|null}, seven_day: {utilization:number,resets_at:string|null} }}
+ */
+export function normalizeWindows(payload) {
+  return {
+    five_hour: normalizeWindow(payload?.five_hour ?? payload?.fiveHour),
+    seven_day: normalizeWindow(payload?.seven_day ?? payload?.sevenDay),
+  };
+}
+
+/**
+ * Decide ok / wait_seconds / resets_at from two normalized windows.
+ *
+ * `ok` = both windows' utilization < threshold. When NOT ok, wait_seconds and
+ * resets_at derive from the LATEST resets_at among the windows that exceeded
+ * the threshold (the soonest the work could safely resume against all
+ * exceeded windows).
+ *
+ * @param {{ five_hour: {utilization:number,resets_at:string|null}, seven_day: {utilization:number,resets_at:string|null} }} windows
+ * @param {object} [opts]
+ * @param {number} [opts.threshold]
+ * @param {() => number} [opts.now]
+ * @returns {{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null }}
+ */
+export function evaluate(windows, { threshold = DEFAULT_THRESHOLD, now = Date.now } = {}) {
+  const exceeded = [windows.five_hour, windows.seven_day].filter((w) => w.utilization >= threshold);
+  const ok = exceeded.length === 0;
+  let resetsAt = null;
+  let waitSeconds = 0;
+  if (!ok) {
+    // Latest resets_at among exceeded windows (max epoch); ignore unparseable.
+    let latestMs = null;
+    for (const w of exceeded) {
+      if (!w.resets_at) continue;
+      const ms = Date.parse(w.resets_at);
+      if (Number.isNaN(ms)) continue;
+      if (latestMs === null || ms > latestMs) {
+        latestMs = ms;
+        resetsAt = w.resets_at;
+      }
+    }
+    if (latestMs !== null) {
+      waitSeconds = Math.max(0, Math.ceil((latestMs - now()) / 1000));
+    }
+  }
+  return {
+    five_hour: windows.five_hour,
+    seven_day: windows.seven_day,
+    ok,
+    wait_seconds: waitSeconds,
+    resets_at: resetsAt,
+  };
+}
+
+/**
+ * Fetch raw usage windows from the OAuth endpoint.
+ *
+ * @param {string} token
+ * @param {object} [deps]
+ * @param {typeof fetch} [deps.fetchImpl]
+ * @returns {Promise<{ five_hour: object, seven_day: object }>}
+ */
+export async function fetchEndpointUsage(token, { fetchImpl = fetch } = {}) {
+  const res = await fetchImpl(USAGE_ENDPOINT, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "anthropic-beta": OAUTH_BETA,
+      "User-Agent": `claude-code/${CLAUDE_CODE_VERSION}`,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`usage endpoint HTTP ${res.status}`);
+  }
+  const payload = await res.json();
+  return normalizeWindows(payload);
+}
+
+/**
+ * Estimate usage windows from local session JSONL transcripts.
+ *
+ * Aggregates per-message `usage` token counts within the trailing 5h / 7d
+ * windows from the per-project session transcripts under
+ * `~/.claude/projects/<project>/<session>.jsonl`. This is a coarse fallback
+ * used only when the endpoint is unavailable; utilization is reported as a best-
+ * effort percentage of a configurable budget. resets_at is the window edge
+ * (oldest counted message + window length).
+ *
+ * @param {object} [deps]
+ * @param {(p: string, o?: any) => Promise<any>} [deps.readdirImpl]
+ * @param {(p: string, enc: string) => Promise<string>} [deps.readFileImpl]
+ * @param {string} [deps.projectsDir]
+ * @param {() => number} [deps.now]
+ * @param {number} [deps.fiveHourBudget]
+ * @param {number} [deps.sevenDayBudget]
+ * @returns {Promise<{ five_hour: object, seven_day: object }>}
+ */
+export async function aggregateJsonlUsage({
+  readdirImpl = readdir,
+  readFileImpl = readFile,
+  projectsDir = PROJECTS_DIR,
+  now = Date.now,
+  // Coarse token budgets for utilization estimation. Intentionally generous —
+  // the JSONL path only needs to be directionally correct as a fallback.
+  fiveHourBudget = 8_000_000,
+  sevenDayBudget = 80_000_000,
+} = {}) {
+  const nowMs = now();
+  const files = [];
+  const projectEntries = await readdirImpl(projectsDir, { withFileTypes: true });
+  for (const entry of projectEntries) {
+    if (!entry.isDirectory()) continue;
+    const dir = join(projectsDir, entry.name);
+    let inner;
+    try {
+      inner = await readdirImpl(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const f of inner) {
+      if (f.isFile() && f.name.endsWith(".jsonl")) files.push(join(dir, f.name));
+    }
+  }
+  if (files.length === 0) {
+    throw new Error("no JSONL transcripts found");
+  }
+
+  let fiveHourTokens = 0;
+  let sevenDayTokens = 0;
+  let oldestFiveHourMs = null;
+  let oldestSevenDayMs = null;
+
+  for (const file of files) {
+    let raw;
+    try {
+      raw = await readFileImpl(file, "utf8");
+    } catch {
+      continue;
+    }
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let rec;
+      try {
+        rec = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      const ts = rec?.timestamp;
+      const tsMs = typeof ts === "string" ? Date.parse(ts) : Number(ts);
+      if (!Number.isFinite(tsMs)) continue;
+      const usage = rec?.message?.usage ?? rec?.usage;
+      if (!usage) continue;
+      const tokens =
+        (Number(usage.input_tokens) || 0) +
+        (Number(usage.output_tokens) || 0) +
+        (Number(usage.cache_creation_input_tokens) || 0) +
+        (Number(usage.cache_read_input_tokens) || 0);
+      if (tokens <= 0) continue;
+      const age = nowMs - tsMs;
+      if (age >= 0 && age <= SEVEN_DAY_MS) {
+        sevenDayTokens += tokens;
+        if (oldestSevenDayMs === null || tsMs < oldestSevenDayMs) oldestSevenDayMs = tsMs;
+        if (age <= FIVE_HOUR_MS) {
+          fiveHourTokens += tokens;
+          if (oldestFiveHourMs === null || tsMs < oldestFiveHourMs) oldestFiveHourMs = tsMs;
+        }
+      }
+    }
+  }
+
+  const pct = (used, budget) => Math.min(100, (used / budget) * 100);
+  const resetsFrom = (oldestMs, windowMs) =>
+    oldestMs === null ? null : new Date(oldestMs + windowMs).toISOString();
+
+  return {
+    five_hour: {
+      utilization: pct(fiveHourTokens, fiveHourBudget),
+      resets_at: resetsFrom(oldestFiveHourMs, FIVE_HOUR_MS),
+    },
+    seven_day: {
+      utilization: pct(sevenDayTokens, sevenDayBudget),
+      resets_at: resetsFrom(oldestSevenDayMs, SEVEN_DAY_MS),
+    },
+  };
+}
+
+/**
+ * Read a cached result if it is fresh (within ttlMs).
+ * @param {object} deps
+ * @returns {Promise<object|null>}
+ */
+export async function readCache({
+  readFileImpl = readFile,
+  cachePath = CACHE_PATH,
+  ttlMs = DEFAULT_CACHE_TTL_MS,
+  now = Date.now,
+} = {}) {
+  try {
+    const parsed = JSON.parse(await readFileImpl(cachePath, "utf8"));
+    if (typeof parsed?.cached_at !== "number") return null;
+    if (now() - parsed.cached_at > ttlMs) return null;
+    return parsed.result ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist a result to the cache (best-effort; failures are swallowed).
+ * @param {object} result
+ * @param {object} deps
+ */
+export async function writeCache(
+  result,
+  { writeFileImpl, mkdirImpl, cachePath = CACHE_PATH, now = Date.now } = {},
+) {
+  if (!writeFileImpl) return;
+  try {
+    if (mkdirImpl) await mkdirImpl(join(cachePath, ".."), { recursive: true });
+    await writeFileImpl(cachePath, JSON.stringify({ cached_at: now(), result }));
+  } catch {
+    // best-effort cache; ignore.
+  }
+}
+
+/**
+ * Orchestrate a full usage check: cache → endpoint → JSONL → fail-open.
+ *
+ * Every dependency is injectable so tests can stub the endpoint, JSONL, creds,
+ * cache, and clock. `warn` defaults to stderr.
+ *
+ * @param {object} [deps]
+ * @returns {Promise<{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, source: string }>}
+ */
+export async function getUsage({
+  fetchImpl = fetch,
+  readFileImpl = readFile,
+  readdirImpl = readdir,
+  writeFileImpl,
+  mkdirImpl,
+  env = process.env,
+  now = Date.now,
+  credentialsPath = CREDENTIALS_PATH,
+  projectsDir = PROJECTS_DIR,
+  cachePath = CACHE_PATH,
+  cacheTtlMs = DEFAULT_CACHE_TTL_MS,
+  warn = (msg) => process.stderr.write(`${msg}\n`),
+} = {}) {
+  const threshold = resolveThreshold(env);
+
+  // 1. Fresh cache → return as-is (no endpoint re-fetch within TTL).
+  const cached = await readCache({ readFileImpl, cachePath, ttlMs: cacheTtlMs, now });
+  if (cached) return { ...cached, source: "cache" };
+
+  const evalOpts = { threshold, now };
+
+  // 2. Endpoint.
+  try {
+    const token = await readAccessToken({ readFileImpl, credentialsPath, now });
+    if (!token) throw new Error("no usable OAuth access token");
+    const windows = await fetchEndpointUsage(token, { fetchImpl });
+    const result = { ...evaluate(windows, evalOpts), source: "endpoint" };
+    await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
+    return result;
+  } catch (endpointErr) {
+    // 3. JSONL fallback.
+    try {
+      const windows = await aggregateJsonlUsage({ readdirImpl, readFileImpl, projectsDir, now });
+      const result = { ...evaluate(windows, evalOpts), source: "jsonl" };
+      await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
+      return result;
+    } catch (jsonlErr) {
+      // 4. Both failed → fail-open + warn (guard never hard-stops on its bug).
+      warn(
+        `usage-guard: signal unavailable (endpoint: ${endpointErr.message}; jsonl: ${jsonlErr.message}); failing open`,
+      );
+      return {
+        five_hour: { utilization: 0, resets_at: null },
+        seven_day: { utilization: 0, resets_at: null },
+        ok: true,
+        wait_seconds: 0,
+        resets_at: null,
+        source: "fail-open",
+      };
+    }
+  }
+}
+
+// CLI entry: print the usage JSON to stdout. Exit 0 always (fail-open ethos);
+// the JSON's `ok` field is the signal, not the exit code.
+async function main() {
+  const { mkdir, writeFile } = await import("node:fs/promises");
+  const result = await getUsage({ writeFileImpl: writeFile, mkdirImpl: mkdir });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+// Only run main() when executed directly (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    process.stderr.write(`usage-guard: fatal ${err.message}; failing open\n`);
+    process.stdout.write(
+      `${JSON.stringify({
+        five_hour: { utilization: 0, resets_at: null },
+        seven_day: { utilization: 0, resets_at: null },
+        ok: true,
+        wait_seconds: 0,
+        resets_at: null,
+        source: "fail-open",
+      })}\n`,
+    );
+  });
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@
 - `/health` — リポジトリ状態と skill catalog 整合性を 16 領域確認し、推奨アクションを inline 表示（`--deep` で `要確認` 項目を追加調査）
 - `/topics` — research-driven な GitHub topics 設定（ozzy-labs scope）。候補を公式制約検証 → 人気度測定（session キャッシュ）→ broad+narrow / 単数複数比較 → ozzy-labs 慣行ハードコードで選定し、`--apply` で `gh repo edit --add-topic` を実行、`--dry-run` で分析のみ
 - `/lessons-triage` — セッション教訓 queue（`~/.agents/lessons/queue.jsonl`）を消化し、User Skills 改善の教訓を承認制で ozzy-labs/skills へ issue 起票（HITL、起票のみ）
+- `/usage-guard` — **Claude 専用**。Usage Limit（5 時間 / 週次）を OAuth 使用率エンドポイントで監視し、95%（env で上書き可）超過で自動 pause→`ScheduleWakeup` で待機→回復後に自動再開。drive 等の caller が checkpoint で Read するエンジン形態と、`/usage-guard "<継続コマンド>"`（継続コマンド冪等前提）の単体形態を同梱。endpoint → JSONL → fail-open
 
 ## Skills の共通ルール
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This package backs the [OzzyLabs handbook ADR-0016](https://github.com/ozzy-labs
 
 ## Skills in v0.x
 
-14 skills total: 11 generic workflow skills shared across all OzzyLabs repositories, plus 3 internal-use skills (`health`, `topics`, `phase-issue`) bundled in the package. Only the 10 original generic skills are subject to `npx @ozzylabs/skills migrate` when removing the legacy project-scoped layout (`lessons-triage` was never distributed project-scoped).
+15 skills total: 11 generic workflow skills shared across all OzzyLabs repositories, 1 Claude-Code-only skill (`usage-guard`), plus 3 internal-use skills (`health`, `topics`, `phase-issue`) bundled in the package. Only the 10 original generic skills are subject to `npx @ozzylabs/skills migrate` when removing the legacy project-scoped layout (`lessons-triage` and `usage-guard` were never distributed project-scoped).
 
 | Skill | Description |
 | --- | --- |
@@ -27,6 +27,7 @@ This package backs the [OzzyLabs handbook ADR-0016](https://github.com/ozzy-labs
 | `ship` | Lint + commit + PR creation in one go |
 | `test` | Run build, tests, and type checks |
 | `topics` | Research-driven GitHub topics setup (ozzy-labs scope): validate official constraints (lowercase / hyphen / 50 chars / max 20), measure popularity via `gh api search/repositories` with session-scoped cache, decide broad+narrow / singular-plural pairs, and apply ozzy-labs hardcoded conventions (`claude-code` exception, `*-cli` suffix removal, `multi-agent` canonical form). `--apply` to commit, `--dry-run` for analysis only |
+| `usage-guard` | **Claude Code only.** Monitor the Usage Limit (5-hour / 7-day) via the OAuth usage endpoint and auto pause/resume work at 95% (env-overridable): exceeded → `ScheduleWakeup` until the latest exceeded window resets, then re-enter. Doubles as a pause/resume engine (callers like `drive` Read it at checkpoints) and a standalone `/usage-guard "<continuation>"` form (idempotent continuation assumed). Endpoint → JSONL fallback → fail-open |
 
 Repo-specific skills (e.g. `road`'s `improve-loop` / `road-repo-context`) are intentionally not included in this package.
 

--- a/dist/claude-code-project/.claude/skills/usage-guard/SKILL.md
+++ b/dist/claude-code-project/.claude/skills/usage-guard/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: usage-guard
+description: Claude Code の Usage Limit（5 時間 = Current / 週次 = Weekly）を監視し、95% 超過で作業を一時停止、リセットで枠が回復したら自動再開する pause/resume エンジン。drive 等の caller が checkpoint で Read するエンジン形態と、`/usage-guard "<継続コマンド>"` で任意作業を guard する単体形態を同梱。Claude 専用（OAuth 使用率エンドポイント + ScheduleWakeup 依存）。
+adapters: claude-code
+user-invocable: true
+argument-hint: "<継続コマンド>（空欄で status 確認のみ）"
+disable-model-invocation: true
+---
+
+# usage-guard - Usage Limit pause/resume エンジン
+
+Claude Code の Usage Limit が 100% に達するとセッションが中断される。本スキルは 100% 手前（既定 95%）で作業を一時停止し、リセットで枠が回復したら自動再開する仕組みを提供する。
+
+> **Claude 専用**: OAuth 使用率エンドポイント（`~/.claude/.credentials.json` のトークン）と `ScheduleWakeup` に依存するため、`adapters: claude-code` で gate している（Codex / Gemini / Copilot には配信しない）。
+>
+> **自己完結ドキュメント**: 本 SKILL.md は他ファイル（`.agents/skills/...` の canonical）を Read しない。gate により codex adapter の `.agents/` 出力が存在しないため、本体手順をすべてここに内包している。
+
+## シグナル取得: usage-check スクリプト
+
+判定の決定論部分は `usage-check.mjs` が担う。skill ディレクトリ直下に同梱され、user-scope では `~/.claude/skills/usage-guard/usage-check.mjs`、dogfood では `.claude/skills/usage-guard/usage-check.mjs` に置かれる。**実行時は本 SKILL.md と同じディレクトリの `usage-check.mjs`** を Bash で実行する:
+
+```bash
+node ~/.claude/skills/usage-guard/usage-check.mjs
+```
+
+> dogfood（skills/commons リポ内）で動かす場合はリポルートの `.claude/skills/usage-guard/usage-check.mjs` を実行する。どちらの環境でも「本 SKILL.md と同じ階層の `usage-check.mjs`」を指す。
+
+### 振る舞い
+
+- `~/.claude/.credentials.json` の `claudeAiOauth.accessToken` を**毎回読み直す**（`expiresAt` 失効を考慮）
+- `GET https://api.anthropic.com/api/oauth/usage`（ヘッダ `Authorization: Bearer` / `anthropic-beta: oauth-2025-04-20` / `User-Agent: claude-code/<version>`）で `five_hour` / `seven_day` の `utilization` と `resets_at` を 1 回で取得
+- 30–60s のローカルキャッシュ（`~/.claude/usage-guard/cache.json`、`.claude/skills/` 配下に置かない）で連打を防止。`#123` の PreToolUse hook と同じキャッシュを共有する
+- endpoint 失敗時は `~/.claude/projects/*/*.jsonl` の per-message `usage` + timestamp から 5h / 7d window を推定する JSONL フォールバック
+- endpoint と JSONL の**両方が失敗したら fail-open**（`ok: true`）+ stderr に警告（ガードが自バグで hard-stop しない）
+
+### 出力 JSON
+
+```json
+{
+  "five_hour": { "utilization": 0, "resets_at": "..." },
+  "seven_day": { "utilization": 0, "resets_at": "..." },
+  "ok": true,
+  "wait_seconds": 0,
+  "resets_at": null,
+  "source": "endpoint"
+}
+```
+
+- `ok`: **両枠の `utilization` が閾値未満**なら `true`
+- `wait_seconds` / `resets_at`: 超過枠の `resets_at` の**最遅**（最も遅くリセットする枠）から算出。`ok` のときは `wait_seconds: 0` / `resets_at: null`
+- `source`: `endpoint` / `jsonl` / `cache` / `fail-open`
+
+### 閾値
+
+既定 95%。環境変数 `USAGE_GUARD_THRESHOLD` で上書き可能（例 `USAGE_GUARD_THRESHOLD=80`）。
+
+## 軽量 wait-loop（共通ロジック）
+
+両形態が共有する停止/再開の中核:
+
+1. `usage-check.mjs` を実行して JSON を得る
+2. `ok` なら**通常進行**（継続コマンドを実行 / caller は次の checkpoint へ）
+3. `ok` が `false` なら `ScheduleWakeup(min(wait_seconds, 3600))` で heartbeat を仕込み、**待機する**
+   - 上限 3600s は ScheduleWakeup 1 回の最大待機。`wait_seconds` がそれより長ければ複数回に分けて再チェックする
+   - **待機中は再入しない**（予算を一切消費しない）
+4. 起床したら再び `usage-check.mjs` を実行し、`ok` になるまで 3〜4 を繰り返す
+5. `ok` になったら継続コマンドへ進む
+
+> `wait_seconds` は `resets_at` から算出するため秒精度ではない。ScheduleWakeup の発火も下限 + オーバーヘッドで多少遅れる（実機で 60s 要求に対し ~110s）。reset 待ちには十分な精度。
+
+## 利用形態 1: エンジン形態（呼び出し側が Read）
+
+drive（#122）等の caller が **resumable unit の境界（checkpoint）** で本 SKILL.md を Read し、上記 wait-loop を実行する。
+
+### checkpoint 規約
+
+- 停止は**常にクリーンに再入できる境界**で行う。mid-implement（PR 作成前など）では止めない
+- caller は各 unit の**入口**で usage-check を実行し、`ok` でなければ wait-loop に入る
+- 継続コマンドは **caller が供給**する。drive は冪等 resume（既存 PR を検出して Phase 3 から再開）なので、待機後の再実行をそのまま再開機構に流用する（例: `/drive --usage-guard <args>`）
+- drive のオーケストレーションモードでは wave 境界の粒度で呼ぶ。走行中の worker 内の超過は `#123` の PreToolUse hook が mid-unit ceiling として捕捉する
+
+## 利用形態 2: 単体形態 `/usage-guard "<継続コマンド>"`
+
+drive 非依存で、任意の長い作業を auto pause/resume で guard する（user-invocable）。
+
+### 引数
+
+- `$ARGUMENTS` を**継続コマンド**として解釈する
+- **空欄なら status 確認のみ**: `usage-check.mjs` を実行して現在の `five_hour` / `seven_day` の `utilization` と `ok` / `wait_seconds` を表示して終了する
+
+### 手順
+
+1. `usage-check.mjs` を実行する
+2. **両枠 `ok`** なら、継続コマンドを実行する（通常進行）
+3. **超過**なら:
+   - `ScheduleWakeup(min(wait_seconds, 3600))` で待機する（待機中は再入しない）
+   - 起床（回復検知）したら **`/usage-guard "<継続コマンド>"` を自己再入**する
+   - `ok` になるまで heartbeat を繰り返し、`ok` で継続コマンドを実行する
+
+### 継続コマンドの冪等性
+
+継続コマンドは**冪等前提**で扱う。待機を挟んで再実行されても安全であること（重複副作用を生まない / 進捗を検出して途中から再開できる）がユーザーの責任。
+
+- drive は元来冪等（既存 PR / ブランチを検出して再開）なので、`/usage-guard "/drive --usage-guard #123"` のように安全に巻ける
+- 汎用の長い作業（ビルド・バッチ等）を巻く場合は、再実行で壊れない設計か自分で確認すること
+
+### 実行例
+
+```text
+/usage-guard "/drive --usage-guard #123"
+/usage-guard ""                 # status 確認のみ
+USAGE_GUARD_THRESHOLD=80 /usage-guard "<継続コマンド>"   # 閾値を一時的に 80% へ
+```
+
+## PreToolUse hook との併用（推奨）
+
+本スキルの停止粒度は resumable unit の境界。長い unit 内での超過に備え、全 tool 呼び出し前に効く PreToolUse hook（`#123`）を mid-unit ceiling として併用することを推奨する（hook は同じ `~/.claude/usage-guard/cache.json` を読む）。hook の有効化手順は `#123` 実装時に本節へ追記する。
+
+## 注意事項
+
+- ガードは**自バグで hard-stop しない**: シグナル取得が全滅したら fail-open で作業を継続する（`source: "fail-open"` + stderr 警告）
+- 待機中は予算を消費しない（再入しない・heartbeat のみ）
+- 長い待機は live セッションで吸収する前提（WSL + 常時起動）

--- a/dist/claude-code-project/.claude/skills/usage-guard/usage-check.mjs
+++ b/dist/claude-code-project/.claude/skills/usage-guard/usage-check.mjs
@@ -1,0 +1,429 @@
+#!/usr/bin/env node
+// usage-check — deterministic Claude Code budget signal for usage-guard.
+//
+// Reads the live OAuth usage utilization for the two limit windows Claude Code
+// enforces (5-hour "Current" and 7-day "Weekly") and decides whether work may
+// continue (both windows below the threshold) or must pause. Shipped verbatim
+// as a skill extra file alongside SKILL.md (user scope under HOME, dogfood under
+// the repo) — it is always resolved as the sibling of SKILL.md.
+//
+// M2 (path-literal note): the build's rewriteSkillRefsToUserScope rewrites
+// skill-dir path literals (the `agents`/`claude` skills dirs). The HOME-anchored
+// paths used here (the credentials file, the projects transcripts dir, and the
+// usage-guard cache file — all under ~/.claude/ but NOT under a skills dir) do
+// NOT match that pattern, so they survive the dist build intact. Crucially, no
+// functional path literal here is written in the rewritable skills-dir form.
+//
+// Output (stdout, single JSON line):
+//   { five_hour, seven_day, ok, wait_seconds, resets_at, source }
+//   - five_hour / seven_day: { utilization (0-100), resets_at (ISO|null) }
+//   - ok:           both windows' utilization < threshold (default 95)
+//   - wait_seconds: seconds until the LATEST resets_at among exceeded windows
+//                   (0 when ok). Derived from `resets_at` minus now.
+//   - resets_at:    that same latest exceeded resets_at (null when ok)
+//   - source:       "endpoint" | "jsonl" | "fail-open" | "cache"
+//
+// Fail-open: if the endpoint fails AND the JSONL fallback fails, emit
+// { ok: true, ... source: "fail-open" } and a warning on stderr so the guard
+// never hard-stops on its own bug.
+//
+// This is a plain .mjs (NOT a Workflow script): Date.now() / real fetch / real
+// fs are fine. Pure/injectable functions are exported for tests.
+
+import { readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const USAGE_ENDPOINT = "https://api.anthropic.com/api/oauth/usage";
+const OAUTH_BETA = "oauth-2025-04-20";
+const CLAUDE_CODE_VERSION = "2.0.0";
+const DEFAULT_THRESHOLD = 95;
+const DEFAULT_CACHE_TTL_MS = 45_000; // 30–60s window so the #123 hook can share it.
+const FIVE_HOUR_MS = 5 * 60 * 60 * 1000;
+const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1000;
+
+// HOME-anchored paths, built with path.join so no rewritable skills-dir literal
+// ever appears in source (M2).
+const CREDENTIALS_PATH = join(homedir(), ".claude", ".credentials.json");
+const PROJECTS_DIR = join(homedir(), ".claude", "projects");
+// Cache lives OUTSIDE any skills dir so the #123 PreToolUse hook can read the
+// same file (and so it is never wiped when the dogfood skills mirror is
+// rebuilt).
+const CACHE_PATH = join(homedir(), ".claude", "usage-guard", "cache.json");
+
+/**
+ * Resolve the threshold (env override → default).
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {number}
+ */
+export function resolveThreshold(env = process.env) {
+  const raw = env?.USAGE_GUARD_THRESHOLD;
+  if (raw === undefined || raw === null || String(raw).trim() === "") return DEFAULT_THRESHOLD;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : DEFAULT_THRESHOLD;
+}
+
+/**
+ * Read + parse the OAuth access token, honoring `expiresAt`.
+ *
+ * Re-reads the credentials file on EVERY call (no caching of the token) so a
+ * refreshed token is picked up immediately.
+ *
+ * @param {object} [deps]
+ * @param {(p: string, enc: string) => Promise<string>} [deps.readFileImpl]
+ * @param {string} [deps.credentialsPath]
+ * @param {() => number} [deps.now]
+ * @returns {Promise<string|null>} the access token, or null when missing/expired.
+ */
+export async function readAccessToken({
+  readFileImpl = readFile,
+  credentialsPath = CREDENTIALS_PATH,
+  now = Date.now,
+} = {}) {
+  let parsed;
+  try {
+    parsed = JSON.parse(await readFileImpl(credentialsPath, "utf8"));
+  } catch {
+    return null;
+  }
+  const oauth = parsed?.claudeAiOauth;
+  const token = oauth?.accessToken;
+  if (!token) return null;
+  // expiresAt is epoch milliseconds. Treat an expired token as absent so we
+  // fall through to the JSONL fallback rather than sending a dead Bearer.
+  if (typeof oauth.expiresAt === "number" && oauth.expiresAt <= now()) return null;
+  return token;
+}
+
+/**
+ * Normalize one raw usage window (`{ utilization, resets_at }`-ish) into a
+ * stable `{ utilization, resets_at }` shape. Tolerates missing fields and
+ * `utilization` expressed as a 0–1 fraction (scaled to 0–100).
+ *
+ * @param {any} raw
+ * @returns {{ utilization: number, resets_at: string|null }}
+ */
+export function normalizeWindow(raw) {
+  if (!raw || typeof raw !== "object") return { utilization: 0, resets_at: null };
+  let util = Number(raw.utilization);
+  if (!Number.isFinite(util)) util = 0;
+  if (util > 0 && util <= 1) util *= 100; // fraction → percent
+  const resetsAt = raw.resets_at ?? raw.resetsAt ?? null;
+  return { utilization: util, resets_at: typeof resetsAt === "string" ? resetsAt : null };
+}
+
+/**
+ * Normalize the endpoint payload into `{ five_hour, seven_day }`.
+ * @param {any} payload
+ * @returns {{ five_hour: {utilization:number,resets_at:string|null}, seven_day: {utilization:number,resets_at:string|null} }}
+ */
+export function normalizeWindows(payload) {
+  return {
+    five_hour: normalizeWindow(payload?.five_hour ?? payload?.fiveHour),
+    seven_day: normalizeWindow(payload?.seven_day ?? payload?.sevenDay),
+  };
+}
+
+/**
+ * Decide ok / wait_seconds / resets_at from two normalized windows.
+ *
+ * `ok` = both windows' utilization < threshold. When NOT ok, wait_seconds and
+ * resets_at derive from the LATEST resets_at among the windows that exceeded
+ * the threshold (the soonest the work could safely resume against all
+ * exceeded windows).
+ *
+ * @param {{ five_hour: {utilization:number,resets_at:string|null}, seven_day: {utilization:number,resets_at:string|null} }} windows
+ * @param {object} [opts]
+ * @param {number} [opts.threshold]
+ * @param {() => number} [opts.now]
+ * @returns {{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null }}
+ */
+export function evaluate(windows, { threshold = DEFAULT_THRESHOLD, now = Date.now } = {}) {
+  const exceeded = [windows.five_hour, windows.seven_day].filter((w) => w.utilization >= threshold);
+  const ok = exceeded.length === 0;
+  let resetsAt = null;
+  let waitSeconds = 0;
+  if (!ok) {
+    // Latest resets_at among exceeded windows (max epoch); ignore unparseable.
+    let latestMs = null;
+    for (const w of exceeded) {
+      if (!w.resets_at) continue;
+      const ms = Date.parse(w.resets_at);
+      if (Number.isNaN(ms)) continue;
+      if (latestMs === null || ms > latestMs) {
+        latestMs = ms;
+        resetsAt = w.resets_at;
+      }
+    }
+    if (latestMs !== null) {
+      waitSeconds = Math.max(0, Math.ceil((latestMs - now()) / 1000));
+    }
+  }
+  return {
+    five_hour: windows.five_hour,
+    seven_day: windows.seven_day,
+    ok,
+    wait_seconds: waitSeconds,
+    resets_at: resetsAt,
+  };
+}
+
+/**
+ * Fetch raw usage windows from the OAuth endpoint.
+ *
+ * @param {string} token
+ * @param {object} [deps]
+ * @param {typeof fetch} [deps.fetchImpl]
+ * @returns {Promise<{ five_hour: object, seven_day: object }>}
+ */
+export async function fetchEndpointUsage(token, { fetchImpl = fetch } = {}) {
+  const res = await fetchImpl(USAGE_ENDPOINT, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "anthropic-beta": OAUTH_BETA,
+      "User-Agent": `claude-code/${CLAUDE_CODE_VERSION}`,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`usage endpoint HTTP ${res.status}`);
+  }
+  const payload = await res.json();
+  return normalizeWindows(payload);
+}
+
+/**
+ * Estimate usage windows from local session JSONL transcripts.
+ *
+ * Aggregates per-message `usage` token counts within the trailing 5h / 7d
+ * windows from the per-project session transcripts under
+ * `~/.claude/projects/<project>/<session>.jsonl`. This is a coarse fallback
+ * used only when the endpoint is unavailable; utilization is reported as a best-
+ * effort percentage of a configurable budget. resets_at is the window edge
+ * (oldest counted message + window length).
+ *
+ * @param {object} [deps]
+ * @param {(p: string, o?: any) => Promise<any>} [deps.readdirImpl]
+ * @param {(p: string, enc: string) => Promise<string>} [deps.readFileImpl]
+ * @param {string} [deps.projectsDir]
+ * @param {() => number} [deps.now]
+ * @param {number} [deps.fiveHourBudget]
+ * @param {number} [deps.sevenDayBudget]
+ * @returns {Promise<{ five_hour: object, seven_day: object }>}
+ */
+export async function aggregateJsonlUsage({
+  readdirImpl = readdir,
+  readFileImpl = readFile,
+  projectsDir = PROJECTS_DIR,
+  now = Date.now,
+  // Coarse token budgets for utilization estimation. Intentionally generous —
+  // the JSONL path only needs to be directionally correct as a fallback.
+  fiveHourBudget = 8_000_000,
+  sevenDayBudget = 80_000_000,
+} = {}) {
+  const nowMs = now();
+  const files = [];
+  const projectEntries = await readdirImpl(projectsDir, { withFileTypes: true });
+  for (const entry of projectEntries) {
+    if (!entry.isDirectory()) continue;
+    const dir = join(projectsDir, entry.name);
+    let inner;
+    try {
+      inner = await readdirImpl(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const f of inner) {
+      if (f.isFile() && f.name.endsWith(".jsonl")) files.push(join(dir, f.name));
+    }
+  }
+  if (files.length === 0) {
+    throw new Error("no JSONL transcripts found");
+  }
+
+  let fiveHourTokens = 0;
+  let sevenDayTokens = 0;
+  let oldestFiveHourMs = null;
+  let oldestSevenDayMs = null;
+
+  for (const file of files) {
+    let raw;
+    try {
+      raw = await readFileImpl(file, "utf8");
+    } catch {
+      continue;
+    }
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let rec;
+      try {
+        rec = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      const ts = rec?.timestamp;
+      const tsMs = typeof ts === "string" ? Date.parse(ts) : Number(ts);
+      if (!Number.isFinite(tsMs)) continue;
+      const usage = rec?.message?.usage ?? rec?.usage;
+      if (!usage) continue;
+      const tokens =
+        (Number(usage.input_tokens) || 0) +
+        (Number(usage.output_tokens) || 0) +
+        (Number(usage.cache_creation_input_tokens) || 0) +
+        (Number(usage.cache_read_input_tokens) || 0);
+      if (tokens <= 0) continue;
+      const age = nowMs - tsMs;
+      if (age >= 0 && age <= SEVEN_DAY_MS) {
+        sevenDayTokens += tokens;
+        if (oldestSevenDayMs === null || tsMs < oldestSevenDayMs) oldestSevenDayMs = tsMs;
+        if (age <= FIVE_HOUR_MS) {
+          fiveHourTokens += tokens;
+          if (oldestFiveHourMs === null || tsMs < oldestFiveHourMs) oldestFiveHourMs = tsMs;
+        }
+      }
+    }
+  }
+
+  const pct = (used, budget) => Math.min(100, (used / budget) * 100);
+  const resetsFrom = (oldestMs, windowMs) =>
+    oldestMs === null ? null : new Date(oldestMs + windowMs).toISOString();
+
+  return {
+    five_hour: {
+      utilization: pct(fiveHourTokens, fiveHourBudget),
+      resets_at: resetsFrom(oldestFiveHourMs, FIVE_HOUR_MS),
+    },
+    seven_day: {
+      utilization: pct(sevenDayTokens, sevenDayBudget),
+      resets_at: resetsFrom(oldestSevenDayMs, SEVEN_DAY_MS),
+    },
+  };
+}
+
+/**
+ * Read a cached result if it is fresh (within ttlMs).
+ * @param {object} deps
+ * @returns {Promise<object|null>}
+ */
+export async function readCache({
+  readFileImpl = readFile,
+  cachePath = CACHE_PATH,
+  ttlMs = DEFAULT_CACHE_TTL_MS,
+  now = Date.now,
+} = {}) {
+  try {
+    const parsed = JSON.parse(await readFileImpl(cachePath, "utf8"));
+    if (typeof parsed?.cached_at !== "number") return null;
+    if (now() - parsed.cached_at > ttlMs) return null;
+    return parsed.result ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist a result to the cache (best-effort; failures are swallowed).
+ * @param {object} result
+ * @param {object} deps
+ */
+export async function writeCache(
+  result,
+  { writeFileImpl, mkdirImpl, cachePath = CACHE_PATH, now = Date.now } = {},
+) {
+  if (!writeFileImpl) return;
+  try {
+    if (mkdirImpl) await mkdirImpl(join(cachePath, ".."), { recursive: true });
+    await writeFileImpl(cachePath, JSON.stringify({ cached_at: now(), result }));
+  } catch {
+    // best-effort cache; ignore.
+  }
+}
+
+/**
+ * Orchestrate a full usage check: cache → endpoint → JSONL → fail-open.
+ *
+ * Every dependency is injectable so tests can stub the endpoint, JSONL, creds,
+ * cache, and clock. `warn` defaults to stderr.
+ *
+ * @param {object} [deps]
+ * @returns {Promise<{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, source: string }>}
+ */
+export async function getUsage({
+  fetchImpl = fetch,
+  readFileImpl = readFile,
+  readdirImpl = readdir,
+  writeFileImpl,
+  mkdirImpl,
+  env = process.env,
+  now = Date.now,
+  credentialsPath = CREDENTIALS_PATH,
+  projectsDir = PROJECTS_DIR,
+  cachePath = CACHE_PATH,
+  cacheTtlMs = DEFAULT_CACHE_TTL_MS,
+  warn = (msg) => process.stderr.write(`${msg}\n`),
+} = {}) {
+  const threshold = resolveThreshold(env);
+
+  // 1. Fresh cache → return as-is (no endpoint re-fetch within TTL).
+  const cached = await readCache({ readFileImpl, cachePath, ttlMs: cacheTtlMs, now });
+  if (cached) return { ...cached, source: "cache" };
+
+  const evalOpts = { threshold, now };
+
+  // 2. Endpoint.
+  try {
+    const token = await readAccessToken({ readFileImpl, credentialsPath, now });
+    if (!token) throw new Error("no usable OAuth access token");
+    const windows = await fetchEndpointUsage(token, { fetchImpl });
+    const result = { ...evaluate(windows, evalOpts), source: "endpoint" };
+    await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
+    return result;
+  } catch (endpointErr) {
+    // 3. JSONL fallback.
+    try {
+      const windows = await aggregateJsonlUsage({ readdirImpl, readFileImpl, projectsDir, now });
+      const result = { ...evaluate(windows, evalOpts), source: "jsonl" };
+      await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
+      return result;
+    } catch (jsonlErr) {
+      // 4. Both failed → fail-open + warn (guard never hard-stops on its bug).
+      warn(
+        `usage-guard: signal unavailable (endpoint: ${endpointErr.message}; jsonl: ${jsonlErr.message}); failing open`,
+      );
+      return {
+        five_hour: { utilization: 0, resets_at: null },
+        seven_day: { utilization: 0, resets_at: null },
+        ok: true,
+        wait_seconds: 0,
+        resets_at: null,
+        source: "fail-open",
+      };
+    }
+  }
+}
+
+// CLI entry: print the usage JSON to stdout. Exit 0 always (fail-open ethos);
+// the JSON's `ok` field is the signal, not the exit code.
+async function main() {
+  const { mkdir, writeFile } = await import("node:fs/promises");
+  const result = await getUsage({ writeFileImpl: writeFile, mkdirImpl: mkdir });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+// Only run main() when executed directly (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    process.stderr.write(`usage-guard: fatal ${err.message}; failing open\n`);
+    process.stdout.write(
+      `${JSON.stringify({
+        five_hour: { utilization: 0, resets_at: null },
+        seven_day: { utilization: 0, resets_at: null },
+        ok: true,
+        wait_seconds: 0,
+        resets_at: null,
+        source: "fail-open",
+      })}\n`,
+    );
+  });
+}

--- a/dist/claude-code/.claude/skills/usage-guard/SKILL.md
+++ b/dist/claude-code/.claude/skills/usage-guard/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: usage-guard
+description: Claude Code の Usage Limit（5 時間 = Current / 週次 = Weekly）を監視し、95% 超過で作業を一時停止、リセットで枠が回復したら自動再開する pause/resume エンジン。drive 等の caller が checkpoint で Read するエンジン形態と、`/usage-guard "<継続コマンド>"` で任意作業を guard する単体形態を同梱。Claude 専用（OAuth 使用率エンドポイント + ScheduleWakeup 依存）。
+adapters: claude-code
+user-invocable: true
+argument-hint: "<継続コマンド>（空欄で status 確認のみ）"
+disable-model-invocation: true
+---
+
+# usage-guard - Usage Limit pause/resume エンジン
+
+Claude Code の Usage Limit が 100% に達するとセッションが中断される。本スキルは 100% 手前（既定 95%）で作業を一時停止し、リセットで枠が回復したら自動再開する仕組みを提供する。
+
+> **Claude 専用**: OAuth 使用率エンドポイント（`~/.claude/.credentials.json` のトークン）と `ScheduleWakeup` に依存するため、`adapters: claude-code` で gate している（Codex / Gemini / Copilot には配信しない）。
+>
+> **自己完結ドキュメント**: 本 SKILL.md は他ファイル（`~/.agents/skills/...` の canonical）を Read しない。gate により codex adapter の `.agents/` 出力が存在しないため、本体手順をすべてここに内包している。
+
+## シグナル取得: usage-check スクリプト
+
+判定の決定論部分は `usage-check.mjs` が担う。skill ディレクトリ直下に同梱され、user-scope では `~/.claude/skills/usage-guard/usage-check.mjs`、dogfood では `~/.claude/skills/usage-guard/usage-check.mjs` に置かれる。**実行時は本 SKILL.md と同じディレクトリの `usage-check.mjs`** を Bash で実行する:
+
+```bash
+node ~/.claude/skills/usage-guard/usage-check.mjs
+```
+
+> dogfood（skills/commons リポ内）で動かす場合はリポルートの `~/.claude/skills/usage-guard/usage-check.mjs` を実行する。どちらの環境でも「本 SKILL.md と同じ階層の `usage-check.mjs`」を指す。
+
+### 振る舞い
+
+- `~/.claude/.credentials.json` の `claudeAiOauth.accessToken` を**毎回読み直す**（`expiresAt` 失効を考慮）
+- `GET https://api.anthropic.com/api/oauth/usage`（ヘッダ `Authorization: Bearer` / `anthropic-beta: oauth-2025-04-20` / `User-Agent: claude-code/<version>`）で `five_hour` / `seven_day` の `utilization` と `resets_at` を 1 回で取得
+- 30–60s のローカルキャッシュ（`~/.claude/usage-guard/cache.json`、`~/.claude/skills/` 配下に置かない）で連打を防止。`#123` の PreToolUse hook と同じキャッシュを共有する
+- endpoint 失敗時は `~/.claude/projects/*/*.jsonl` の per-message `usage` + timestamp から 5h / 7d window を推定する JSONL フォールバック
+- endpoint と JSONL の**両方が失敗したら fail-open**（`ok: true`）+ stderr に警告（ガードが自バグで hard-stop しない）
+
+### 出力 JSON
+
+```json
+{
+  "five_hour": { "utilization": 0, "resets_at": "..." },
+  "seven_day": { "utilization": 0, "resets_at": "..." },
+  "ok": true,
+  "wait_seconds": 0,
+  "resets_at": null,
+  "source": "endpoint"
+}
+```
+
+- `ok`: **両枠の `utilization` が閾値未満**なら `true`
+- `wait_seconds` / `resets_at`: 超過枠の `resets_at` の**最遅**（最も遅くリセットする枠）から算出。`ok` のときは `wait_seconds: 0` / `resets_at: null`
+- `source`: `endpoint` / `jsonl` / `cache` / `fail-open`
+
+### 閾値
+
+既定 95%。環境変数 `USAGE_GUARD_THRESHOLD` で上書き可能（例 `USAGE_GUARD_THRESHOLD=80`）。
+
+## 軽量 wait-loop（共通ロジック）
+
+両形態が共有する停止/再開の中核:
+
+1. `usage-check.mjs` を実行して JSON を得る
+2. `ok` なら**通常進行**（継続コマンドを実行 / caller は次の checkpoint へ）
+3. `ok` が `false` なら `ScheduleWakeup(min(wait_seconds, 3600))` で heartbeat を仕込み、**待機する**
+   - 上限 3600s は ScheduleWakeup 1 回の最大待機。`wait_seconds` がそれより長ければ複数回に分けて再チェックする
+   - **待機中は再入しない**（予算を一切消費しない）
+4. 起床したら再び `usage-check.mjs` を実行し、`ok` になるまで 3〜4 を繰り返す
+5. `ok` になったら継続コマンドへ進む
+
+> `wait_seconds` は `resets_at` から算出するため秒精度ではない。ScheduleWakeup の発火も下限 + オーバーヘッドで多少遅れる（実機で 60s 要求に対し ~110s）。reset 待ちには十分な精度。
+
+## 利用形態 1: エンジン形態（呼び出し側が Read）
+
+drive（#122）等の caller が **resumable unit の境界（checkpoint）** で本 SKILL.md を Read し、上記 wait-loop を実行する。
+
+### checkpoint 規約
+
+- 停止は**常にクリーンに再入できる境界**で行う。mid-implement（PR 作成前など）では止めない
+- caller は各 unit の**入口**で usage-check を実行し、`ok` でなければ wait-loop に入る
+- 継続コマンドは **caller が供給**する。drive は冪等 resume（既存 PR を検出して Phase 3 から再開）なので、待機後の再実行をそのまま再開機構に流用する（例: `/drive --usage-guard <args>`）
+- drive のオーケストレーションモードでは wave 境界の粒度で呼ぶ。走行中の worker 内の超過は `#123` の PreToolUse hook が mid-unit ceiling として捕捉する
+
+## 利用形態 2: 単体形態 `/usage-guard "<継続コマンド>"`
+
+drive 非依存で、任意の長い作業を auto pause/resume で guard する（user-invocable）。
+
+### 引数
+
+- `$ARGUMENTS` を**継続コマンド**として解釈する
+- **空欄なら status 確認のみ**: `usage-check.mjs` を実行して現在の `five_hour` / `seven_day` の `utilization` と `ok` / `wait_seconds` を表示して終了する
+
+### 手順
+
+1. `usage-check.mjs` を実行する
+2. **両枠 `ok`** なら、継続コマンドを実行する（通常進行）
+3. **超過**なら:
+   - `ScheduleWakeup(min(wait_seconds, 3600))` で待機する（待機中は再入しない）
+   - 起床（回復検知）したら **`/usage-guard "<継続コマンド>"` を自己再入**する
+   - `ok` になるまで heartbeat を繰り返し、`ok` で継続コマンドを実行する
+
+### 継続コマンドの冪等性
+
+継続コマンドは**冪等前提**で扱う。待機を挟んで再実行されても安全であること（重複副作用を生まない / 進捗を検出して途中から再開できる）がユーザーの責任。
+
+- drive は元来冪等（既存 PR / ブランチを検出して再開）なので、`/usage-guard "/drive --usage-guard #123"` のように安全に巻ける
+- 汎用の長い作業（ビルド・バッチ等）を巻く場合は、再実行で壊れない設計か自分で確認すること
+
+### 実行例
+
+```text
+/usage-guard "/drive --usage-guard #123"
+/usage-guard ""                 # status 確認のみ
+USAGE_GUARD_THRESHOLD=80 /usage-guard "<継続コマンド>"   # 閾値を一時的に 80% へ
+```
+
+## PreToolUse hook との併用（推奨）
+
+本スキルの停止粒度は resumable unit の境界。長い unit 内での超過に備え、全 tool 呼び出し前に効く PreToolUse hook（`#123`）を mid-unit ceiling として併用することを推奨する（hook は同じ `~/.claude/usage-guard/cache.json` を読む）。hook の有効化手順は `#123` 実装時に本節へ追記する。
+
+## 注意事項
+
+- ガードは**自バグで hard-stop しない**: シグナル取得が全滅したら fail-open で作業を継続する（`source: "fail-open"` + stderr 警告）
+- 待機中は予算を消費しない（再入しない・heartbeat のみ）
+- 長い待機は live セッションで吸収する前提（WSL + 常時起動）

--- a/dist/claude-code/.claude/skills/usage-guard/usage-check.mjs
+++ b/dist/claude-code/.claude/skills/usage-guard/usage-check.mjs
@@ -1,0 +1,429 @@
+#!/usr/bin/env node
+// usage-check — deterministic Claude Code budget signal for usage-guard.
+//
+// Reads the live OAuth usage utilization for the two limit windows Claude Code
+// enforces (5-hour "Current" and 7-day "Weekly") and decides whether work may
+// continue (both windows below the threshold) or must pause. Shipped verbatim
+// as a skill extra file alongside SKILL.md (user scope under HOME, dogfood under
+// the repo) — it is always resolved as the sibling of SKILL.md.
+//
+// M2 (path-literal note): the build's rewriteSkillRefsToUserScope rewrites
+// skill-dir path literals (the `agents`/`claude` skills dirs). The HOME-anchored
+// paths used here (the credentials file, the projects transcripts dir, and the
+// usage-guard cache file — all under ~/.claude/ but NOT under a skills dir) do
+// NOT match that pattern, so they survive the dist build intact. Crucially, no
+// functional path literal here is written in the rewritable skills-dir form.
+//
+// Output (stdout, single JSON line):
+//   { five_hour, seven_day, ok, wait_seconds, resets_at, source }
+//   - five_hour / seven_day: { utilization (0-100), resets_at (ISO|null) }
+//   - ok:           both windows' utilization < threshold (default 95)
+//   - wait_seconds: seconds until the LATEST resets_at among exceeded windows
+//                   (0 when ok). Derived from `resets_at` minus now.
+//   - resets_at:    that same latest exceeded resets_at (null when ok)
+//   - source:       "endpoint" | "jsonl" | "fail-open" | "cache"
+//
+// Fail-open: if the endpoint fails AND the JSONL fallback fails, emit
+// { ok: true, ... source: "fail-open" } and a warning on stderr so the guard
+// never hard-stops on its own bug.
+//
+// This is a plain .mjs (NOT a Workflow script): Date.now() / real fetch / real
+// fs are fine. Pure/injectable functions are exported for tests.
+
+import { readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const USAGE_ENDPOINT = "https://api.anthropic.com/api/oauth/usage";
+const OAUTH_BETA = "oauth-2025-04-20";
+const CLAUDE_CODE_VERSION = "2.0.0";
+const DEFAULT_THRESHOLD = 95;
+const DEFAULT_CACHE_TTL_MS = 45_000; // 30–60s window so the #123 hook can share it.
+const FIVE_HOUR_MS = 5 * 60 * 60 * 1000;
+const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1000;
+
+// HOME-anchored paths, built with path.join so no rewritable skills-dir literal
+// ever appears in source (M2).
+const CREDENTIALS_PATH = join(homedir(), ".claude", ".credentials.json");
+const PROJECTS_DIR = join(homedir(), ".claude", "projects");
+// Cache lives OUTSIDE any skills dir so the #123 PreToolUse hook can read the
+// same file (and so it is never wiped when the dogfood skills mirror is
+// rebuilt).
+const CACHE_PATH = join(homedir(), ".claude", "usage-guard", "cache.json");
+
+/**
+ * Resolve the threshold (env override → default).
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {number}
+ */
+export function resolveThreshold(env = process.env) {
+  const raw = env?.USAGE_GUARD_THRESHOLD;
+  if (raw === undefined || raw === null || String(raw).trim() === "") return DEFAULT_THRESHOLD;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : DEFAULT_THRESHOLD;
+}
+
+/**
+ * Read + parse the OAuth access token, honoring `expiresAt`.
+ *
+ * Re-reads the credentials file on EVERY call (no caching of the token) so a
+ * refreshed token is picked up immediately.
+ *
+ * @param {object} [deps]
+ * @param {(p: string, enc: string) => Promise<string>} [deps.readFileImpl]
+ * @param {string} [deps.credentialsPath]
+ * @param {() => number} [deps.now]
+ * @returns {Promise<string|null>} the access token, or null when missing/expired.
+ */
+export async function readAccessToken({
+  readFileImpl = readFile,
+  credentialsPath = CREDENTIALS_PATH,
+  now = Date.now,
+} = {}) {
+  let parsed;
+  try {
+    parsed = JSON.parse(await readFileImpl(credentialsPath, "utf8"));
+  } catch {
+    return null;
+  }
+  const oauth = parsed?.claudeAiOauth;
+  const token = oauth?.accessToken;
+  if (!token) return null;
+  // expiresAt is epoch milliseconds. Treat an expired token as absent so we
+  // fall through to the JSONL fallback rather than sending a dead Bearer.
+  if (typeof oauth.expiresAt === "number" && oauth.expiresAt <= now()) return null;
+  return token;
+}
+
+/**
+ * Normalize one raw usage window (`{ utilization, resets_at }`-ish) into a
+ * stable `{ utilization, resets_at }` shape. Tolerates missing fields and
+ * `utilization` expressed as a 0–1 fraction (scaled to 0–100).
+ *
+ * @param {any} raw
+ * @returns {{ utilization: number, resets_at: string|null }}
+ */
+export function normalizeWindow(raw) {
+  if (!raw || typeof raw !== "object") return { utilization: 0, resets_at: null };
+  let util = Number(raw.utilization);
+  if (!Number.isFinite(util)) util = 0;
+  if (util > 0 && util <= 1) util *= 100; // fraction → percent
+  const resetsAt = raw.resets_at ?? raw.resetsAt ?? null;
+  return { utilization: util, resets_at: typeof resetsAt === "string" ? resetsAt : null };
+}
+
+/**
+ * Normalize the endpoint payload into `{ five_hour, seven_day }`.
+ * @param {any} payload
+ * @returns {{ five_hour: {utilization:number,resets_at:string|null}, seven_day: {utilization:number,resets_at:string|null} }}
+ */
+export function normalizeWindows(payload) {
+  return {
+    five_hour: normalizeWindow(payload?.five_hour ?? payload?.fiveHour),
+    seven_day: normalizeWindow(payload?.seven_day ?? payload?.sevenDay),
+  };
+}
+
+/**
+ * Decide ok / wait_seconds / resets_at from two normalized windows.
+ *
+ * `ok` = both windows' utilization < threshold. When NOT ok, wait_seconds and
+ * resets_at derive from the LATEST resets_at among the windows that exceeded
+ * the threshold (the soonest the work could safely resume against all
+ * exceeded windows).
+ *
+ * @param {{ five_hour: {utilization:number,resets_at:string|null}, seven_day: {utilization:number,resets_at:string|null} }} windows
+ * @param {object} [opts]
+ * @param {number} [opts.threshold]
+ * @param {() => number} [opts.now]
+ * @returns {{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null }}
+ */
+export function evaluate(windows, { threshold = DEFAULT_THRESHOLD, now = Date.now } = {}) {
+  const exceeded = [windows.five_hour, windows.seven_day].filter((w) => w.utilization >= threshold);
+  const ok = exceeded.length === 0;
+  let resetsAt = null;
+  let waitSeconds = 0;
+  if (!ok) {
+    // Latest resets_at among exceeded windows (max epoch); ignore unparseable.
+    let latestMs = null;
+    for (const w of exceeded) {
+      if (!w.resets_at) continue;
+      const ms = Date.parse(w.resets_at);
+      if (Number.isNaN(ms)) continue;
+      if (latestMs === null || ms > latestMs) {
+        latestMs = ms;
+        resetsAt = w.resets_at;
+      }
+    }
+    if (latestMs !== null) {
+      waitSeconds = Math.max(0, Math.ceil((latestMs - now()) / 1000));
+    }
+  }
+  return {
+    five_hour: windows.five_hour,
+    seven_day: windows.seven_day,
+    ok,
+    wait_seconds: waitSeconds,
+    resets_at: resetsAt,
+  };
+}
+
+/**
+ * Fetch raw usage windows from the OAuth endpoint.
+ *
+ * @param {string} token
+ * @param {object} [deps]
+ * @param {typeof fetch} [deps.fetchImpl]
+ * @returns {Promise<{ five_hour: object, seven_day: object }>}
+ */
+export async function fetchEndpointUsage(token, { fetchImpl = fetch } = {}) {
+  const res = await fetchImpl(USAGE_ENDPOINT, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "anthropic-beta": OAUTH_BETA,
+      "User-Agent": `claude-code/${CLAUDE_CODE_VERSION}`,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`usage endpoint HTTP ${res.status}`);
+  }
+  const payload = await res.json();
+  return normalizeWindows(payload);
+}
+
+/**
+ * Estimate usage windows from local session JSONL transcripts.
+ *
+ * Aggregates per-message `usage` token counts within the trailing 5h / 7d
+ * windows from the per-project session transcripts under
+ * `~/.claude/projects/<project>/<session>.jsonl`. This is a coarse fallback
+ * used only when the endpoint is unavailable; utilization is reported as a best-
+ * effort percentage of a configurable budget. resets_at is the window edge
+ * (oldest counted message + window length).
+ *
+ * @param {object} [deps]
+ * @param {(p: string, o?: any) => Promise<any>} [deps.readdirImpl]
+ * @param {(p: string, enc: string) => Promise<string>} [deps.readFileImpl]
+ * @param {string} [deps.projectsDir]
+ * @param {() => number} [deps.now]
+ * @param {number} [deps.fiveHourBudget]
+ * @param {number} [deps.sevenDayBudget]
+ * @returns {Promise<{ five_hour: object, seven_day: object }>}
+ */
+export async function aggregateJsonlUsage({
+  readdirImpl = readdir,
+  readFileImpl = readFile,
+  projectsDir = PROJECTS_DIR,
+  now = Date.now,
+  // Coarse token budgets for utilization estimation. Intentionally generous —
+  // the JSONL path only needs to be directionally correct as a fallback.
+  fiveHourBudget = 8_000_000,
+  sevenDayBudget = 80_000_000,
+} = {}) {
+  const nowMs = now();
+  const files = [];
+  const projectEntries = await readdirImpl(projectsDir, { withFileTypes: true });
+  for (const entry of projectEntries) {
+    if (!entry.isDirectory()) continue;
+    const dir = join(projectsDir, entry.name);
+    let inner;
+    try {
+      inner = await readdirImpl(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const f of inner) {
+      if (f.isFile() && f.name.endsWith(".jsonl")) files.push(join(dir, f.name));
+    }
+  }
+  if (files.length === 0) {
+    throw new Error("no JSONL transcripts found");
+  }
+
+  let fiveHourTokens = 0;
+  let sevenDayTokens = 0;
+  let oldestFiveHourMs = null;
+  let oldestSevenDayMs = null;
+
+  for (const file of files) {
+    let raw;
+    try {
+      raw = await readFileImpl(file, "utf8");
+    } catch {
+      continue;
+    }
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let rec;
+      try {
+        rec = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      const ts = rec?.timestamp;
+      const tsMs = typeof ts === "string" ? Date.parse(ts) : Number(ts);
+      if (!Number.isFinite(tsMs)) continue;
+      const usage = rec?.message?.usage ?? rec?.usage;
+      if (!usage) continue;
+      const tokens =
+        (Number(usage.input_tokens) || 0) +
+        (Number(usage.output_tokens) || 0) +
+        (Number(usage.cache_creation_input_tokens) || 0) +
+        (Number(usage.cache_read_input_tokens) || 0);
+      if (tokens <= 0) continue;
+      const age = nowMs - tsMs;
+      if (age >= 0 && age <= SEVEN_DAY_MS) {
+        sevenDayTokens += tokens;
+        if (oldestSevenDayMs === null || tsMs < oldestSevenDayMs) oldestSevenDayMs = tsMs;
+        if (age <= FIVE_HOUR_MS) {
+          fiveHourTokens += tokens;
+          if (oldestFiveHourMs === null || tsMs < oldestFiveHourMs) oldestFiveHourMs = tsMs;
+        }
+      }
+    }
+  }
+
+  const pct = (used, budget) => Math.min(100, (used / budget) * 100);
+  const resetsFrom = (oldestMs, windowMs) =>
+    oldestMs === null ? null : new Date(oldestMs + windowMs).toISOString();
+
+  return {
+    five_hour: {
+      utilization: pct(fiveHourTokens, fiveHourBudget),
+      resets_at: resetsFrom(oldestFiveHourMs, FIVE_HOUR_MS),
+    },
+    seven_day: {
+      utilization: pct(sevenDayTokens, sevenDayBudget),
+      resets_at: resetsFrom(oldestSevenDayMs, SEVEN_DAY_MS),
+    },
+  };
+}
+
+/**
+ * Read a cached result if it is fresh (within ttlMs).
+ * @param {object} deps
+ * @returns {Promise<object|null>}
+ */
+export async function readCache({
+  readFileImpl = readFile,
+  cachePath = CACHE_PATH,
+  ttlMs = DEFAULT_CACHE_TTL_MS,
+  now = Date.now,
+} = {}) {
+  try {
+    const parsed = JSON.parse(await readFileImpl(cachePath, "utf8"));
+    if (typeof parsed?.cached_at !== "number") return null;
+    if (now() - parsed.cached_at > ttlMs) return null;
+    return parsed.result ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist a result to the cache (best-effort; failures are swallowed).
+ * @param {object} result
+ * @param {object} deps
+ */
+export async function writeCache(
+  result,
+  { writeFileImpl, mkdirImpl, cachePath = CACHE_PATH, now = Date.now } = {},
+) {
+  if (!writeFileImpl) return;
+  try {
+    if (mkdirImpl) await mkdirImpl(join(cachePath, ".."), { recursive: true });
+    await writeFileImpl(cachePath, JSON.stringify({ cached_at: now(), result }));
+  } catch {
+    // best-effort cache; ignore.
+  }
+}
+
+/**
+ * Orchestrate a full usage check: cache → endpoint → JSONL → fail-open.
+ *
+ * Every dependency is injectable so tests can stub the endpoint, JSONL, creds,
+ * cache, and clock. `warn` defaults to stderr.
+ *
+ * @param {object} [deps]
+ * @returns {Promise<{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, source: string }>}
+ */
+export async function getUsage({
+  fetchImpl = fetch,
+  readFileImpl = readFile,
+  readdirImpl = readdir,
+  writeFileImpl,
+  mkdirImpl,
+  env = process.env,
+  now = Date.now,
+  credentialsPath = CREDENTIALS_PATH,
+  projectsDir = PROJECTS_DIR,
+  cachePath = CACHE_PATH,
+  cacheTtlMs = DEFAULT_CACHE_TTL_MS,
+  warn = (msg) => process.stderr.write(`${msg}\n`),
+} = {}) {
+  const threshold = resolveThreshold(env);
+
+  // 1. Fresh cache → return as-is (no endpoint re-fetch within TTL).
+  const cached = await readCache({ readFileImpl, cachePath, ttlMs: cacheTtlMs, now });
+  if (cached) return { ...cached, source: "cache" };
+
+  const evalOpts = { threshold, now };
+
+  // 2. Endpoint.
+  try {
+    const token = await readAccessToken({ readFileImpl, credentialsPath, now });
+    if (!token) throw new Error("no usable OAuth access token");
+    const windows = await fetchEndpointUsage(token, { fetchImpl });
+    const result = { ...evaluate(windows, evalOpts), source: "endpoint" };
+    await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
+    return result;
+  } catch (endpointErr) {
+    // 3. JSONL fallback.
+    try {
+      const windows = await aggregateJsonlUsage({ readdirImpl, readFileImpl, projectsDir, now });
+      const result = { ...evaluate(windows, evalOpts), source: "jsonl" };
+      await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
+      return result;
+    } catch (jsonlErr) {
+      // 4. Both failed → fail-open + warn (guard never hard-stops on its bug).
+      warn(
+        `usage-guard: signal unavailable (endpoint: ${endpointErr.message}; jsonl: ${jsonlErr.message}); failing open`,
+      );
+      return {
+        five_hour: { utilization: 0, resets_at: null },
+        seven_day: { utilization: 0, resets_at: null },
+        ok: true,
+        wait_seconds: 0,
+        resets_at: null,
+        source: "fail-open",
+      };
+    }
+  }
+}
+
+// CLI entry: print the usage JSON to stdout. Exit 0 always (fail-open ethos);
+// the JSON's `ok` field is the signal, not the exit code.
+async function main() {
+  const { mkdir, writeFile } = await import("node:fs/promises");
+  const result = await getUsage({ writeFileImpl: writeFile, mkdirImpl: mkdir });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+// Only run main() when executed directly (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    process.stderr.write(`usage-guard: fatal ${err.message}; failing open\n`);
+    process.stdout.write(
+      `${JSON.stringify({
+        five_hour: { utilization: 0, resets_at: null },
+        seven_day: { utilization: 0, resets_at: null },
+        ok: true,
+        wait_seconds: 0,
+        resets_at: null,
+        source: "fail-open",
+      })}\n`,
+    );
+  });
+}

--- a/src/skills/usage-guard/SKILL.md
+++ b/src/skills/usage-guard/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: usage-guard
+description: Claude Code の Usage Limit（5 時間 = Current / 週次 = Weekly）を監視し、95% 超過で作業を一時停止、リセットで枠が回復したら自動再開する pause/resume エンジン。drive 等の caller が checkpoint で Read するエンジン形態と、`/usage-guard "<継続コマンド>"` で任意作業を guard する単体形態を同梱。Claude 専用（OAuth 使用率エンドポイント + ScheduleWakeup 依存）。
+adapters: claude-code
+user-invocable: true
+argument-hint: "<継続コマンド>（空欄で status 確認のみ）"
+disable-model-invocation: true
+---
+
+# usage-guard - Usage Limit pause/resume エンジン
+
+Claude Code の Usage Limit が 100% に達するとセッションが中断される。本スキルは 100% 手前（既定 95%）で作業を一時停止し、リセットで枠が回復したら自動再開する仕組みを提供する。
+
+> **Claude 専用**: OAuth 使用率エンドポイント（`~/.claude/.credentials.json` のトークン）と `ScheduleWakeup` に依存するため、`adapters: claude-code` で gate している（Codex / Gemini / Copilot には配信しない）。
+>
+> **自己完結ドキュメント**: 本 SKILL.md は他ファイル（`.agents/skills/...` の canonical）を Read しない。gate により codex adapter の `.agents/` 出力が存在しないため、本体手順をすべてここに内包している。
+
+## シグナル取得: usage-check スクリプト
+
+判定の決定論部分は `usage-check.mjs` が担う。skill ディレクトリ直下に同梱され、user-scope では `~/.claude/skills/usage-guard/usage-check.mjs`、dogfood では `.claude/skills/usage-guard/usage-check.mjs` に置かれる。**実行時は本 SKILL.md と同じディレクトリの `usage-check.mjs`** を Bash で実行する:
+
+```bash
+node ~/.claude/skills/usage-guard/usage-check.mjs
+```
+
+> dogfood（skills/commons リポ内）で動かす場合はリポルートの `.claude/skills/usage-guard/usage-check.mjs` を実行する。どちらの環境でも「本 SKILL.md と同じ階層の `usage-check.mjs`」を指す。
+
+### 振る舞い
+
+- `~/.claude/.credentials.json` の `claudeAiOauth.accessToken` を**毎回読み直す**（`expiresAt` 失効を考慮）
+- `GET https://api.anthropic.com/api/oauth/usage`（ヘッダ `Authorization: Bearer` / `anthropic-beta: oauth-2025-04-20` / `User-Agent: claude-code/<version>`）で `five_hour` / `seven_day` の `utilization` と `resets_at` を 1 回で取得
+- 30–60s のローカルキャッシュ（`~/.claude/usage-guard/cache.json`、`.claude/skills/` 配下に置かない）で連打を防止。`#123` の PreToolUse hook と同じキャッシュを共有する
+- endpoint 失敗時は `~/.claude/projects/*/*.jsonl` の per-message `usage` + timestamp から 5h / 7d window を推定する JSONL フォールバック
+- endpoint と JSONL の**両方が失敗したら fail-open**（`ok: true`）+ stderr に警告（ガードが自バグで hard-stop しない）
+
+### 出力 JSON
+
+```json
+{
+  "five_hour": { "utilization": 0, "resets_at": "..." },
+  "seven_day": { "utilization": 0, "resets_at": "..." },
+  "ok": true,
+  "wait_seconds": 0,
+  "resets_at": null,
+  "source": "endpoint"
+}
+```
+
+- `ok`: **両枠の `utilization` が閾値未満**なら `true`
+- `wait_seconds` / `resets_at`: 超過枠の `resets_at` の**最遅**（最も遅くリセットする枠）から算出。`ok` のときは `wait_seconds: 0` / `resets_at: null`
+- `source`: `endpoint` / `jsonl` / `cache` / `fail-open`
+
+### 閾値
+
+既定 95%。環境変数 `USAGE_GUARD_THRESHOLD` で上書き可能（例 `USAGE_GUARD_THRESHOLD=80`）。
+
+## 軽量 wait-loop（共通ロジック）
+
+両形態が共有する停止/再開の中核:
+
+1. `usage-check.mjs` を実行して JSON を得る
+2. `ok` なら**通常進行**（継続コマンドを実行 / caller は次の checkpoint へ）
+3. `ok` が `false` なら `ScheduleWakeup(min(wait_seconds, 3600))` で heartbeat を仕込み、**待機する**
+   - 上限 3600s は ScheduleWakeup 1 回の最大待機。`wait_seconds` がそれより長ければ複数回に分けて再チェックする
+   - **待機中は再入しない**（予算を一切消費しない）
+4. 起床したら再び `usage-check.mjs` を実行し、`ok` になるまで 3〜4 を繰り返す
+5. `ok` になったら継続コマンドへ進む
+
+> `wait_seconds` は `resets_at` から算出するため秒精度ではない。ScheduleWakeup の発火も下限 + オーバーヘッドで多少遅れる（実機で 60s 要求に対し ~110s）。reset 待ちには十分な精度。
+
+## 利用形態 1: エンジン形態（呼び出し側が Read）
+
+drive（#122）等の caller が **resumable unit の境界（checkpoint）** で本 SKILL.md を Read し、上記 wait-loop を実行する。
+
+### checkpoint 規約
+
+- 停止は**常にクリーンに再入できる境界**で行う。mid-implement（PR 作成前など）では止めない
+- caller は各 unit の**入口**で usage-check を実行し、`ok` でなければ wait-loop に入る
+- 継続コマンドは **caller が供給**する。drive は冪等 resume（既存 PR を検出して Phase 3 から再開）なので、待機後の再実行をそのまま再開機構に流用する（例: `/drive --usage-guard <args>`）
+- drive のオーケストレーションモードでは wave 境界の粒度で呼ぶ。走行中の worker 内の超過は `#123` の PreToolUse hook が mid-unit ceiling として捕捉する
+
+## 利用形態 2: 単体形態 `/usage-guard "<継続コマンド>"`
+
+drive 非依存で、任意の長い作業を auto pause/resume で guard する（user-invocable）。
+
+### 引数
+
+- `$ARGUMENTS` を**継続コマンド**として解釈する
+- **空欄なら status 確認のみ**: `usage-check.mjs` を実行して現在の `five_hour` / `seven_day` の `utilization` と `ok` / `wait_seconds` を表示して終了する
+
+### 手順
+
+1. `usage-check.mjs` を実行する
+2. **両枠 `ok`** なら、継続コマンドを実行する（通常進行）
+3. **超過**なら:
+   - `ScheduleWakeup(min(wait_seconds, 3600))` で待機する（待機中は再入しない）
+   - 起床（回復検知）したら **`/usage-guard "<継続コマンド>"` を自己再入**する
+   - `ok` になるまで heartbeat を繰り返し、`ok` で継続コマンドを実行する
+
+### 継続コマンドの冪等性
+
+継続コマンドは**冪等前提**で扱う。待機を挟んで再実行されても安全であること（重複副作用を生まない / 進捗を検出して途中から再開できる）がユーザーの責任。
+
+- drive は元来冪等（既存 PR / ブランチを検出して再開）なので、`/usage-guard "/drive --usage-guard #123"` のように安全に巻ける
+- 汎用の長い作業（ビルド・バッチ等）を巻く場合は、再実行で壊れない設計か自分で確認すること
+
+### 実行例
+
+```text
+/usage-guard "/drive --usage-guard #123"
+/usage-guard ""                 # status 確認のみ
+USAGE_GUARD_THRESHOLD=80 /usage-guard "<継続コマンド>"   # 閾値を一時的に 80% へ
+```
+
+## PreToolUse hook との併用（推奨）
+
+本スキルの停止粒度は resumable unit の境界。長い unit 内での超過に備え、全 tool 呼び出し前に効く PreToolUse hook（`#123`）を mid-unit ceiling として併用することを推奨する（hook は同じ `~/.claude/usage-guard/cache.json` を読む）。hook の有効化手順は `#123` 実装時に本節へ追記する。
+
+## 注意事項
+
+- ガードは**自バグで hard-stop しない**: シグナル取得が全滅したら fail-open で作業を継続する（`source: "fail-open"` + stderr 警告）
+- 待機中は予算を消費しない（再入しない・heartbeat のみ）
+- 長い待機は live セッションで吸収する前提（WSL + 常時起動）

--- a/src/skills/usage-guard/usage-check.mjs
+++ b/src/skills/usage-guard/usage-check.mjs
@@ -1,0 +1,429 @@
+#!/usr/bin/env node
+// usage-check — deterministic Claude Code budget signal for usage-guard.
+//
+// Reads the live OAuth usage utilization for the two limit windows Claude Code
+// enforces (5-hour "Current" and 7-day "Weekly") and decides whether work may
+// continue (both windows below the threshold) or must pause. Shipped verbatim
+// as a skill extra file alongside SKILL.md (user scope under HOME, dogfood under
+// the repo) — it is always resolved as the sibling of SKILL.md.
+//
+// M2 (path-literal note): the build's rewriteSkillRefsToUserScope rewrites
+// skill-dir path literals (the `agents`/`claude` skills dirs). The HOME-anchored
+// paths used here (the credentials file, the projects transcripts dir, and the
+// usage-guard cache file — all under ~/.claude/ but NOT under a skills dir) do
+// NOT match that pattern, so they survive the dist build intact. Crucially, no
+// functional path literal here is written in the rewritable skills-dir form.
+//
+// Output (stdout, single JSON line):
+//   { five_hour, seven_day, ok, wait_seconds, resets_at, source }
+//   - five_hour / seven_day: { utilization (0-100), resets_at (ISO|null) }
+//   - ok:           both windows' utilization < threshold (default 95)
+//   - wait_seconds: seconds until the LATEST resets_at among exceeded windows
+//                   (0 when ok). Derived from `resets_at` minus now.
+//   - resets_at:    that same latest exceeded resets_at (null when ok)
+//   - source:       "endpoint" | "jsonl" | "fail-open" | "cache"
+//
+// Fail-open: if the endpoint fails AND the JSONL fallback fails, emit
+// { ok: true, ... source: "fail-open" } and a warning on stderr so the guard
+// never hard-stops on its own bug.
+//
+// This is a plain .mjs (NOT a Workflow script): Date.now() / real fetch / real
+// fs are fine. Pure/injectable functions are exported for tests.
+
+import { readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const USAGE_ENDPOINT = "https://api.anthropic.com/api/oauth/usage";
+const OAUTH_BETA = "oauth-2025-04-20";
+const CLAUDE_CODE_VERSION = "2.0.0";
+const DEFAULT_THRESHOLD = 95;
+const DEFAULT_CACHE_TTL_MS = 45_000; // 30–60s window so the #123 hook can share it.
+const FIVE_HOUR_MS = 5 * 60 * 60 * 1000;
+const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1000;
+
+// HOME-anchored paths, built with path.join so no rewritable skills-dir literal
+// ever appears in source (M2).
+const CREDENTIALS_PATH = join(homedir(), ".claude", ".credentials.json");
+const PROJECTS_DIR = join(homedir(), ".claude", "projects");
+// Cache lives OUTSIDE any skills dir so the #123 PreToolUse hook can read the
+// same file (and so it is never wiped when the dogfood skills mirror is
+// rebuilt).
+const CACHE_PATH = join(homedir(), ".claude", "usage-guard", "cache.json");
+
+/**
+ * Resolve the threshold (env override → default).
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {number}
+ */
+export function resolveThreshold(env = process.env) {
+  const raw = env?.USAGE_GUARD_THRESHOLD;
+  if (raw === undefined || raw === null || String(raw).trim() === "") return DEFAULT_THRESHOLD;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : DEFAULT_THRESHOLD;
+}
+
+/**
+ * Read + parse the OAuth access token, honoring `expiresAt`.
+ *
+ * Re-reads the credentials file on EVERY call (no caching of the token) so a
+ * refreshed token is picked up immediately.
+ *
+ * @param {object} [deps]
+ * @param {(p: string, enc: string) => Promise<string>} [deps.readFileImpl]
+ * @param {string} [deps.credentialsPath]
+ * @param {() => number} [deps.now]
+ * @returns {Promise<string|null>} the access token, or null when missing/expired.
+ */
+export async function readAccessToken({
+  readFileImpl = readFile,
+  credentialsPath = CREDENTIALS_PATH,
+  now = Date.now,
+} = {}) {
+  let parsed;
+  try {
+    parsed = JSON.parse(await readFileImpl(credentialsPath, "utf8"));
+  } catch {
+    return null;
+  }
+  const oauth = parsed?.claudeAiOauth;
+  const token = oauth?.accessToken;
+  if (!token) return null;
+  // expiresAt is epoch milliseconds. Treat an expired token as absent so we
+  // fall through to the JSONL fallback rather than sending a dead Bearer.
+  if (typeof oauth.expiresAt === "number" && oauth.expiresAt <= now()) return null;
+  return token;
+}
+
+/**
+ * Normalize one raw usage window (`{ utilization, resets_at }`-ish) into a
+ * stable `{ utilization, resets_at }` shape. Tolerates missing fields and
+ * `utilization` expressed as a 0–1 fraction (scaled to 0–100).
+ *
+ * @param {any} raw
+ * @returns {{ utilization: number, resets_at: string|null }}
+ */
+export function normalizeWindow(raw) {
+  if (!raw || typeof raw !== "object") return { utilization: 0, resets_at: null };
+  let util = Number(raw.utilization);
+  if (!Number.isFinite(util)) util = 0;
+  if (util > 0 && util <= 1) util *= 100; // fraction → percent
+  const resetsAt = raw.resets_at ?? raw.resetsAt ?? null;
+  return { utilization: util, resets_at: typeof resetsAt === "string" ? resetsAt : null };
+}
+
+/**
+ * Normalize the endpoint payload into `{ five_hour, seven_day }`.
+ * @param {any} payload
+ * @returns {{ five_hour: {utilization:number,resets_at:string|null}, seven_day: {utilization:number,resets_at:string|null} }}
+ */
+export function normalizeWindows(payload) {
+  return {
+    five_hour: normalizeWindow(payload?.five_hour ?? payload?.fiveHour),
+    seven_day: normalizeWindow(payload?.seven_day ?? payload?.sevenDay),
+  };
+}
+
+/**
+ * Decide ok / wait_seconds / resets_at from two normalized windows.
+ *
+ * `ok` = both windows' utilization < threshold. When NOT ok, wait_seconds and
+ * resets_at derive from the LATEST resets_at among the windows that exceeded
+ * the threshold (the soonest the work could safely resume against all
+ * exceeded windows).
+ *
+ * @param {{ five_hour: {utilization:number,resets_at:string|null}, seven_day: {utilization:number,resets_at:string|null} }} windows
+ * @param {object} [opts]
+ * @param {number} [opts.threshold]
+ * @param {() => number} [opts.now]
+ * @returns {{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null }}
+ */
+export function evaluate(windows, { threshold = DEFAULT_THRESHOLD, now = Date.now } = {}) {
+  const exceeded = [windows.five_hour, windows.seven_day].filter((w) => w.utilization >= threshold);
+  const ok = exceeded.length === 0;
+  let resetsAt = null;
+  let waitSeconds = 0;
+  if (!ok) {
+    // Latest resets_at among exceeded windows (max epoch); ignore unparseable.
+    let latestMs = null;
+    for (const w of exceeded) {
+      if (!w.resets_at) continue;
+      const ms = Date.parse(w.resets_at);
+      if (Number.isNaN(ms)) continue;
+      if (latestMs === null || ms > latestMs) {
+        latestMs = ms;
+        resetsAt = w.resets_at;
+      }
+    }
+    if (latestMs !== null) {
+      waitSeconds = Math.max(0, Math.ceil((latestMs - now()) / 1000));
+    }
+  }
+  return {
+    five_hour: windows.five_hour,
+    seven_day: windows.seven_day,
+    ok,
+    wait_seconds: waitSeconds,
+    resets_at: resetsAt,
+  };
+}
+
+/**
+ * Fetch raw usage windows from the OAuth endpoint.
+ *
+ * @param {string} token
+ * @param {object} [deps]
+ * @param {typeof fetch} [deps.fetchImpl]
+ * @returns {Promise<{ five_hour: object, seven_day: object }>}
+ */
+export async function fetchEndpointUsage(token, { fetchImpl = fetch } = {}) {
+  const res = await fetchImpl(USAGE_ENDPOINT, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "anthropic-beta": OAUTH_BETA,
+      "User-Agent": `claude-code/${CLAUDE_CODE_VERSION}`,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`usage endpoint HTTP ${res.status}`);
+  }
+  const payload = await res.json();
+  return normalizeWindows(payload);
+}
+
+/**
+ * Estimate usage windows from local session JSONL transcripts.
+ *
+ * Aggregates per-message `usage` token counts within the trailing 5h / 7d
+ * windows from the per-project session transcripts under
+ * `~/.claude/projects/<project>/<session>.jsonl`. This is a coarse fallback
+ * used only when the endpoint is unavailable; utilization is reported as a best-
+ * effort percentage of a configurable budget. resets_at is the window edge
+ * (oldest counted message + window length).
+ *
+ * @param {object} [deps]
+ * @param {(p: string, o?: any) => Promise<any>} [deps.readdirImpl]
+ * @param {(p: string, enc: string) => Promise<string>} [deps.readFileImpl]
+ * @param {string} [deps.projectsDir]
+ * @param {() => number} [deps.now]
+ * @param {number} [deps.fiveHourBudget]
+ * @param {number} [deps.sevenDayBudget]
+ * @returns {Promise<{ five_hour: object, seven_day: object }>}
+ */
+export async function aggregateJsonlUsage({
+  readdirImpl = readdir,
+  readFileImpl = readFile,
+  projectsDir = PROJECTS_DIR,
+  now = Date.now,
+  // Coarse token budgets for utilization estimation. Intentionally generous —
+  // the JSONL path only needs to be directionally correct as a fallback.
+  fiveHourBudget = 8_000_000,
+  sevenDayBudget = 80_000_000,
+} = {}) {
+  const nowMs = now();
+  const files = [];
+  const projectEntries = await readdirImpl(projectsDir, { withFileTypes: true });
+  for (const entry of projectEntries) {
+    if (!entry.isDirectory()) continue;
+    const dir = join(projectsDir, entry.name);
+    let inner;
+    try {
+      inner = await readdirImpl(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const f of inner) {
+      if (f.isFile() && f.name.endsWith(".jsonl")) files.push(join(dir, f.name));
+    }
+  }
+  if (files.length === 0) {
+    throw new Error("no JSONL transcripts found");
+  }
+
+  let fiveHourTokens = 0;
+  let sevenDayTokens = 0;
+  let oldestFiveHourMs = null;
+  let oldestSevenDayMs = null;
+
+  for (const file of files) {
+    let raw;
+    try {
+      raw = await readFileImpl(file, "utf8");
+    } catch {
+      continue;
+    }
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let rec;
+      try {
+        rec = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      const ts = rec?.timestamp;
+      const tsMs = typeof ts === "string" ? Date.parse(ts) : Number(ts);
+      if (!Number.isFinite(tsMs)) continue;
+      const usage = rec?.message?.usage ?? rec?.usage;
+      if (!usage) continue;
+      const tokens =
+        (Number(usage.input_tokens) || 0) +
+        (Number(usage.output_tokens) || 0) +
+        (Number(usage.cache_creation_input_tokens) || 0) +
+        (Number(usage.cache_read_input_tokens) || 0);
+      if (tokens <= 0) continue;
+      const age = nowMs - tsMs;
+      if (age >= 0 && age <= SEVEN_DAY_MS) {
+        sevenDayTokens += tokens;
+        if (oldestSevenDayMs === null || tsMs < oldestSevenDayMs) oldestSevenDayMs = tsMs;
+        if (age <= FIVE_HOUR_MS) {
+          fiveHourTokens += tokens;
+          if (oldestFiveHourMs === null || tsMs < oldestFiveHourMs) oldestFiveHourMs = tsMs;
+        }
+      }
+    }
+  }
+
+  const pct = (used, budget) => Math.min(100, (used / budget) * 100);
+  const resetsFrom = (oldestMs, windowMs) =>
+    oldestMs === null ? null : new Date(oldestMs + windowMs).toISOString();
+
+  return {
+    five_hour: {
+      utilization: pct(fiveHourTokens, fiveHourBudget),
+      resets_at: resetsFrom(oldestFiveHourMs, FIVE_HOUR_MS),
+    },
+    seven_day: {
+      utilization: pct(sevenDayTokens, sevenDayBudget),
+      resets_at: resetsFrom(oldestSevenDayMs, SEVEN_DAY_MS),
+    },
+  };
+}
+
+/**
+ * Read a cached result if it is fresh (within ttlMs).
+ * @param {object} deps
+ * @returns {Promise<object|null>}
+ */
+export async function readCache({
+  readFileImpl = readFile,
+  cachePath = CACHE_PATH,
+  ttlMs = DEFAULT_CACHE_TTL_MS,
+  now = Date.now,
+} = {}) {
+  try {
+    const parsed = JSON.parse(await readFileImpl(cachePath, "utf8"));
+    if (typeof parsed?.cached_at !== "number") return null;
+    if (now() - parsed.cached_at > ttlMs) return null;
+    return parsed.result ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist a result to the cache (best-effort; failures are swallowed).
+ * @param {object} result
+ * @param {object} deps
+ */
+export async function writeCache(
+  result,
+  { writeFileImpl, mkdirImpl, cachePath = CACHE_PATH, now = Date.now } = {},
+) {
+  if (!writeFileImpl) return;
+  try {
+    if (mkdirImpl) await mkdirImpl(join(cachePath, ".."), { recursive: true });
+    await writeFileImpl(cachePath, JSON.stringify({ cached_at: now(), result }));
+  } catch {
+    // best-effort cache; ignore.
+  }
+}
+
+/**
+ * Orchestrate a full usage check: cache → endpoint → JSONL → fail-open.
+ *
+ * Every dependency is injectable so tests can stub the endpoint, JSONL, creds,
+ * cache, and clock. `warn` defaults to stderr.
+ *
+ * @param {object} [deps]
+ * @returns {Promise<{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, source: string }>}
+ */
+export async function getUsage({
+  fetchImpl = fetch,
+  readFileImpl = readFile,
+  readdirImpl = readdir,
+  writeFileImpl,
+  mkdirImpl,
+  env = process.env,
+  now = Date.now,
+  credentialsPath = CREDENTIALS_PATH,
+  projectsDir = PROJECTS_DIR,
+  cachePath = CACHE_PATH,
+  cacheTtlMs = DEFAULT_CACHE_TTL_MS,
+  warn = (msg) => process.stderr.write(`${msg}\n`),
+} = {}) {
+  const threshold = resolveThreshold(env);
+
+  // 1. Fresh cache → return as-is (no endpoint re-fetch within TTL).
+  const cached = await readCache({ readFileImpl, cachePath, ttlMs: cacheTtlMs, now });
+  if (cached) return { ...cached, source: "cache" };
+
+  const evalOpts = { threshold, now };
+
+  // 2. Endpoint.
+  try {
+    const token = await readAccessToken({ readFileImpl, credentialsPath, now });
+    if (!token) throw new Error("no usable OAuth access token");
+    const windows = await fetchEndpointUsage(token, { fetchImpl });
+    const result = { ...evaluate(windows, evalOpts), source: "endpoint" };
+    await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
+    return result;
+  } catch (endpointErr) {
+    // 3. JSONL fallback.
+    try {
+      const windows = await aggregateJsonlUsage({ readdirImpl, readFileImpl, projectsDir, now });
+      const result = { ...evaluate(windows, evalOpts), source: "jsonl" };
+      await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
+      return result;
+    } catch (jsonlErr) {
+      // 4. Both failed → fail-open + warn (guard never hard-stops on its bug).
+      warn(
+        `usage-guard: signal unavailable (endpoint: ${endpointErr.message}; jsonl: ${jsonlErr.message}); failing open`,
+      );
+      return {
+        five_hour: { utilization: 0, resets_at: null },
+        seven_day: { utilization: 0, resets_at: null },
+        ok: true,
+        wait_seconds: 0,
+        resets_at: null,
+        source: "fail-open",
+      };
+    }
+  }
+}
+
+// CLI entry: print the usage JSON to stdout. Exit 0 always (fail-open ethos);
+// the JSON's `ok` field is the signal, not the exit code.
+async function main() {
+  const { mkdir, writeFile } = await import("node:fs/promises");
+  const result = await getUsage({ writeFileImpl: writeFile, mkdirImpl: mkdir });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+// Only run main() when executed directly (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    process.stderr.write(`usage-guard: fatal ${err.message}; failing open\n`);
+    process.stdout.write(
+      `${JSON.stringify({
+        five_hour: { utilization: 0, resets_at: null },
+        seven_day: { utilization: 0, resets_at: null },
+        ok: true,
+        wait_seconds: 0,
+        resets_at: null,
+        source: "fail-open",
+      })}\n`,
+    );
+  });
+}

--- a/tests/usage-check.test.mjs
+++ b/tests/usage-check.test.mjs
@@ -1,0 +1,349 @@
+// Tests for the usage-guard usage-check signal (issue #121).
+//
+// Covers the 6 issue cases via dependency injection (endpoint / JSONL / creds /
+// cache / clock are all stubbed — no network, no real ~/.claude reads):
+//   (1) endpoint OK → ok decision
+//   (2) endpoint fail → JSONL fallback
+//   (3) both fail → fail-open + warn
+//   (4) threshold boundary 94.9 (ok) / 95.1 (not ok)
+//   (5) wait_seconds = latest resets_at among exceeded windows
+//   (6) cache TTL within window → no endpoint re-fetch
+// Plus a structural assert that the BUILT claude-code SKILL.md frontmatter has
+// `user-invocable` and a standalone-form section.
+
+import assert from "node:assert/strict";
+import { readFile as realReadFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  aggregateJsonlUsage,
+  evaluate,
+  getUsage,
+  normalizeWindows,
+  readAccessToken,
+  resolveThreshold,
+} from "../src/skills/usage-guard/usage-check.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const FIXED_NOW = Date.parse("2026-06-15T00:00:00.000Z");
+const now = () => FIXED_NOW;
+
+// Build a credentials reader that returns a live (non-expired) token.
+function credsReader({ token = "tok-abc", expiresAt = FIXED_NOW + 3_600_000 } = {}) {
+  return async (path) => {
+    if (path.endsWith(".credentials.json")) {
+      return JSON.stringify({ claudeAiOauth: { accessToken: token, expiresAt } });
+    }
+    throw new Error(`unexpected read ${path}`);
+  };
+}
+
+// A fetch stub returning the given window payload with HTTP 200.
+function fetchOk(payload) {
+  return async () => ({ ok: true, status: 200, json: async () => payload });
+}
+
+// --- (1) endpoint OK → ok ----------------------------------------------------
+
+test("(1) endpoint OK below threshold → ok:true, source endpoint", async () => {
+  const result = await getUsage({
+    fetchImpl: fetchOk({
+      five_hour: { utilization: 40, resets_at: "2026-06-15T04:00:00.000Z" },
+      seven_day: { utilization: 60, resets_at: "2026-06-20T00:00:00.000Z" },
+    }),
+    readFileImpl: credsReader(),
+    now,
+    cachePath: "/nonexistent/cache.json",
+    credentialsPath: "/fake/.credentials.json",
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.source, "endpoint");
+  assert.equal(result.wait_seconds, 0);
+  assert.equal(result.resets_at, null);
+  assert.equal(result.five_hour.utilization, 40);
+});
+
+// --- (2) endpoint fail → JSONL fallback --------------------------------------
+
+test("(2) endpoint fail → JSONL fallback (source jsonl)", async () => {
+  const recentTs = new Date(FIXED_NOW - 60_000).toISOString(); // 1 min ago
+  const jsonlContent = [
+    JSON.stringify({
+      timestamp: recentTs,
+      message: { usage: { input_tokens: 100, output_tokens: 50 } },
+    }),
+    "not-json-line",
+    "",
+  ].join("\n");
+  const readFileImpl = async (path) => {
+    if (path.endsWith(".credentials.json")) {
+      return JSON.stringify({ claudeAiOauth: { accessToken: "t", expiresAt: FIXED_NOW + 1000 } });
+    }
+    if (path.endsWith(".jsonl")) return jsonlContent;
+    throw new Error(`unexpected ${path}`);
+  };
+  const readdirImpl = async (path, _opts) => {
+    if (path.endsWith("/projects"))
+      return [{ name: "proj-a", isDirectory: () => true, isFile: () => false }];
+    return [{ name: "session.jsonl", isDirectory: () => false, isFile: () => true }];
+  };
+  const result = await getUsage({
+    fetchImpl: async () => ({ ok: false, status: 500, json: async () => ({}) }),
+    readFileImpl,
+    readdirImpl,
+    now,
+    cachePath: "/nonexistent/cache.json",
+    projectsDir: "/fake/projects",
+  });
+  assert.equal(result.source, "jsonl");
+  assert.equal(result.ok, true); // tiny token count → well under threshold
+  assert.ok(result.five_hour.utilization >= 0);
+});
+
+// --- (3) both fail → fail-open + warn ----------------------------------------
+
+test("(3) endpoint + JSONL both fail → fail-open + stderr warn", async () => {
+  const warnings = [];
+  const result = await getUsage({
+    fetchImpl: async () => {
+      throw new Error("network down");
+    },
+    readFileImpl: async (path) => {
+      // creds present but endpoint throws; JSONL readdir throws below.
+      if (path.endsWith(".credentials.json")) {
+        return JSON.stringify({ claudeAiOauth: { accessToken: "t", expiresAt: FIXED_NOW + 1000 } });
+      }
+      throw new Error("ENOENT");
+    },
+    readdirImpl: async () => {
+      throw new Error("no projects dir");
+    },
+    now,
+    cachePath: "/nonexistent/cache.json",
+    warn: (m) => warnings.push(m),
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.source, "fail-open");
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /failing open/);
+});
+
+// --- (4) threshold boundary --------------------------------------------------
+
+test("(4) threshold boundary: 94.9 ok, 95.1 not ok (default 95)", () => {
+  const below = evaluate(
+    normalizeWindows({
+      five_hour: { utilization: 94.9, resets_at: "2026-06-15T04:00:00.000Z" },
+      seven_day: { utilization: 10, resets_at: "2026-06-20T00:00:00.000Z" },
+    }),
+    { now },
+  );
+  assert.equal(below.ok, true, "94.9 < 95 → ok");
+
+  const above = evaluate(
+    normalizeWindows({
+      five_hour: { utilization: 95.1, resets_at: "2026-06-15T04:00:00.000Z" },
+      seven_day: { utilization: 10, resets_at: "2026-06-20T00:00:00.000Z" },
+    }),
+    { now },
+  );
+  assert.equal(above.ok, false, "95.1 >= 95 → not ok");
+  assert.ok(above.wait_seconds > 0);
+});
+
+test("(4b) threshold env override changes the boundary", () => {
+  assert.equal(resolveThreshold({ USAGE_GUARD_THRESHOLD: "80" }), 80);
+  assert.equal(resolveThreshold({}), 95);
+  const at85 = evaluate(
+    normalizeWindows({
+      five_hour: { utilization: 85, resets_at: "2026-06-15T04:00:00.000Z" },
+      seven_day: { utilization: 10, resets_at: null },
+    }),
+    { threshold: 80, now },
+  );
+  assert.equal(at85.ok, false, "85 >= 80 → not ok at threshold 80");
+});
+
+// --- (5) wait_seconds = latest exceeded resets_at ----------------------------
+
+test("(5) wait_seconds derives from the LATEST resets_at among exceeded windows", () => {
+  const fiveHourReset = "2026-06-15T02:00:00.000Z"; // +2h
+  const sevenDayReset = "2026-06-18T00:00:00.000Z"; // +3d (latest)
+  const res = evaluate(
+    normalizeWindows({
+      five_hour: { utilization: 99, resets_at: fiveHourReset },
+      seven_day: { utilization: 96, resets_at: sevenDayReset },
+    }),
+    { now },
+  );
+  assert.equal(res.ok, false);
+  assert.equal(res.resets_at, sevenDayReset, "picks the later (7d) reset");
+  const expected = Math.ceil((Date.parse(sevenDayReset) - FIXED_NOW) / 1000);
+  assert.equal(res.wait_seconds, expected);
+});
+
+test("(5b) only the exceeded window counts toward the wait", () => {
+  // 5h exceeded with a LATER reset than 7d, but 7d is NOT exceeded → use 5h.
+  const res = evaluate(
+    normalizeWindows({
+      five_hour: { utilization: 99, resets_at: "2026-06-15T05:00:00.000Z" },
+      seven_day: { utilization: 10, resets_at: "2026-06-15T01:00:00.000Z" },
+    }),
+    { now },
+  );
+  assert.equal(res.resets_at, "2026-06-15T05:00:00.000Z");
+});
+
+// --- (6) cache TTL within window → no re-fetch -------------------------------
+
+test("(6) fresh cache within TTL → no endpoint re-fetch", async () => {
+  let fetchCalls = 0;
+  const cached = {
+    five_hour: { utilization: 12, resets_at: null },
+    seven_day: { utilization: 34, resets_at: null },
+    ok: true,
+    wait_seconds: 0,
+    resets_at: null,
+  };
+  const readFileImpl = async (path) => {
+    if (path.endsWith("cache.json")) {
+      return JSON.stringify({ cached_at: FIXED_NOW - 10_000, result: cached }); // 10s old, TTL 45s
+    }
+    throw new Error(`unexpected ${path}`);
+  };
+  const result = await getUsage({
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return { ok: true, status: 200, json: async () => ({}) };
+    },
+    readFileImpl,
+    now,
+    cachePath: "/fake/cache.json",
+  });
+  assert.equal(fetchCalls, 0, "endpoint must NOT be re-fetched within cache TTL");
+  assert.equal(result.source, "cache");
+  assert.equal(result.five_hour.utilization, 12);
+});
+
+test("(6b) stale cache beyond TTL → endpoint re-fetched", async () => {
+  let fetchCalls = 0;
+  const readFileImpl = async (path) => {
+    if (path.endsWith("cache.json")) {
+      return JSON.stringify({ cached_at: FIXED_NOW - 120_000, result: { ok: true } }); // 2 min old > 45s TTL
+    }
+    if (path.endsWith(".credentials.json")) {
+      return JSON.stringify({ claudeAiOauth: { accessToken: "t", expiresAt: FIXED_NOW + 1000 } });
+    }
+    throw new Error(`unexpected ${path}`);
+  };
+  const result = await getUsage({
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          five_hour: { utilization: 5, resets_at: null },
+          seven_day: { utilization: 5, resets_at: null },
+        }),
+      };
+    },
+    readFileImpl,
+    now,
+    cachePath: "/fake/cache.json",
+  });
+  assert.equal(fetchCalls, 1, "stale cache must trigger a re-fetch");
+  assert.equal(result.source, "endpoint");
+});
+
+// --- token expiry ------------------------------------------------------------
+
+test("readAccessToken returns null for an expired token", async () => {
+  const expired = await readAccessToken({
+    readFileImpl: credsReader({ expiresAt: FIXED_NOW - 1000 }),
+    credentialsPath: "/fake/.credentials.json",
+    now,
+  });
+  assert.equal(expired, null);
+  const live = await readAccessToken({
+    readFileImpl: credsReader({ expiresAt: FIXED_NOW + 1000 }),
+    credentialsPath: "/fake/.credentials.json",
+    now,
+  });
+  assert.equal(live, "tok-abc");
+});
+
+// --- JSONL aggregation directly ----------------------------------------------
+
+test("aggregateJsonlUsage windows tokens by 5h / 7d age", async () => {
+  const within5h = new Date(FIXED_NOW - 60 * 60 * 1000).toISOString(); // 1h ago
+  const within7d = new Date(FIXED_NOW - 3 * 24 * 60 * 60 * 1000).toISOString(); // 3d ago
+  const tooOld = new Date(FIXED_NOW - 10 * 24 * 60 * 60 * 1000).toISOString(); // 10d ago (ignored)
+  const content = [
+    JSON.stringify({
+      timestamp: within5h,
+      message: { usage: { input_tokens: 1000, output_tokens: 1000 } },
+    }),
+    JSON.stringify({
+      timestamp: within7d,
+      message: { usage: { input_tokens: 2000, output_tokens: 0 } },
+    }),
+    JSON.stringify({ timestamp: tooOld, message: { usage: { input_tokens: 9_999_999 } } }),
+  ].join("\n");
+  const windows = await aggregateJsonlUsage({
+    readdirImpl: async (path) => {
+      if (path.endsWith("/projects"))
+        return [{ name: "p", isDirectory: () => true, isFile: () => false }];
+      return [{ name: "s.jsonl", isDirectory: () => false, isFile: () => true }];
+    },
+    readFileImpl: async () => content,
+    projectsDir: "/fake/projects",
+    now,
+    fiveHourBudget: 10_000,
+    sevenDayBudget: 10_000,
+  });
+  // 5h window: 2000 tokens / 10000 budget = 20%
+  assert.equal(Math.round(windows.five_hour.utilization), 20);
+  // 7d window: (2000 + 2000) = 4000 / 10000 = 40% (10d-old row excluded)
+  assert.equal(Math.round(windows.seven_day.utilization), 40);
+  assert.ok(windows.five_hour.resets_at, "5h resets_at derived from oldest counted message");
+});
+
+// --- structural assert on the BUILT SKILL.md ---------------------------------
+
+test("built claude-code usage-guard SKILL.md is user-invocable + has standalone-form section", async () => {
+  const built = await realReadFile(
+    join(ROOT, "dist", "claude-code", ".claude", "skills", "usage-guard", "SKILL.md"),
+    "utf8",
+  );
+  // frontmatter block
+  const fm = built.match(/^---\n([\s\S]*?)\n---\n/);
+  assert.ok(fm, "SKILL.md must have frontmatter");
+  assert.match(fm[1], /user-invocable:\s*true/, "frontmatter must declare user-invocable: true");
+  assert.match(fm[1], /adapters:\s*claude-code/, "frontmatter must be gated to claude-code");
+  assert.match(fm[1], /argument-hint:/, "frontmatter must declare argument-hint");
+  // standalone form section
+  assert.match(built, /単体形態/, "body must document the standalone /usage-guard form");
+  assert.match(built, /\/usage-guard/, "body must reference the /usage-guard invocation");
+  // self-contained (M1): must NOT thin-wrap the .agents/ canonical
+  assert.doesNotMatch(
+    built,
+    /`\.agents\/skills\/usage-guard\/SKILL\.md` を Read/,
+    "usage-guard must be self-contained, not a thin wrapper over .agents/ canonical",
+  );
+});
+
+test("usage-guard ships its usage-check.mjs extra file in the claude-code payload", async () => {
+  const script = await realReadFile(
+    join(ROOT, "dist", "claude-code", ".claude", "skills", "usage-guard", "usage-check.mjs"),
+    "utf8",
+  );
+  assert.match(script, /api\/oauth\/usage/, "extra file must ship verbatim");
+  // M2: the dist rewrite must not have corrupted HOME-anchored path literals.
+  assert.doesNotMatch(
+    script,
+    /~\/\.claude\/skills\/usage-guard\/usage-check\.mjs/,
+    "extra file must not contain a rewritten .claude/skills/ self-path literal",
+  );
+});


### PR DESCRIPTION
## Summary

Sub-issue B (#121) of the usage-limit epic (#119): a self-contained, Claude-Code-only `usage-guard` skill that monitors the Usage Limit and auto pauses/resumes work near the cap. Depends on #120 (adapter gating, already merged).

## What's in it

- **`src/skills/usage-guard/usage-check.mjs`** (extra file, shipped verbatim): deterministic budget signal.
  - Reads `~/.claude/.credentials.json` OAuth `accessToken` every call (honors `expiresAt`).
  - `GET https://api.anthropic.com/api/oauth/usage` with `Authorization: Bearer` / `anthropic-beta: oauth-2025-04-20` / `User-Agent: claude-code/<version>`.
  - Evaluates both windows against a threshold (default `95`, override via `USAGE_GUARD_THRESHOLD`); `ok` = both windows below threshold; `wait_seconds`/`resets_at` derive from the **latest** `resets_at` among exceeded windows.
  - 30–60s cache at `~/.claude/usage-guard/cache.json` (outside any skills dir, shareable with the #123 hook).
  - JSONL transcript aggregation fallback when the endpoint fails; **fail-open** + stderr warning when both fail.
  - Pure/injectable exports (`evaluate`, `normalizeWindows`, `readAccessToken`, `getUsage`, …) for tests.
- **`src/skills/usage-guard/SKILL.md`** — self-contained (M1: not a thin wrapper over the `.agents/` canonical, which the gate removes). `user-invocable: true`, `adapters: claude-code`, `disable-model-invocation: true`. Documents both the **engine form** (callers Read it at checkpoints) and the **standalone form** `/usage-guard "<継続コマンド>"` (auto pause → `ScheduleWakeup(min(wait_seconds, 3600))` → self-re-enter on recovery; idempotent continuation assumed).
- **`tests/usage-check.test.mjs`** — the 6 issue cases (endpoint ok; endpoint fail→JSONL; both fail→fail-open+warn; threshold boundary 94.9/95.1; wait_seconds = latest exceeded resets_at; cache TTL no re-fetch) plus a structural assert on the built SKILL.md (`user-invocable` + standalone section) and the shipped extra file.
- **Docs** — README skill table (+ count) and `CLAUDE.md` skill list.

## Review corrections addressed

- **M1**: SKILL.md is self-contained (no `.agents/` Read), since the gate removes the codex canonical.
- **M2**: no rewritable skills-dir path literal in the `.mjs`; HOME-anchored paths built with `path.join` survive `rewriteSkillRefsToUserScope` intact (asserted in tests).

## Verification

- `pnpm build` regenerated; `pnpm test` (190 pass) and `pnpm lint:all` green.
- Gating confirmed: `usage-guard` present in `dist/claude-code/`, `dist/claude-code-project/`, and the `.claude/skills/` dogfood; **absent** from `dist/codex-cli`, `dist/gemini-cli`, `dist/copilot`, and `.agents/skills/`.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)