### PR TITLE
feat(drive): add --usage-guard flag

### DIFF
--- a/.agents/skills/drive/SKILL.md
+++ b/.agents/skills/drive/SKILL.md
@@ -40,6 +40,11 @@ Issue または指示を受け取り、実装 → ship → セルフレビュー
 
   オーケストレーションモードでは `--review=quick` を強制し、`final-deep` / `deep` 指定時は警告を出して `quick` にフォールバックする。
 
+- `--usage-guard`: Claude Code の Usage Limit 超過手前で作業を pause し、枠回復後に自動再開する（opt-in）。**Claude Code 環境のみ**（`review --deep` と同じ扱い。OAuth 使用率エンドポイント + `ScheduleWakeup` 依存のため他アダプタでは無効）。pause/resume の配線はホスト依存なので `SKILL.claude-code.md` の「usage-guard 配線（`--usage-guard`）」で吸収する。未指定時は drive 本体の挙動を一切変えない。
+  - 停止は **resumable unit の入口**でのみ行う（単一モード: Phase 1 開始前 / review loop 各反復前、オーケストレーション: 各 wave 開始前 / worker dispatch 前）。mid-implement（PR 作成前）では止めない。
+  - orchestration の停止粒度は **wave 境界**。一度起動した走行中 worker の mid-unit 超過はこのフラグでは止められず、PreToolUse hook（#123）が ceiling を担う。
+  - 超過時は枠リセットまで待機してから継続コマンド `/drive --usage-guard <元の引数>` を自己再入する（drive 冪等 resume で続行）。
+
 ### モード分岐
 
 - target が 1 件かつ依存記法なし → **単一モード**

--- a/.claude/skills/drive/SKILL.md
+++ b/.claude/skills/drive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Issue または指示から実装・PR 作成・セルフレビュー・修正を自動で回し、merge-ready な PR を出す。単一/複数の Issue/PR と明示依存記法に対応。オプションでマージまで実行可能。
-argument-hint: <#N | #N,#N | #N-N | instruction> [--merge] [--concurrency N] [--review=quick|final-deep|deep]
+argument-hint: <#N | #N,#N | #N-N | instruction> [--merge] [--concurrency N] [--review=quick|final-deep|deep] [--usage-guard]
 disable-model-invocation: true
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUserQuestion, Agent, Workflow
 ---
@@ -15,7 +15,7 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUser
 
 ### 入力解析
 
-`$ARGUMENTS` を解析し、target リスト（Issue/PR/指示）と依存記法、オプション（`--merge`, `--concurrency N`, `--review=<mode>`）を特定する。
+`$ARGUMENTS` を解析し、target リスト（Issue/PR/指示）と依存記法、オプション（`--merge`, `--concurrency N`, `--review=<mode>`, `--usage-guard`）を特定する。
 
 - target が 1 件かつ依存記法（`->`）なし → 単一モード
 - target が 2 件以上、または依存記法あり → オーケストレーションモード
@@ -26,9 +26,56 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUser
 - 単一モード: `quick` / `final-deep` / `deep` をすべて受け付ける
 - オーケストレーションモード: `--review=quick` を強制し、`final-deep` / `deep` 指定時は警告を表示して `quick` にフォールバックする（コスト管理）
 
+`--usage-guard` の取り扱い:
+
+- **opt-in フラグ。未指定時は drive 本体の挙動を一切変えない**（checkpoint を挟まない素の drive）。
+- 指定時のみ、後述「usage-guard 配線（`--usage-guard`）」の checkpoint で usage-guard エンジンを呼び、Usage Limit 超過時は枠回復まで待機してから自己再入する。
+- 解析時に**元の引数列を保存**する（継続コマンド `/drive --usage-guard <元の引数>` の組み立てに使う）。`--usage-guard` 自体も保存対象に含める（resume 後も guard を効かせ続けるため）。
+
 ### 自律実行
 
 計画承認を含め、マージ処理（またはマージ確認）まで AskUserQuestion を使用しない（完全自律実行）。
+
+### usage-guard 配線（`--usage-guard`）
+
+`--usage-guard` 指定時のみ有効。Claude Code の Usage Limit（5 時間 = Current / 週次 = Weekly）が 100% に達する前に作業を一時停止し、枠が回復したら自動再開する。**フラグ未指定なら本節の処理は一切実行せず、drive 本体の挙動を変えない**（pause/resume は Claude 固有なので配線を本 overlay に閉じる。前例: `review --deep`）。
+
+> **Claude 専用**: usage-guard エンジンは OAuth 使用率エンドポイントと `ScheduleWakeup` に依存するため Claude Code でのみ動作する（`adapters: claude-code` で gate された `usage-guard` skill = #121）。
+
+#### checkpoint の発火点
+
+`--usage-guard` 指定時、以下の **resumable unit の入口**でのみ usage-guard を呼ぶ:
+
+| モード | checkpoint |
+|---|---|
+| 単一モード | 各 target の **Phase 1（implement）開始前** |
+| 単一モード | **review loop の各反復前**（Phase 3 の各 pass 開始前） |
+| オーケストレーション | 各 **wave の開始前**（Phase 1..N の wave ループ先頭） |
+| オーケストレーション | 各 **worker dispatch 前**（同一 wave 内で worker を起動する直前） |
+
+**checkpoint は常にクリーンに再入できる境界に置く**。mid-implement（PR がまだ存在しない実装途中）や review pass の途中、コミット/push の途中では**止めない** — そこで停止すると再入時に進捗を取りこぼす恐れがある。drive は冪等 resume（既存 PR を検出して Phase 3 から再開）なので、上記の境界はいずれも再実行で安全に続きから再開できる。
+
+#### checkpoint での手順
+
+各 checkpoint で以下を実行する:
+
+1. `usage-guard` エンジン（`.claude/skills/usage-guard/SKILL.md`、user-scope では `~/.claude/skills/usage-guard/SKILL.md`）を Read し、その「軽量 wait-loop」を実行する（= 同階層の `usage-check.mjs` を Bash 実行して JSON を得る）。
+2. `ok: true`（両枠とも閾値未満）→ **通常進行**。次のフェーズ／wave／worker dispatch へそのまま進む。
+3. `ok: false`（いずれかの枠が閾値超過）→ usage-guard の wait-loop に委譲する:
+   - `ScheduleWakeup(min(wait_seconds, 3600))` で heartbeat を仕込み、**待機する**（待機中は再入せず予算を消費しない）。`wait_seconds` が 3600 を超える場合は複数回に分けて再チェックする。
+   - 起床したら継続コマンド **`/drive --usage-guard <元の引数>`** を自己再入する。drive の冪等 resume が既存 PR / ブランチ / 完了済み worker を検出して**続きから再開**する（待機を挟んでも重複副作用を生まない）。
+   - `usage-check.mjs` が `ok: true` を返すまで 3〜4 を繰り返す。
+
+> 継続コマンドには `--usage-guard` を含めた**元の引数列**を渡す（resume 後も guard を効かせ続けるため）。
+
+#### 粒度と二重化
+
+- orchestration の停止は **wave 境界 / worker dispatch 境界の粒度**。一度起動した worker の**走行中（mid-unit）の超過**はこのフラグでは止められない。長い unit 内の ceiling は #123 の **PreToolUse hook**（全 tool 呼び出し前に効き、subagent 内にも届く）が担う（推奨併用）。
+- worker（subagent）に渡す prompt 自体は無改変でよい。worker は単一モードを実行するため、**親が `--usage-guard` で worker dispatch 前に checkpoint を挟む**ことで wave 粒度の予算対応になる。
+
+#### fail-open
+
+usage-check のシグナル取得が全滅（endpoint → JSONL フォールバックともに失敗）した場合、usage-guard は `ok: true`（fail-open）を返す。drive はそのまま通常進行する — **ガードが自バグで drive を hard-stop させない**。
 
 ### オーケストレーション実行機構の選択
 
@@ -97,6 +144,7 @@ Workflow 方式固有の注意:
 - 途中失敗からの再開は `Workflow({scriptPath, resumeFromRunId})`。完了済み worker はキャッシュから復元される
 - **Phase Final-1 / Final-2 / Final-3 は workflow 終了後に会話側で実行する**。worker の worktree は変更を含むためランタイムの自動削除対象にならず、cleanup 手順（後述の Phase Final-2 節）が引き続き必要。worktree path 規約（`.claude/worktrees/agent-<id>/`）も同一
 - `--merge` 未指定時の一括マージ確認（「完了後」節の AskUserQuestion）は workflow の return 後に行う
+- **`--usage-guard` 指定時の wave checkpoint は会話側で挟む**。workflow スクリプトは決定論実行で SKILL.md の Read も `ScheduleWakeup` も呼べないため、wave 単位で workflow を起動し、各 wave の起動**前**に会話側で「usage-guard 配線」節の checkpoint を実行する（`ok` なら次 wave の workflow を起動、超過なら待機 → `/drive --usage-guard <元の引数>` で再入し、`resumeFromRunId` で完了済み worker をキャッシュ復元して続行）
 
 ### subagent dispatch（オーケストレーションモード・Agent tool 方式 fallback）
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@
 - `/pr` — 変更を push し、PR を作成・更新
 - `/review` — コード変更や PR を 11 観点（正確性 / セキュリティ / 規約 / アーキテクチャ / 互換性 / 保守性 / テスト / パフォーマンス / 可観測性 / ユーザビリティ / ドキュメント整合性）でレビューし、JSON 構造化出力を併載。`--axes=<list>` で観点指定、`--deep` で観点別 subagent 並列起動
 - `/ship` — lint・コミット・PR 作成を一括実行
-- `/drive` — implement + ship + review loop（Issue から merge-ready な PR まで自律駆動）。`--review=quick|final-deep|deep` で review モード切替（既定 quick）
+- `/drive` — implement + ship + review loop（Issue から merge-ready な PR まで自律駆動）。`--review=quick|final-deep|deep` で review モード切替（既定 quick）。`--usage-guard`（**Claude Code only**・opt-in）で予算対応: resumable unit の入口（Phase 1 開始前 / review loop 各反復前 / 各 wave 開始前 / worker dispatch 前）で `usage-guard` エンジンを Read し、Usage Limit 超過なら枠回復まで待機 → `/drive --usage-guard <元の引数>` で冪等 resume。orchestration は wave 境界粒度、走行中 worker は PreToolUse hook が ceiling
 - `/health` — リポジトリ状態と skill catalog 整合性を 16 領域確認し、推奨アクションを inline 表示（`--deep` で `要確認` 項目を追加調査）
 - `/topics` — research-driven な GitHub topics 設定（ozzy-labs scope）。候補を公式制約検証 → 人気度測定（session キャッシュ）→ broad+narrow / 単数複数比較 → ozzy-labs 慣行ハードコードで選定し、`--apply` で `gh repo edit --add-topic` を実行、`--dry-run` で分析のみ
 - `/lessons-triage` — セッション教訓 queue（`~/.agents/lessons/queue.jsonl`）を消化し、User Skills 改善の教訓を承認制で ozzy-labs/skills へ issue 起票（HITL、起票のみ）

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This package backs the [OzzyLabs handbook ADR-0016](https://github.com/ozzy-labs
 | --- | --- |
 | `commit` | Stage changes and create a Conventional Commit |
 | `commit-conventions` | Commit / branch / PR naming conventions |
-| `drive` | Issue → merge-ready PR autonomous loop |
+| `drive` | Issue → merge-ready PR autonomous loop. `--usage-guard` (Claude Code only) makes the loop budget-aware: at resumable-unit boundaries (Phase 1 start / each review-loop pass / each wave / before worker dispatch) it Reads the `usage-guard` engine and, when over the Usage Limit threshold, waits for the window to reset then re-enters via `/drive --usage-guard <args>` (idempotent resume). Orchestration pauses at wave-boundary granularity; an in-flight worker's ceiling is the PreToolUse hook |
 | `health` | Inspect repo state and skill catalog consistency across 16 areas with inline recommended actions (`--deep` for follow-up investigation of `要確認` items) |
 | `implement` | Branch creation and implementation from an issue or instructions |
 | `lint` | Run all linters with auto-fix |

--- a/dist/claude-code-project/.agents/skills/drive/SKILL.md
+++ b/dist/claude-code-project/.agents/skills/drive/SKILL.md
@@ -40,6 +40,11 @@ Issue または指示を受け取り、実装 → ship → セルフレビュー
 
   オーケストレーションモードでは `--review=quick` を強制し、`final-deep` / `deep` 指定時は警告を出して `quick` にフォールバックする。
 
+- `--usage-guard`: Claude Code の Usage Limit 超過手前で作業を pause し、枠回復後に自動再開する（opt-in）。**Claude Code 環境のみ**（`review --deep` と同じ扱い。OAuth 使用率エンドポイント + `ScheduleWakeup` 依存のため他アダプタでは無効）。pause/resume の配線はホスト依存なので `SKILL.claude-code.md` の「usage-guard 配線（`--usage-guard`）」で吸収する。未指定時は drive 本体の挙動を一切変えない。
+  - 停止は **resumable unit の入口**でのみ行う（単一モード: Phase 1 開始前 / review loop 各反復前、オーケストレーション: 各 wave 開始前 / worker dispatch 前）。mid-implement（PR 作成前）では止めない。
+  - orchestration の停止粒度は **wave 境界**。一度起動した走行中 worker の mid-unit 超過はこのフラグでは止められず、PreToolUse hook（#123）が ceiling を担う。
+  - 超過時は枠リセットまで待機してから継続コマンド `/drive --usage-guard <元の引数>` を自己再入する（drive 冪等 resume で続行）。
+
 ### モード分岐
 
 - target が 1 件かつ依存記法なし → **単一モード**

--- a/dist/claude-code-project/.claude/skills/drive/SKILL.md
+++ b/dist/claude-code-project/.claude/skills/drive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Issue または指示から実装・PR 作成・セルフレビュー・修正を自動で回し、merge-ready な PR を出す。単一/複数の Issue/PR と明示依存記法に対応。オプションでマージまで実行可能。
-argument-hint: <#N | #N,#N | #N-N | instruction> [--merge] [--concurrency N] [--review=quick|final-deep|deep]
+argument-hint: <#N | #N,#N | #N-N | instruction> [--merge] [--concurrency N] [--review=quick|final-deep|deep] [--usage-guard]
 disable-model-invocation: true
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUserQuestion, Agent, Workflow
 ---
@@ -15,7 +15,7 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUser
 
 ### 入力解析
 
-`$ARGUMENTS` を解析し、target リスト（Issue/PR/指示）と依存記法、オプション（`--merge`, `--concurrency N`, `--review=<mode>`）を特定する。
+`$ARGUMENTS` を解析し、target リスト（Issue/PR/指示）と依存記法、オプション（`--merge`, `--concurrency N`, `--review=<mode>`, `--usage-guard`）を特定する。
 
 - target が 1 件かつ依存記法（`->`）なし → 単一モード
 - target が 2 件以上、または依存記法あり → オーケストレーションモード
@@ -26,9 +26,56 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUser
 - 単一モード: `quick` / `final-deep` / `deep` をすべて受け付ける
 - オーケストレーションモード: `--review=quick` を強制し、`final-deep` / `deep` 指定時は警告を表示して `quick` にフォールバックする（コスト管理）
 
+`--usage-guard` の取り扱い:
+
+- **opt-in フラグ。未指定時は drive 本体の挙動を一切変えない**（checkpoint を挟まない素の drive）。
+- 指定時のみ、後述「usage-guard 配線（`--usage-guard`）」の checkpoint で usage-guard エンジンを呼び、Usage Limit 超過時は枠回復まで待機してから自己再入する。
+- 解析時に**元の引数列を保存**する（継続コマンド `/drive --usage-guard <元の引数>` の組み立てに使う）。`--usage-guard` 自体も保存対象に含める（resume 後も guard を効かせ続けるため）。
+
 ### 自律実行
 
 計画承認を含め、マージ処理（またはマージ確認）まで AskUserQuestion を使用しない（完全自律実行）。
+
+### usage-guard 配線（`--usage-guard`）
+
+`--usage-guard` 指定時のみ有効。Claude Code の Usage Limit（5 時間 = Current / 週次 = Weekly）が 100% に達する前に作業を一時停止し、枠が回復したら自動再開する。**フラグ未指定なら本節の処理は一切実行せず、drive 本体の挙動を変えない**（pause/resume は Claude 固有なので配線を本 overlay に閉じる。前例: `review --deep`）。
+
+> **Claude 専用**: usage-guard エンジンは OAuth 使用率エンドポイントと `ScheduleWakeup` に依存するため Claude Code でのみ動作する（`adapters: claude-code` で gate された `usage-guard` skill = #121）。
+
+#### checkpoint の発火点
+
+`--usage-guard` 指定時、以下の **resumable unit の入口**でのみ usage-guard を呼ぶ:
+
+| モード | checkpoint |
+|---|---|
+| 単一モード | 各 target の **Phase 1（implement）開始前** |
+| 単一モード | **review loop の各反復前**（Phase 3 の各 pass 開始前） |
+| オーケストレーション | 各 **wave の開始前**（Phase 1..N の wave ループ先頭） |
+| オーケストレーション | 各 **worker dispatch 前**（同一 wave 内で worker を起動する直前） |
+
+**checkpoint は常にクリーンに再入できる境界に置く**。mid-implement（PR がまだ存在しない実装途中）や review pass の途中、コミット/push の途中では**止めない** — そこで停止すると再入時に進捗を取りこぼす恐れがある。drive は冪等 resume（既存 PR を検出して Phase 3 から再開）なので、上記の境界はいずれも再実行で安全に続きから再開できる。
+
+#### checkpoint での手順
+
+各 checkpoint で以下を実行する:
+
+1. `usage-guard` エンジン（`.claude/skills/usage-guard/SKILL.md`、user-scope では `~/.claude/skills/usage-guard/SKILL.md`）を Read し、その「軽量 wait-loop」を実行する（= 同階層の `usage-check.mjs` を Bash 実行して JSON を得る）。
+2. `ok: true`（両枠とも閾値未満）→ **通常進行**。次のフェーズ／wave／worker dispatch へそのまま進む。
+3. `ok: false`（いずれかの枠が閾値超過）→ usage-guard の wait-loop に委譲する:
+   - `ScheduleWakeup(min(wait_seconds, 3600))` で heartbeat を仕込み、**待機する**（待機中は再入せず予算を消費しない）。`wait_seconds` が 3600 を超える場合は複数回に分けて再チェックする。
+   - 起床したら継続コマンド **`/drive --usage-guard <元の引数>`** を自己再入する。drive の冪等 resume が既存 PR / ブランチ / 完了済み worker を検出して**続きから再開**する（待機を挟んでも重複副作用を生まない）。
+   - `usage-check.mjs` が `ok: true` を返すまで 3〜4 を繰り返す。
+
+> 継続コマンドには `--usage-guard` を含めた**元の引数列**を渡す（resume 後も guard を効かせ続けるため）。
+
+#### 粒度と二重化
+
+- orchestration の停止は **wave 境界 / worker dispatch 境界の粒度**。一度起動した worker の**走行中（mid-unit）の超過**はこのフラグでは止められない。長い unit 内の ceiling は #123 の **PreToolUse hook**（全 tool 呼び出し前に効き、subagent 内にも届く）が担う（推奨併用）。
+- worker（subagent）に渡す prompt 自体は無改変でよい。worker は単一モードを実行するため、**親が `--usage-guard` で worker dispatch 前に checkpoint を挟む**ことで wave 粒度の予算対応になる。
+
+#### fail-open
+
+usage-check のシグナル取得が全滅（endpoint → JSONL フォールバックともに失敗）した場合、usage-guard は `ok: true`（fail-open）を返す。drive はそのまま通常進行する — **ガードが自バグで drive を hard-stop させない**。
 
 ### オーケストレーション実行機構の選択
 
@@ -97,6 +144,7 @@ Workflow 方式固有の注意:
 - 途中失敗からの再開は `Workflow({scriptPath, resumeFromRunId})`。完了済み worker はキャッシュから復元される
 - **Phase Final-1 / Final-2 / Final-3 は workflow 終了後に会話側で実行する**。worker の worktree は変更を含むためランタイムの自動削除対象にならず、cleanup 手順（後述の Phase Final-2 節）が引き続き必要。worktree path 規約（`.claude/worktrees/agent-<id>/`）も同一
 - `--merge` 未指定時の一括マージ確認（「完了後」節の AskUserQuestion）は workflow の return 後に行う
+- **`--usage-guard` 指定時の wave checkpoint は会話側で挟む**。workflow スクリプトは決定論実行で SKILL.md の Read も `ScheduleWakeup` も呼べないため、wave 単位で workflow を起動し、各 wave の起動**前**に会話側で「usage-guard 配線」節の checkpoint を実行する（`ok` なら次 wave の workflow を起動、超過なら待機 → `/drive --usage-guard <元の引数>` で再入し、`resumeFromRunId` で完了済み worker をキャッシュ復元して続行）
 
 ### subagent dispatch（オーケストレーションモード・Agent tool 方式 fallback）
 

--- a/dist/claude-code/.claude/skills/drive/SKILL.md
+++ b/dist/claude-code/.claude/skills/drive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Issue または指示から実装・PR 作成・セルフレビュー・修正を自動で回し、merge-ready な PR を出す。単一/複数の Issue/PR と明示依存記法に対応。オプションでマージまで実行可能。
-argument-hint: <#N | #N,#N | #N-N | instruction> [--merge] [--concurrency N] [--review=quick|final-deep|deep]
+argument-hint: <#N | #N,#N | #N-N | instruction> [--merge] [--concurrency N] [--review=quick|final-deep|deep] [--usage-guard]
 disable-model-invocation: true
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUserQuestion, Agent, Workflow
 ---
@@ -15,7 +15,7 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUser
 
 ### 入力解析
 
-`$ARGUMENTS` を解析し、target リスト（Issue/PR/指示）と依存記法、オプション（`--merge`, `--concurrency N`, `--review=<mode>`）を特定する。
+`$ARGUMENTS` を解析し、target リスト（Issue/PR/指示）と依存記法、オプション（`--merge`, `--concurrency N`, `--review=<mode>`, `--usage-guard`）を特定する。
 
 - target が 1 件かつ依存記法（`->`）なし → 単一モード
 - target が 2 件以上、または依存記法あり → オーケストレーションモード
@@ -26,9 +26,56 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUser
 - 単一モード: `quick` / `final-deep` / `deep` をすべて受け付ける
 - オーケストレーションモード: `--review=quick` を強制し、`final-deep` / `deep` 指定時は警告を表示して `quick` にフォールバックする（コスト管理）
 
+`--usage-guard` の取り扱い:
+
+- **opt-in フラグ。未指定時は drive 本体の挙動を一切変えない**（checkpoint を挟まない素の drive）。
+- 指定時のみ、後述「usage-guard 配線（`--usage-guard`）」の checkpoint で usage-guard エンジンを呼び、Usage Limit 超過時は枠回復まで待機してから自己再入する。
+- 解析時に**元の引数列を保存**する（継続コマンド `/drive --usage-guard <元の引数>` の組み立てに使う）。`--usage-guard` 自体も保存対象に含める（resume 後も guard を効かせ続けるため）。
+
 ### 自律実行
 
 計画承認を含め、マージ処理（またはマージ確認）まで AskUserQuestion を使用しない（完全自律実行）。
+
+### usage-guard 配線（`--usage-guard`）
+
+`--usage-guard` 指定時のみ有効。Claude Code の Usage Limit（5 時間 = Current / 週次 = Weekly）が 100% に達する前に作業を一時停止し、枠が回復したら自動再開する。**フラグ未指定なら本節の処理は一切実行せず、drive 本体の挙動を変えない**（pause/resume は Claude 固有なので配線を本 overlay に閉じる。前例: `review --deep`）。
+
+> **Claude 専用**: usage-guard エンジンは OAuth 使用率エンドポイントと `ScheduleWakeup` に依存するため Claude Code でのみ動作する（`adapters: claude-code` で gate された `usage-guard` skill = #121）。
+
+#### checkpoint の発火点
+
+`--usage-guard` 指定時、以下の **resumable unit の入口**でのみ usage-guard を呼ぶ:
+
+| モード | checkpoint |
+|---|---|
+| 単一モード | 各 target の **Phase 1（implement）開始前** |
+| 単一モード | **review loop の各反復前**（Phase 3 の各 pass 開始前） |
+| オーケストレーション | 各 **wave の開始前**（Phase 1..N の wave ループ先頭） |
+| オーケストレーション | 各 **worker dispatch 前**（同一 wave 内で worker を起動する直前） |
+
+**checkpoint は常にクリーンに再入できる境界に置く**。mid-implement（PR がまだ存在しない実装途中）や review pass の途中、コミット/push の途中では**止めない** — そこで停止すると再入時に進捗を取りこぼす恐れがある。drive は冪等 resume（既存 PR を検出して Phase 3 から再開）なので、上記の境界はいずれも再実行で安全に続きから再開できる。
+
+#### checkpoint での手順
+
+各 checkpoint で以下を実行する:
+
+1. `usage-guard` エンジン（`~/.claude/skills/usage-guard/SKILL.md`、user-scope では `~/.claude/skills/usage-guard/SKILL.md`）を Read し、その「軽量 wait-loop」を実行する（= 同階層の `usage-check.mjs` を Bash 実行して JSON を得る）。
+2. `ok: true`（両枠とも閾値未満）→ **通常進行**。次のフェーズ／wave／worker dispatch へそのまま進む。
+3. `ok: false`（いずれかの枠が閾値超過）→ usage-guard の wait-loop に委譲する:
+   - `ScheduleWakeup(min(wait_seconds, 3600))` で heartbeat を仕込み、**待機する**（待機中は再入せず予算を消費しない）。`wait_seconds` が 3600 を超える場合は複数回に分けて再チェックする。
+   - 起床したら継続コマンド **`/drive --usage-guard <元の引数>`** を自己再入する。drive の冪等 resume が既存 PR / ブランチ / 完了済み worker を検出して**続きから再開**する（待機を挟んでも重複副作用を生まない）。
+   - `usage-check.mjs` が `ok: true` を返すまで 3〜4 を繰り返す。
+
+> 継続コマンドには `--usage-guard` を含めた**元の引数列**を渡す（resume 後も guard を効かせ続けるため）。
+
+#### 粒度と二重化
+
+- orchestration の停止は **wave 境界 / worker dispatch 境界の粒度**。一度起動した worker の**走行中（mid-unit）の超過**はこのフラグでは止められない。長い unit 内の ceiling は #123 の **PreToolUse hook**（全 tool 呼び出し前に効き、subagent 内にも届く）が担う（推奨併用）。
+- worker（subagent）に渡す prompt 自体は無改変でよい。worker は単一モードを実行するため、**親が `--usage-guard` で worker dispatch 前に checkpoint を挟む**ことで wave 粒度の予算対応になる。
+
+#### fail-open
+
+usage-check のシグナル取得が全滅（endpoint → JSONL フォールバックともに失敗）した場合、usage-guard は `ok: true`（fail-open）を返す。drive はそのまま通常進行する — **ガードが自バグで drive を hard-stop させない**。
 
 ### オーケストレーション実行機構の選択
 
@@ -97,6 +144,7 @@ Workflow 方式固有の注意:
 - 途中失敗からの再開は `Workflow({scriptPath, resumeFromRunId})`。完了済み worker はキャッシュから復元される
 - **Phase Final-1 / Final-2 / Final-3 は workflow 終了後に会話側で実行する**。worker の worktree は変更を含むためランタイムの自動削除対象にならず、cleanup 手順（後述の Phase Final-2 節）が引き続き必要。worktree path 規約（`.claude/worktrees/agent-<id>/`）も同一
 - `--merge` 未指定時の一括マージ確認（「完了後」節の AskUserQuestion）は workflow の return 後に行う
+- **`--usage-guard` 指定時の wave checkpoint は会話側で挟む**。workflow スクリプトは決定論実行で SKILL.md の Read も `ScheduleWakeup` も呼べないため、wave 単位で workflow を起動し、各 wave の起動**前**に会話側で「usage-guard 配線」節の checkpoint を実行する（`ok` なら次 wave の workflow を起動、超過なら待機 → `/drive --usage-guard <元の引数>` で再入し、`resumeFromRunId` で完了済み worker をキャッシュ復元して続行）
 
 ### subagent dispatch（オーケストレーションモード・Agent tool 方式 fallback）
 

--- a/dist/codex-cli/.agents/skills/drive/SKILL.md
+++ b/dist/codex-cli/.agents/skills/drive/SKILL.md
@@ -40,6 +40,11 @@ Issue または指示を受け取り、実装 → ship → セルフレビュー
 
   オーケストレーションモードでは `--review=quick` を強制し、`final-deep` / `deep` 指定時は警告を出して `quick` にフォールバックする。
 
+- `--usage-guard`: Claude Code の Usage Limit 超過手前で作業を pause し、枠回復後に自動再開する（opt-in）。**Claude Code 環境のみ**（`review --deep` と同じ扱い。OAuth 使用率エンドポイント + `ScheduleWakeup` 依存のため他アダプタでは無効）。pause/resume の配線はホスト依存なので `SKILL.claude-code.md` の「usage-guard 配線（`--usage-guard`）」で吸収する。未指定時は drive 本体の挙動を一切変えない。
+  - 停止は **resumable unit の入口**でのみ行う（単一モード: Phase 1 開始前 / review loop 各反復前、オーケストレーション: 各 wave 開始前 / worker dispatch 前）。mid-implement（PR 作成前）では止めない。
+  - orchestration の停止粒度は **wave 境界**。一度起動した走行中 worker の mid-unit 超過はこのフラグでは止められず、PreToolUse hook（#123）が ceiling を担う。
+  - 超過時は枠リセットまで待機してから継続コマンド `/drive --usage-guard <元の引数>` を自己再入する（drive 冪等 resume で続行）。
+
 ### モード分岐
 
 - target が 1 件かつ依存記法なし → **単一モード**

--- a/src/skills/drive/SKILL.claude-code.md
+++ b/src/skills/drive/SKILL.claude-code.md
@@ -1,6 +1,6 @@
 ---
 description: Issue または指示から実装・PR 作成・セルフレビュー・修正を自動で回し、merge-ready な PR を出す。単一/複数の Issue/PR と明示依存記法に対応。オプションでマージまで実行可能。
-argument-hint: <#N | #N,#N | #N-N | instruction> [--merge] [--concurrency N] [--review=quick|final-deep|deep]
+argument-hint: <#N | #N,#N | #N-N | instruction> [--merge] [--concurrency N] [--review=quick|final-deep|deep] [--usage-guard]
 disable-model-invocation: true
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUserQuestion, Agent, Workflow
 ---
@@ -15,7 +15,7 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUser
 
 ### 入力解析
 
-`$ARGUMENTS` を解析し、target リスト（Issue/PR/指示）と依存記法、オプション（`--merge`, `--concurrency N`, `--review=<mode>`）を特定する。
+`$ARGUMENTS` を解析し、target リスト（Issue/PR/指示）と依存記法、オプション（`--merge`, `--concurrency N`, `--review=<mode>`, `--usage-guard`）を特定する。
 
 - target が 1 件かつ依存記法（`->`）なし → 単一モード
 - target が 2 件以上、または依存記法あり → オーケストレーションモード
@@ -26,9 +26,56 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, AskUser
 - 単一モード: `quick` / `final-deep` / `deep` をすべて受け付ける
 - オーケストレーションモード: `--review=quick` を強制し、`final-deep` / `deep` 指定時は警告を表示して `quick` にフォールバックする（コスト管理）
 
+`--usage-guard` の取り扱い:
+
+- **opt-in フラグ。未指定時は drive 本体の挙動を一切変えない**（checkpoint を挟まない素の drive）。
+- 指定時のみ、後述「usage-guard 配線（`--usage-guard`）」の checkpoint で usage-guard エンジンを呼び、Usage Limit 超過時は枠回復まで待機してから自己再入する。
+- 解析時に**元の引数列を保存**する（継続コマンド `/drive --usage-guard <元の引数>` の組み立てに使う）。`--usage-guard` 自体も保存対象に含める（resume 後も guard を効かせ続けるため）。
+
 ### 自律実行
 
 計画承認を含め、マージ処理（またはマージ確認）まで AskUserQuestion を使用しない（完全自律実行）。
+
+### usage-guard 配線（`--usage-guard`）
+
+`--usage-guard` 指定時のみ有効。Claude Code の Usage Limit（5 時間 = Current / 週次 = Weekly）が 100% に達する前に作業を一時停止し、枠が回復したら自動再開する。**フラグ未指定なら本節の処理は一切実行せず、drive 本体の挙動を変えない**（pause/resume は Claude 固有なので配線を本 overlay に閉じる。前例: `review --deep`）。
+
+> **Claude 専用**: usage-guard エンジンは OAuth 使用率エンドポイントと `ScheduleWakeup` に依存するため Claude Code でのみ動作する（`adapters: claude-code` で gate された `usage-guard` skill = #121）。
+
+#### checkpoint の発火点
+
+`--usage-guard` 指定時、以下の **resumable unit の入口**でのみ usage-guard を呼ぶ:
+
+| モード | checkpoint |
+|---|---|
+| 単一モード | 各 target の **Phase 1（implement）開始前** |
+| 単一モード | **review loop の各反復前**（Phase 3 の各 pass 開始前） |
+| オーケストレーション | 各 **wave の開始前**（Phase 1..N の wave ループ先頭） |
+| オーケストレーション | 各 **worker dispatch 前**（同一 wave 内で worker を起動する直前） |
+
+**checkpoint は常にクリーンに再入できる境界に置く**。mid-implement（PR がまだ存在しない実装途中）や review pass の途中、コミット/push の途中では**止めない** — そこで停止すると再入時に進捗を取りこぼす恐れがある。drive は冪等 resume（既存 PR を検出して Phase 3 から再開）なので、上記の境界はいずれも再実行で安全に続きから再開できる。
+
+#### checkpoint での手順
+
+各 checkpoint で以下を実行する:
+
+1. `usage-guard` エンジン（`.claude/skills/usage-guard/SKILL.md`、user-scope では `~/.claude/skills/usage-guard/SKILL.md`）を Read し、その「軽量 wait-loop」を実行する（= 同階層の `usage-check.mjs` を Bash 実行して JSON を得る）。
+2. `ok: true`（両枠とも閾値未満）→ **通常進行**。次のフェーズ／wave／worker dispatch へそのまま進む。
+3. `ok: false`（いずれかの枠が閾値超過）→ usage-guard の wait-loop に委譲する:
+   - `ScheduleWakeup(min(wait_seconds, 3600))` で heartbeat を仕込み、**待機する**（待機中は再入せず予算を消費しない）。`wait_seconds` が 3600 を超える場合は複数回に分けて再チェックする。
+   - 起床したら継続コマンド **`/drive --usage-guard <元の引数>`** を自己再入する。drive の冪等 resume が既存 PR / ブランチ / 完了済み worker を検出して**続きから再開**する（待機を挟んでも重複副作用を生まない）。
+   - `usage-check.mjs` が `ok: true` を返すまで 3〜4 を繰り返す。
+
+> 継続コマンドには `--usage-guard` を含めた**元の引数列**を渡す（resume 後も guard を効かせ続けるため）。
+
+#### 粒度と二重化
+
+- orchestration の停止は **wave 境界 / worker dispatch 境界の粒度**。一度起動した worker の**走行中（mid-unit）の超過**はこのフラグでは止められない。長い unit 内の ceiling は #123 の **PreToolUse hook**（全 tool 呼び出し前に効き、subagent 内にも届く）が担う（推奨併用）。
+- worker（subagent）に渡す prompt 自体は無改変でよい。worker は単一モードを実行するため、**親が `--usage-guard` で worker dispatch 前に checkpoint を挟む**ことで wave 粒度の予算対応になる。
+
+#### fail-open
+
+usage-check のシグナル取得が全滅（endpoint → JSONL フォールバックともに失敗）した場合、usage-guard は `ok: true`（fail-open）を返す。drive はそのまま通常進行する — **ガードが自バグで drive を hard-stop させない**。
 
 ### オーケストレーション実行機構の選択
 
@@ -97,6 +144,7 @@ Workflow 方式固有の注意:
 - 途中失敗からの再開は `Workflow({scriptPath, resumeFromRunId})`。完了済み worker はキャッシュから復元される
 - **Phase Final-1 / Final-2 / Final-3 は workflow 終了後に会話側で実行する**。worker の worktree は変更を含むためランタイムの自動削除対象にならず、cleanup 手順（後述の Phase Final-2 節）が引き続き必要。worktree path 規約（`.claude/worktrees/agent-<id>/`）も同一
 - `--merge` 未指定時の一括マージ確認（「完了後」節の AskUserQuestion）は workflow の return 後に行う
+- **`--usage-guard` 指定時の wave checkpoint は会話側で挟む**。workflow スクリプトは決定論実行で SKILL.md の Read も `ScheduleWakeup` も呼べないため、wave 単位で workflow を起動し、各 wave の起動**前**に会話側で「usage-guard 配線」節の checkpoint を実行する（`ok` なら次 wave の workflow を起動、超過なら待機 → `/drive --usage-guard <元の引数>` で再入し、`resumeFromRunId` で完了済み worker をキャッシュ復元して続行）
 
 ### subagent dispatch（オーケストレーションモード・Agent tool 方式 fallback）
 

--- a/src/skills/drive/SKILL.md
+++ b/src/skills/drive/SKILL.md
@@ -40,6 +40,11 @@ Issue または指示を受け取り、実装 → ship → セルフレビュー
 
   オーケストレーションモードでは `--review=quick` を強制し、`final-deep` / `deep` 指定時は警告を出して `quick` にフォールバックする。
 
+- `--usage-guard`: Claude Code の Usage Limit 超過手前で作業を pause し、枠回復後に自動再開する（opt-in）。**Claude Code 環境のみ**（`review --deep` と同じ扱い。OAuth 使用率エンドポイント + `ScheduleWakeup` 依存のため他アダプタでは無効）。pause/resume の配線はホスト依存なので `SKILL.claude-code.md` の「usage-guard 配線（`--usage-guard`）」で吸収する。未指定時は drive 本体の挙動を一切変えない。
+  - 停止は **resumable unit の入口**でのみ行う（単一モード: Phase 1 開始前 / review loop 各反復前、オーケストレーション: 各 wave 開始前 / worker dispatch 前）。mid-implement（PR 作成前）では止めない。
+  - orchestration の停止粒度は **wave 境界**。一度起動した走行中 worker の mid-unit 超過はこのフラグでは止められず、PreToolUse hook（#123）が ceiling を担う。
+  - 超過時は枠リセットまで待機してから継続コマンド `/drive --usage-guard <元の引数>` を自己再入する（drive 冪等 resume で続行）。
+
 ### モード分岐
 
 - target が 1 件かつ依存記法なし → **単一モード**

--- a/tests/drive-overlay.test.mjs
+++ b/tests/drive-overlay.test.mjs
@@ -1,0 +1,125 @@
+// drive `--usage-guard` overlay wiring (issue #122).
+//
+// The pause/resume mechanism is Claude-specific (OAuth usage endpoint +
+// ScheduleWakeup), so the wiring lives in the Claude Code overlay
+// (src/skills/drive/SKILL.claude-code.md) — the precedent is `review --deep`.
+// The neutral drive/SKILL.md only documents the flag as Claude Code only.
+//
+// These are simple string-contains assertions over (a) the source companion,
+// (b) the built claude-code output (companion emitted verbatim as
+// .claude/skills/drive/SKILL.md), and (c) the neutral SKILL.md.
+
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { ClaudeCodeAdapter } from "../scripts/adapters/claude-code.mjs";
+import { assertRequiredFields, parseSkillDocument } from "../scripts/lib/frontmatter.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SRC = join(ROOT, "src", "skills");
+
+async function loadCompanion(name, suffix, requiredFields) {
+  const file = join(SRC, name, `SKILL.${suffix}.md`);
+  if (!existsSync(file)) return null;
+  const raw = await readFile(file, "utf8");
+  const label = `src/skills/${name}/SKILL.${suffix}.md`;
+  const { frontmatter, body } = parseSkillDocument(raw, label);
+  assertRequiredFields(frontmatter, requiredFields, label);
+  return { frontmatter, body, raw };
+}
+
+async function loadSkill(name) {
+  const file = join(SRC, name, "SKILL.md");
+  const raw = await readFile(file, "utf8");
+  const label = `src/skills/${name}/SKILL.md`;
+  const { frontmatter, body } = parseSkillDocument(raw, label);
+  assertRequiredFields(frontmatter, ["name", "description"], label);
+  const claudeCodeCompanion = await loadCompanion(name, "claude-code", ["description"]);
+  return {
+    name: frontmatter.name,
+    description: frontmatter.description,
+    frontmatter,
+    body,
+    raw,
+    claudeCodeCompanion,
+  };
+}
+
+// --- source companion: the wiring section -----------------------------------
+
+test("drive claude-code companion documents the --usage-guard flag + section", async () => {
+  const companion = await loadCompanion("drive", "claude-code", ["description"]);
+  assert.ok(companion, "src/skills/drive/SKILL.claude-code.md must exist");
+  const raw = companion.raw;
+  // argument-hint advertises the flag
+  assert.match(raw, /argument-hint:.*--usage-guard/);
+  // dedicated wiring section
+  assert.ok(
+    raw.includes("usage-guard 配線（`--usage-guard`）"),
+    "companion must carry a dedicated usage-guard wiring section",
+  );
+});
+
+test("drive companion places checkpoints at the four resumable-unit boundaries", async () => {
+  const companion = await loadCompanion("drive", "claude-code", ["description"]);
+  const raw = companion.raw;
+  // Phase 1 start (single mode)
+  assert.ok(raw.includes("Phase 1"), "checkpoint at Phase 1 (implement) start");
+  // each review-loop iteration
+  assert.ok(raw.includes("review loop"), "checkpoint before each review-loop iteration");
+  // each wave (orchestration)
+  assert.ok(raw.includes("wave"), "checkpoint before each wave");
+  // before worker dispatch (orchestration)
+  assert.ok(raw.includes("worker dispatch"), "checkpoint before worker dispatch");
+});
+
+test("drive companion delegates over-threshold to the usage-guard wait-loop + idempotent resume", async () => {
+  const companion = await loadCompanion("drive", "claude-code", ["description"]);
+  const raw = companion.raw;
+  // Reads/invokes the usage-guard engine
+  assert.ok(raw.includes("usage-guard"), "references the usage-guard engine");
+  assert.ok(raw.includes("ScheduleWakeup"), "delegates to ScheduleWakeup-based wait-loop");
+  // continuation command is /drive --usage-guard <original args>
+  assert.ok(
+    raw.includes("/drive --usage-guard"),
+    "continuation command is /drive --usage-guard <original args>",
+  );
+  // checkpoints must sit at resumable boundaries — must NOT pause mid-implement
+  assert.ok(
+    raw.includes("mid-implement") || raw.includes("PR がまだ存在しない"),
+    "must note checkpoints sit at resumable-unit boundaries (no mid-implement pause)",
+  );
+});
+
+// --- built claude-code output (companion emitted verbatim) ------------------
+
+test("built claude-code drive output carries the --usage-guard wiring", async () => {
+  const drive = await loadSkill("drive");
+  const out = await new ClaudeCodeAdapter().generate([drive]);
+  const driveOut = out.find((o) => o.relativePath === ".claude/skills/drive/SKILL.md");
+  assert.ok(driveOut, "claude-code adapter emits .claude/skills/drive/SKILL.md");
+  assert.match(driveOut.content, /--usage-guard/);
+  assert.ok(driveOut.content.includes("ScheduleWakeup"));
+  assert.ok(driveOut.content.includes("/drive --usage-guard"));
+});
+
+// --- neutral SKILL.md: flag is documented as Claude Code only ---------------
+
+test("neutral drive SKILL.md documents --usage-guard as Claude Code only", async () => {
+  const raw = await readFile(join(SRC, "drive", "SKILL.md"), "utf8");
+  assert.match(raw, /--usage-guard/);
+  // marked Claude Code only (same treatment as review --deep)
+  assert.ok(
+    raw.includes("Claude Code 環境のみ") || raw.includes("Claude Code only"),
+    "neutral SKILL.md must mark --usage-guard as Claude Code only",
+  );
+  // wave-boundary granularity + PreToolUse hook ceiling noted
+  assert.ok(raw.includes("wave 境界"), "notes orchestration pauses at wave-boundary granularity");
+  assert.ok(
+    raw.includes("PreToolUse hook"),
+    "notes an in-flight worker's ceiling is the PreToolUse hook",
+  );
+});


### PR DESCRIPTION
## What

Add an opt-in `--usage-guard` flag to `/drive` that makes the autonomous loop budget-aware against the Claude Code Usage Limit (5-hour / weekly). The pause/resume is Claude-specific (OAuth usage endpoint + `ScheduleWakeup`), so the wiring lives in the **Claude Code overlay** (`SKILL.claude-code.md`) — precedent: `review --deep`. drive's core workflow is unchanged; everything is gated behind the flag (no flag → plain drive).

## Changes

- **`src/skills/drive/SKILL.claude-code.md`** — parse `--usage-guard`; insert usage-guard checkpoints (flag-only) at the four resumable-unit boundaries:
  - single mode: each target's **Phase 1 (implement) start**, **before each review-loop iteration**
  - orchestration: **before each wave**, **before worker dispatch**

  At a checkpoint, Read the `usage-guard` engine and run its wait-loop; on over-threshold, `ScheduleWakeup` until the latest exceeded window resets, then self-re-enter with continuation command `/drive --usage-guard <original args>` (drive's idempotent resume continues from the existing PR). Checkpoints sit at resumable-unit boundaries — **never mid-implement** (before a PR exists). Includes a Workflow-mode note (the deterministic workflow script can't Read/ScheduleWakeup, so the wave checkpoint is driven conversation-side between per-wave invocations).
- **`src/skills/drive/SKILL.md`** (neutral) — document `--usage-guard` as **Claude Code only** (same treatment as `review --deep`); note orchestration pauses at **wave-boundary granularity** and that an in-flight worker's ceiling is the **PreToolUse hook (#123)**. Wiring detail stays in the overlay.
- **`README.md` / `CLAUDE.md`** — document the flag in the `drive` entries.
- **`tests/drive-overlay.test.mjs`** (new) — string-contains assertions that the built claude-code drive output (the companion, emitted verbatim as `.claude/skills/drive/SKILL.md`) carries the `--usage-guard` section, the four checkpoints, the `ScheduleWakeup` wait-loop + `/drive --usage-guard` continuation, the no-mid-implement note, and that the neutral SKILL.md marks the flag Claude Code only.
- `dist/` + in-repo dogfood mirrors regenerated via `pnpm build`.

## Verification

- `pnpm build` (idempotent — re-run produces no diff), `pnpm test` (195 pass, incl. 5 new), `pnpm lint:all` (clean).
- ⚠️ **Manual dogfood verification still needed** for live behavior: temporarily set a low threshold (`USAGE_GUARD_THRESHOLD=…`) and confirm `/drive --usage-guard #<test>` pauses at a unit boundary → `ScheduleWakeup` → re-enters and resumes. This cannot be auto-tested (depends on the OAuth usage endpoint + live ScheduleWakeup firing).

Closes #122
Part of #119 (sub-issue C). Depends on the merged #121 (usage-guard engine) / #120 (adapter gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)