### PR TITLE
test(usage-guard): add verification integration test + opt-in smoke harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ pnpm lint:all
 
 `dist/` is committed and the CI verifies it matches `pnpm build` output. After editing any `src/skills/*/SKILL.md` or `src/skills/*/SKILL.claude-code.md`, run `pnpm build` and commit the resulting `dist/` changes.
 
+Verifying the `usage-guard` skill: the deterministic signal runs in CI (`tests/usage-guard-integration.test.mjs`); the live `ScheduleWakeup` pause/resume is driven manually via `scripts/usage-guard-smoke.mjs`. See [docs/usage-guard-verification.md](docs/usage-guard-verification.md).
+
 ## Release flow (maintainer)
 
 `@ozzylabs/skills` is published to npm via [release-please](https://github.com/googleapis/release-please) + OIDC [Trusted Publishers](https://docs.npmjs.com/trusted-publishers). The full pipeline lives in `.github/workflows/release.yaml`:

--- a/docs/usage-guard-verification.md
+++ b/docs/usage-guard-verification.md
@@ -1,0 +1,92 @@
+# usage-guard verification runbook
+
+How to verify the Claude-Code-only `usage-guard` skill (epic #119). The
+deterministic signal is covered by an automated integration test that runs in
+CI; the live `ScheduleWakeup` pause→resume behaviour is covered by an opt-in
+manual harness because it cannot be reproduced hermetically. See also the
+in-process unit tests `tests/usage-check.test.mjs` and
+`tests/usage-guard-hook.test.mjs`.
+
+## A. Automated integration test (CI)
+
+`tests/usage-guard-integration.test.mjs` spawns the REAL
+`src/skills/usage-guard/{usage-check,usage-guard-hook}.mjs` as child processes
+and asserts on the actual exit code + stdout/stderr. It is fully hermetic: each
+spawn runs with `HOME=<tmpHome>` (a `fs.mkdtemp` dir under `os.tmpdir()`), so it
+never touches the real `~/.claude`, and it seeds
+`<tmpHome>/.claude/usage-guard/cache.json` to control the budget signal. Because
+both scripts are cache-first, the seeded cases never reach the OAuth endpoint;
+the no-cache cases have no credentials file, so they don't either.
+
+Run it (with the rest of the suite):
+
+```bash
+pnpm test
+# or just this file:
+node --test 'tests/usage-guard-integration.test.mjs'
+```
+
+Cases exercised:
+
+| # | Scenario | Expected |
+| --- | --- | --- |
+| 1 | hook + over-threshold cache (5h 99%) | exit 2, stderr `Usage Limit reached` + `resets at HH:MM` + `[origin: main session]` |
+| 2 | hook + over-threshold + `agent_id` payload | exit 2, stderr `[origin: subagent abc123]` |
+| 3 | hook + ok cache | exit 0, no deny output |
+| 4 | hook + empty home (no cache/creds) | exit 0 (fail-open), stderr warns `unavailable` / `failing open` |
+| 5 | hook + `USAGE_GUARD_THRESHOLD=10` over an `ok:false` cache | exit 2, deny names `≥ 10%` |
+| 6 | usage-check CLI + over cache | exit 0, stdout JSON `source:"cache"`, `ok:false` |
+| 7 | usage-check CLI + empty home | exit 0, stdout JSON `ok:true`, `source:"fail-open"` |
+
+## B. `/usage-guard` standalone pause→resume (manual)
+
+Uses `scripts/usage-guard-smoke.mjs` against the REAL
+`~/.claude/usage-guard/cache.json` (B/C run in a live Claude session, which
+reads the real cache). Print the exact session commands any time with:
+
+```bash
+node scripts/usage-guard-smoke.mjs steps
+```
+
+Steps:
+
+1. Shell: `node scripts/usage-guard-smoke.mjs seed-over 75` — seed an
+   over-threshold cache (5h 99%, resets in 75s).
+2. Shell: `node scripts/usage-guard-smoke.mjs watch 240` — leave it polling for
+   the resume marker.
+3. Claude: `/usage-guard "node scripts/usage-guard-smoke.mjs mark"` — usage-guard
+   sees the over cache, `ScheduleWakeup`-waits ~75s, then on resume runs the
+   continuation, which writes `/tmp/ug-resumed.marker`.
+4. The watcher prints `PASS (resumed after Ns)` once the marker appears.
+5. Shell: `node scripts/usage-guard-smoke.mjs clear` — **always** clean up the
+   seeded cache.
+
+## C. `/drive --usage-guard` budget-aware loop (manual)
+
+1. Shell: `node scripts/usage-guard-smoke.mjs seed-over 75`.
+2. Claude: `/drive --usage-guard "<a trivial idempotent task>"` — at the first
+   resumable-unit boundary the loop Reads the usage-guard engine, sees over
+   threshold, waits for the window to reset, then re-enters
+   `/drive --usage-guard <args>` and continues.
+3. Confirm the run paused then resumed (engine log / wave boundary).
+4. Shell: `node scripts/usage-guard-smoke.mjs clear`.
+
+Inspect the live signal at any point with
+`node scripts/usage-guard-smoke.mjs status`.
+
+## What cannot be auto-tested, and why
+
+The `ScheduleWakeup` pause→resume cycle (sections B & C) is **not** covered by
+CI. It depends on two things a hermetic, deterministic test can't provide:
+
+- **Real time** — the wakeup fires minutes later when the usage window resets;
+  a unit test would have to either sleep for real (flaky, slow) or mock the
+  clock, which defeats the point of verifying the real pause.
+- **The agent runtime** — `ScheduleWakeup` is an agent-harness primitive, and
+  resuming the continuation command (`/usage-guard "<cmd>"` /
+  `/drive --usage-guard <args>`) is driven by the Claude Code harness, not by a
+  plain Node process.
+
+CI therefore verifies the deterministic budget signal and the hook decision
+(section A); a human drives the real pause/resume with the opt-in harness
+(sections B & C).

--- a/scripts/usage-guard-smoke.mjs
+++ b/scripts/usage-guard-smoke.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+// usage-guard-smoke — OPT-IN, MANUAL harness for the usage-guard runbook (B/C).
+//
+// This is NOT a test. It is intentionally excluded from `node --test`:
+//   - it lives under scripts/, while the test glob is `tests/**/*.test.mjs`, and
+//   - it is named *.mjs (never *.test.mjs).
+//
+// Why it can't be a CI test: runbook sections B & C exercise usage-guard's
+// `ScheduleWakeup` pause→resume against a LIVE Claude Code session and the REAL
+// ~/.claude/usage-guard/cache.json. That round-trip is real-time (the wakeup
+// fires minutes later) and depends on the agent runtime resuming a continuation
+// command — neither of which a deterministic, hermetic CI test can reproduce.
+// The integration test (tests/usage-guard-integration.test.mjs) covers the
+// deterministic signal; THIS harness drives the parts that need a human + the
+// real harness.
+//
+// It operates on the REAL cache file at ~/.claude/usage-guard/cache.json
+// (because B/C run in a live session against the real cache). SAFETY: after a
+// run, ALWAYS execute `node scripts/usage-guard-smoke.mjs clear` to remove the
+// seeded cache so a stale over-threshold signal does not block your next
+// session. The cache TTL is only ~45s, but `clear` is the clean reset.
+//
+// Subcommands:
+//   seed-over [seconds=75]  write an over-threshold cache (5h 99%, 7d 10%,
+//                           resets in N seconds), cached_at=now.
+//   seed-ok                 write an under-threshold (ok) cache.
+//   clear                   remove the cache file and the resume marker.
+//   status                  run the REAL usage-check.mjs and print its JSON.
+//   mark                    write /tmp/ug-resumed.marker with a timestamp
+//                           (use as the continuation command in test B so the
+//                           resume is observable).
+//   watch [seconds=240]     poll for the marker; print PASS (resumed after Ns)
+//                           when it appears, or TIMEOUT after the budget.
+//   steps                   print the exact runbook B & C session commands.
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const CACHE_DIR = join(homedir(), ".claude", "usage-guard");
+const CACHE_PATH = join(CACHE_DIR, "cache.json");
+const MARKER_PATH = "/tmp/ug-resumed.marker";
+
+// usage-check.mjs is shipped as a sibling of SKILL.md. Prefer the user-scope
+// install; fall back to the dogfood project-scope copy in this repo.
+const USER_SCOPE_CHECK = join(homedir(), ".claude", "skills", "usage-guard", "usage-check.mjs");
+const REPO_CHECK = join(
+  dirname(new URL(import.meta.url).pathname),
+  "..",
+  ".claude",
+  "skills",
+  "usage-guard",
+  "usage-check.mjs",
+);
+
+function resolveCheckScript() {
+  if (existsSync(USER_SCOPE_CHECK)) return USER_SCOPE_CHECK;
+  return REPO_CHECK;
+}
+
+/** Write a cache file wrapping `result` with a fresh `cached_at`. */
+async function writeCache(result) {
+  await mkdir(CACHE_DIR, { recursive: true });
+  await writeFile(CACHE_PATH, JSON.stringify({ cached_at: Date.now(), result }, null, 2));
+}
+
+async function seedOver(seconds) {
+  const resetsAt = new Date(Date.now() + seconds * 1000).toISOString();
+  await writeCache({
+    five_hour: { utilization: 99, resets_at: resetsAt },
+    seven_day: { utilization: 10, resets_at: null },
+    ok: false,
+    wait_seconds: seconds,
+    resets_at: resetsAt,
+    source: "endpoint",
+  });
+  console.log(`seeded OVER cache → ${CACHE_PATH}`);
+  console.log(`  5h 99% (resets in ${seconds}s @ ${resetsAt}), 7d 10%, ok:false`);
+}
+
+async function seedOk() {
+  await writeCache({
+    five_hour: { utilization: 40, resets_at: null },
+    seven_day: { utilization: 50, resets_at: null },
+    ok: true,
+    wait_seconds: 0,
+    resets_at: null,
+    source: "endpoint",
+  });
+  console.log(`seeded OK cache → ${CACHE_PATH} (5h 40%, 7d 50%, ok:true)`);
+}
+
+async function clear() {
+  await rm(CACHE_PATH, { force: true });
+  await rm(MARKER_PATH, { force: true });
+  console.log(`cleared ${CACHE_PATH} and ${MARKER_PATH}`);
+}
+
+function status() {
+  const script = resolveCheckScript();
+  if (!existsSync(script)) {
+    console.error(`usage-check.mjs not found (looked at ${USER_SCOPE_CHECK} and ${REPO_CHECK})`);
+    process.exitCode = 1;
+    return;
+  }
+  const res = spawnSync("node", [script], { encoding: "utf8" });
+  if (res.stderr) process.stderr.write(res.stderr);
+  process.stdout.write(res.stdout);
+}
+
+async function mark() {
+  const stamp = new Date().toISOString();
+  await writeFile(MARKER_PATH, `${stamp}\n`);
+  console.log(`wrote resume marker ${MARKER_PATH} @ ${stamp}`);
+}
+
+async function watch(seconds) {
+  const startedAt = Date.now();
+  const deadline = startedAt + seconds * 1000;
+  // Remove any stale marker so we only observe a fresh resume.
+  await rm(MARKER_PATH, { force: true });
+  console.log(`watching for ${MARKER_PATH} (budget ${seconds}s)…`);
+  while (Date.now() < deadline) {
+    if (existsSync(MARKER_PATH)) {
+      const elapsed = Math.round((Date.now() - startedAt) / 1000);
+      console.log(`PASS (resumed after ${elapsed}s)`);
+      return;
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  console.log(`TIMEOUT (no resume within ${seconds}s)`);
+  process.exitCode = 1;
+}
+
+function steps() {
+  console.log(`usage-guard manual runbook (B & C) — copy/paste session commands
+============================================================
+
+Prereqs (shell):
+  - usage-guard installed user-scope (npx @ozzylabs/skills install) OR run
+    from inside this repo (dogfood project-scope copy is used as fallback).
+
+── B. /usage-guard standalone pause→resume ─────────────────────────────────
+1. Shell:  node scripts/usage-guard-smoke.mjs seed-over 75
+2. Shell:  node scripts/usage-guard-smoke.mjs watch 240   (leave running)
+3. Claude: /usage-guard "node scripts/usage-guard-smoke.mjs mark"
+     → usage-guard sees the OVER cache, ScheduleWakeup-waits ~75s, then on
+       resume runs the continuation, which writes the marker.
+4. The watcher prints  PASS (resumed after Ns)  once the marker appears.
+5. Shell:  node scripts/usage-guard-smoke.mjs clear     (ALWAYS clean up)
+
+── C. /drive --usage-guard budget-aware loop ───────────────────────────────
+1. Shell:  node scripts/usage-guard-smoke.mjs seed-over 75
+2. Claude: /drive --usage-guard "<a trivial idempotent task>"
+     → at the first resumable-unit boundary the loop Reads the usage-guard
+       engine, sees OVER, waits for the window, then re-enters
+       /drive --usage-guard <args> and continues.
+3. Confirm the drive run paused then resumed (engine log / wave boundary).
+4. Shell:  node scripts/usage-guard-smoke.mjs clear     (ALWAYS clean up)
+
+Inspect the live signal at any time:
+  node scripts/usage-guard-smoke.mjs status
+`);
+}
+
+async function main() {
+  const [cmd, arg] = process.argv.slice(2);
+  switch (cmd) {
+    case "seed-over":
+      await seedOver(Number.isFinite(Number(arg)) && arg ? Number(arg) : 75);
+      break;
+    case "seed-ok":
+      await seedOk();
+      break;
+    case "clear":
+      await clear();
+      break;
+    case "status":
+      status();
+      break;
+    case "mark":
+      await mark();
+      break;
+    case "watch":
+      await watch(Number.isFinite(Number(arg)) && arg ? Number(arg) : 240);
+      break;
+    case "steps":
+      steps();
+      break;
+    default:
+      console.error(
+        `usage: node scripts/usage-guard-smoke.mjs <seed-over [s] | seed-ok | clear | status | mark | watch [s] | steps>`,
+      );
+      process.exitCode = 2;
+  }
+}
+
+main().catch((err) => {
+  console.error(`usage-guard-smoke: ${err?.message ?? err}`);
+  process.exitCode = 1;
+});

--- a/tests/usage-guard-integration.test.mjs
+++ b/tests/usage-guard-integration.test.mjs
@@ -1,0 +1,207 @@
+// Process-level E2E for the usage-guard skill (epic #119).
+//
+// Unlike the unit tests (tests/usage-check.test.mjs, tests/usage-guard-hook.test.mjs)
+// which exercise the exported pure/injectable functions in-process, THIS file
+// spawns the REAL `src/skills/usage-guard/*.mjs` scripts via `node:child_process`
+// and asserts on their actual exit code + stdout/stderr. It is the only test
+// that proves the end-to-end CLI contract (stdin payload → exit code → message).
+//
+// Fully HERMETIC:
+//   - No network. Both scripts are cache-first (`getUsage` returns a seeded
+//     cache without hitting the OAuth endpoint), and the no-cache cases have no
+//     `.credentials.json` so `readAccessToken` returns null → the endpoint path
+//     is never reached either.
+//   - Never touches the real ~/.claude. Each spawn runs with `HOME=<tmpHome>`
+//     (the scripts build every path from `os.homedir()` → `$HOME` on POSIX), and
+//     the tmpHome is created under `os.tmpdir()` and removed afterwards.
+//
+// We seed `<tmpHome>/.claude/usage-guard/cache.json` with the
+// `{ cached_at, result }` shape usage-check.mjs writes to fully control the
+// budget signal.
+
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = join(HERE, "..", "src", "skills", "usage-guard");
+const HOOK = join(SRC, "usage-guard-hook.mjs");
+const CHECK = join(SRC, "usage-check.mjs");
+
+let tmpHome;
+
+beforeEach(async () => {
+  tmpHome = await mkdtemp(join(tmpdir(), "usage-guard-it-"));
+});
+
+afterEach(async () => {
+  if (tmpHome) await rm(tmpHome, { recursive: true, force: true });
+  tmpHome = null;
+});
+
+/**
+ * Seed `<tmpHome>/.claude/usage-guard/cache.json` with a fresh cache wrapping
+ * the given `result` (the JSON shape usage-check.mjs emits). `cached_at` is now
+ * so the 45s TTL keeps it fresh → cache-first, no endpoint/JSONL.
+ * @param {object} result
+ */
+async function seedCache(result) {
+  const dir = join(tmpHome, ".claude", "usage-guard");
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "cache.json"), JSON.stringify({ cached_at: Date.now(), result }));
+}
+
+/** A reset timestamp ~1h out (so the hook can render `resets at HH:MM`). */
+function resetInOneHour() {
+  return new Date(Date.now() + 60 * 60 * 1000).toISOString();
+}
+
+/** Over-threshold cache result: 5h at 99%, 7d at 10%, ok:false. */
+function overResult(resetsAt = resetInOneHour()) {
+  return {
+    five_hour: { utilization: 99, resets_at: resetsAt },
+    seven_day: { utilization: 10, resets_at: null },
+    ok: false,
+    wait_seconds: 3600,
+    resets_at: resetsAt,
+    source: "endpoint",
+  };
+}
+
+/** Under-threshold cache result: both windows low, ok:true. */
+function okResult() {
+  return {
+    five_hour: { utilization: 40, resets_at: null },
+    seven_day: { utilization: 50, resets_at: null },
+    ok: true,
+    wait_seconds: 0,
+    resets_at: null,
+    source: "endpoint",
+  };
+}
+
+/**
+ * Spawn the real script with HOME=<tmpHome>, optionally piping a stdin payload.
+ * Resolves with { code, stdout, stderr } on process close.
+ * @param {string} script absolute path to the .mjs
+ * @param {object} [opts]
+ * @param {string|null} [opts.stdin]   payload to write then end (null = no write)
+ * @param {Record<string,string>} [opts.env]  extra env vars
+ * @returns {Promise<{ code: number, stdout: string, stderr: string }>}
+ */
+function spawnScript(script, { stdin = null, env = {} } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [script], {
+      env: { ...process.env, HOME: tmpHome, ...env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (c) => {
+      stdout += c;
+    });
+    child.stderr.on("data", (c) => {
+      stderr += c;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+    if (stdin !== null) child.stdin.write(stdin);
+    child.stdin.end();
+  });
+}
+
+// ── Case 1: hook + over-threshold seeded cache → deny (exit 2) ───────────────
+test("hook: over-threshold seeded cache → exit 2 with 'Usage Limit reached' + reset time", async () => {
+  await seedCache(overResult());
+  const { code, stdout, stderr } = await spawnScript(HOOK, { stdin: "{}" });
+  assert.equal(code, 2, "over threshold → DENY (exit 2)");
+  assert.match(stderr, /Usage Limit reached/, "deny reason names the limit");
+  assert.match(stderr, /5h 99%/, "deny reason names the exceeded window");
+  assert.match(stderr, /resets at \d{2}:\d{2}/, "deny reason carries the local reset time");
+  assert.match(stderr, /\[origin: main session\]/, "no agent_id → main session origin");
+  assert.equal(stdout, "", "deny goes to stderr, not stdout");
+});
+
+// ── Case 2: hook + subagent agent_id over-threshold → deny tagged subagent ───
+test("hook: over-threshold + agent_id payload → exit 2 tagged 'subagent abc123'", async () => {
+  await seedCache(overResult());
+  const { code, stderr } = await spawnScript(HOOK, { stdin: '{"agent_id":"abc123"}' });
+  assert.equal(code, 2, "over threshold → DENY (exit 2)");
+  assert.match(stderr, /Usage Limit reached/);
+  assert.match(stderr, /\[origin: subagent abc123\]/, "deny reason records the subagent origin");
+});
+
+// ── Case 3: hook + ok seeded cache → allow (exit 0), silent ──────────────────
+test("hook: under-threshold seeded cache → exit 0 with no deny output", async () => {
+  await seedCache(okResult());
+  const { code, stdout, stderr } = await spawnScript(HOOK, { stdin: "{}" });
+  assert.equal(code, 0, "under threshold → ALLOW (exit 0)");
+  assert.equal(stdout, "", "allow path is silent on stdout");
+  assert.doesNotMatch(stderr, /Usage Limit reached/, "no deny reason when under threshold");
+});
+
+// ── Case 4: hook + no cache / no creds → fail-open allow (exit 0) + warn ─────
+test("hook: no cache + no credentials → exit 0 (fail-open) with an 'unavailable' warning", async () => {
+  // Empty tmpHome: no cache, no ~/.claude/.credentials.json, no projects dir.
+  // resolveUsage → getUsage: endpoint has no token, JSONL has no projects dir,
+  // so getUsage returns a fail-open ok:true result and warns on stderr. The
+  // hook then ALLOWs (the signal is "ok"), never hard-stopping on its own gap.
+  const { code, stdout, stderr } = await spawnScript(HOOK, { stdin: "{}" });
+  assert.equal(code, 0, "no signal → fail-open ALLOW (exit 0)");
+  assert.equal(stdout, "", "fail-open path is silent on stdout");
+  assert.match(stderr, /unavailable/, "warns that the signal is unavailable");
+  assert.match(stderr, /failing open/, "warns it is failing open (never hard-stops)");
+  assert.doesNotMatch(stderr, /Usage Limit reached/, "fail-open must never emit a deny");
+});
+
+// ── Case 5: hook + USAGE_GUARD_THRESHOLD env threads into the deny message ───
+test("hook: USAGE_GUARD_THRESHOLD=10 over an ok:false cache → deny names the overridden threshold", async () => {
+  // The hook trusts `usage.ok` from the cache (it does not re-evaluate the
+  // windows). To keep this case correct against decide(), we seed ok:false with
+  // ~12% windows and override the threshold to 10. decide() then re-formats the
+  // exceeded windows against the env threshold (12% ≥ 10%) and the env value
+  // shows up verbatim in the deny reason — proving the env parses end to end.
+  const resetsAt = resetInOneHour();
+  await seedCache({
+    five_hour: { utilization: 12, resets_at: resetsAt },
+    seven_day: { utilization: 5, resets_at: null },
+    ok: false,
+    wait_seconds: 3600,
+    resets_at: resetsAt,
+    source: "endpoint",
+  });
+  const { code, stderr } = await spawnScript(HOOK, {
+    stdin: "{}",
+    env: { USAGE_GUARD_THRESHOLD: "10" },
+  });
+  assert.equal(code, 2, "ok:false signal → DENY (exit 2)");
+  assert.match(stderr, /Usage Limit reached/);
+  assert.match(stderr, /5h 12%/, "names the (low) exceeded window");
+  assert.match(stderr, /≥ 10%/, "the overridden threshold env is parsed and surfaced");
+});
+
+// ── Case 6: usage-check CLI + over seeded cache → JSON, source=cache, ok=false ─
+test("usage-check CLI: over seeded cache → stdout JSON parses, source='cache', ok=false", async () => {
+  await seedCache(overResult());
+  const { code, stdout } = await spawnScript(CHECK);
+  assert.equal(code, 0, "usage-check always exits 0 (the JSON 'ok' is the signal)");
+  const json = JSON.parse(stdout.trim());
+  assert.equal(json.source, "cache", "served from the seeded cache (no endpoint hit)");
+  assert.equal(json.ok, false, "over threshold → ok:false");
+  assert.equal(json.five_hour.utilization, 99, "windows round-trip through the cache");
+});
+
+// ── Case 7: usage-check CLI + empty tmpHome → fail-open ok:true ──────────────
+test("usage-check CLI: no cache / creds / projects → exit 0, JSON ok=true, source='fail-open'", async () => {
+  // Empty tmpHome: cache miss → endpoint (no token) throws → JSONL (no projects
+  // dir) throws → fail-open. ok:true so a missing signal never blocks work.
+  const { code, stdout } = await spawnScript(CHECK);
+  assert.equal(code, 0, "fail-open still exits 0");
+  const json = JSON.parse(stdout.trim());
+  assert.equal(json.ok, true, "fail-open is an 'ok' signal");
+  assert.equal(json.source, "fail-open", "both endpoint and JSONL unavailable → fail-open");
+});


### PR DESCRIPTION
Adds verification coverage for the Claude-Code-only `usage-guard` skill (epic #119).

## What

- **`tests/usage-guard-integration.test.mjs`** — hermetic, process-level E2E. Spawns the REAL `src/skills/usage-guard/{usage-check,usage-guard-hook}.mjs` via `node:child_process` with `HOME=<tmpHome>` and a seeded `cache.json` to control the budget signal. Asserts exit code + stdout/stderr across 7 cases: over/ok seeded cache, subagent `agent_id` origin, no-cache fail-open, `USAGE_GUARD_THRESHOLD` env, and the usage-check CLI `source`/`ok`. No network; never touches the real `~/.claude` (cache-first + no creds file).
- **`scripts/usage-guard-smoke.mjs`** — opt-in MANUAL harness (NOT a test; lives in `scripts/`, not `tests/**/*.test.mjs`) operating on the real cache: `seed-over` / `seed-ok` / `clear` / `status` / `mark` / `watch` / `steps`. Drives runbook B/C in a live session.
- **`docs/usage-guard-verification.md`** — runbook: A = automated test, B/C = manual session steps, plus a "what cannot be auto-tested and why" note.
- **`README.md`** — one-line pointer to the runbook under Local development.

## Verification

`pnpm build` (no `dist/` change), `pnpm test` (216 pass, +7 new), `pnpm lint:all` all green.

## Note

Sections **B & C remain manual**: the real-time `ScheduleWakeup` pause→resume depends on the agent runtime and cannot be reproduced in a hermetic CI test. CI covers the deterministic signal + hook decision (section A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)