### PR TITLE
feat(usage-guard): detect post-reset reflection lag + bypass cache

### DIFF
--- a/.claude/skills/drive/SKILL.md
+++ b/.claude/skills/drive/SKILL.md
@@ -69,6 +69,7 @@ usage-guard の取り扱い:
 3. `ok: false`（いずれかの枠が閾値超過）→ usage-guard の wait-loop に委譲する。`wait_seconds` にはポストリセットのバッファ（`resume_buffer_seconds`、既定 +300 秒）が折り込まれており、待機は `resets_at + buffer` まで延びる（リセット丁度の再突入による再ハネを回避）:
    - in-session・待機 ≤1h → `ScheduleWakeup(min(wait_seconds, 3600))` で heartbeat を仕込み、**待機する**（待機中は再入せず予算を消費しない）。`wait_seconds` が 3600 を超える場合は複数回に分けて再チェックする。
    - 非 /loop オーケストレーション（Agent tool / Workflow drive）・待機 >1h・再起動耐性が必要 → `CronCreate`（`recurring: false`, durable）を **`resets_at + resume_buffer_seconds`** にセットし、発火時に継続コマンドを再投入する（壁時計一発・再起動耐性。one-shot は発火後 auto-delete）。既定 ON によりこの経路（>1h・非 /loop）を踏みやすいため、該当時は `ScheduleWakeup` ではなく **`CronCreate`(one-shot, durable)** を優先する。詳細は usage-guard SKILL.md §軽量 wait-loop「再開トリガの選択」。
+   - **反映ラグ疑い時（`suspected_reflection_lag: true`）は境界に長時間 CronCreate を張らず、短間隔（`wait_seconds` ≈ 180 秒）で `ScheduleWakeup` 再チェック**する（境界直後の前枠残像による偽 100% を回復確認後に拾い、~5h 放置の偽陰性を回避。usage-guard SKILL.md §振る舞い: 反映ラグ検知 を参照）。
    - 起床したら継続コマンド **`/drive <元の引数>`** を自己再入する（既定 ON のため `--usage-guard` を強制付与しない。`--no-usage-guard` がユーザー指定されていた場合のみ引き継ぐ ── ただし `--no-usage-guard` 時はそもそも本節を実行しないため、実際の継続コマンドは元の引数をそのまま渡せばよい）。drive の冪等 resume が既存 PR / ブランチ / 完了済み worker を検出して**続きから再開**する（待機を挟んでも重複副作用を生まない）。
    - `usage-check.mjs` が `ok: true` を返すまで 3〜4 を繰り返す。
 

--- a/.claude/skills/usage-guard/SKILL.md
+++ b/.claude/skills/usage-guard/SKILL.md
@@ -50,6 +50,7 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
 - endpoint 失敗時は `~/.claude/projects/*/*.jsonl` の per-message `usage` + timestamp から 5h / 7d window を推定する JSONL フォールバック
 - endpoint と JSONL の**両方が失敗したら fail-open**（`ok: true`）+ stderr に警告（ガードが自バグで hard-stop しない）
 - 超過時の `wait_seconds` には**ポストリセットのバッファ**（既定 +300 秒）を加算する。サーバ側 `utilization` 反映の遅延・ScheduleWakeup の発火ブレを吸収し、リセット丁度に絞られた枠へ再突入して再ハネするのを防ぐ（後述「閾値」「振る舞い: 再開バッファ」）
+- **反映ラグ検知**（`suspected_reflection_lag`）: リセット直後はサーバ側 `utilization` が**前枠の残像**を返すことがある（リセット済みなのに 5h util 100% 等）。超過枠が**境界直後**（枠開始からの経過 `elapsed = period - (resets_at - now)` が epsilon=900 秒未満）なら矛盾とみなし、`wait_seconds` を full-window ではなく**短い再チェック間隔**（既定 180 秒）に切り替える。この結果は cache に書かない（後述「振る舞い: 反映ラグ検知」）
 
 ### 出力 JSON
 
@@ -61,14 +62,16 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
   "wait_seconds": 0,
   "resets_at": null,
   "resume_buffer_seconds": 300,
+  "suspected_reflection_lag": false,
   "source": "endpoint"
 }
 ```
 
 - `ok`: **両枠の `utilization` が閾値未満**なら `true`
-- `wait_seconds`: 超過枠の `resets_at` の**最遅**（最も遅くリセットする枠）までの秒数 **+ `resume_buffer_seconds`**。`ok` のときは `0`
-- `resets_at`: その最遅の超過枠の `resets_at`（**枠端のまま不変**。バッファは加算しない）。`ok` のときは `null`。再開予定 = `resets_at + resume_buffer_seconds` として区別できる
+- `wait_seconds`: 超過枠の `resets_at` の**最遅**（最も遅くリセットする枠）までの秒数 **+ `resume_buffer_seconds`**。`ok` のときは `0`。**`suspected_reflection_lag` が `true` のときは**短い再チェック間隔（`USAGE_GUARD_LAG_RECHECK_SECONDS`、既定 180 秒）に縮退する
+- `resets_at`: その最遅の超過枠の `resets_at`（**枠端のまま不変**。バッファ加算も lag 縮退もしない）。`ok` のときは `null`。再開予定 = `resets_at + resume_buffer_seconds` として区別できる
 - `resume_buffer_seconds`: `wait_seconds` に折り込まれたポストリセットのバッファ秒数（既定 300、0 で従来挙動）
+- `suspected_reflection_lag`: 反映ラグ（境界直後なのに超過）の疑いなら `true`。`true` のとき `wait_seconds` は短い再チェック間隔になり、この結果は **cache に書かれない**（次チェックが endpoint 実値を即取得できる）。`ok` のときは常に `false`。endpoint / jsonl 両経路でセットされる
 - `source`: `endpoint` / `jsonl` / `cache` / `fail-open`
 
 ### 振る舞い: 再開バッファ
@@ -79,11 +82,27 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
 - `ok`（未超過）時はバッファを加算しない（`wait_seconds: 0`）
 - PreToolUse hook の deny ヒント（「あと N 分」）も `wait_seconds` 由来なのでバッファ込みで提示され整合する
 
+### 振る舞い: 反映ラグ検知（境界直後の偽陰性回避）
+
+リセット直後はサーバ側 `utilization` が**前枠の残像**を引きずることがある（例: 5h 枠が 21:00 にリセット済みなのに 21:05 の endpoint が util 100% を返し、`resets_at` は既に次境界 02:00 を指す矛盾状態）。この状態をそのまま扱うと「回復済みの枠を ~5h 無駄に放置」する偽陰性になる。`resume_buffer`（#129）は「reset 未到来」前提の対策でこのケースには効かない。
+
+判定原理: 超過枠ごとに **枠開始からの経過** `elapsed = period - (resets_at - now)`（`five_hour` の period = 18000 秒、`seven_day` = 604800 秒）を算出する。`elapsed` が epsilon（`USAGE_GUARD_LAG_EPSILON_SECONDS`、既定 900 秒）未満かつ超過なら**矛盾** → 反映ラグの疑いとして `suspected_reflection_lag = true` をセットする。
+
+- lag 疑い時は `wait_seconds` を full-window+buffer ではなく**短い再チェック間隔**（`USAGE_GUARD_LAG_RECHECK_SECONDS`、既定 180 秒）にする。caller は長時間 CronCreate を境界に張らず、この短間隔で再 fetch すればラグ解消後の実値を拾える
+- `resets_at` は**枠端のまま不変**（情報を捨てない）
+- lag 疑いの結果は **cache に書かない**（前枠の偽 100% が TTL 間 cache に固定されて再チェックを潰すのを防ぐ。次チェックは endpoint 実値を即取得する）
+- `ok`（閾値未満）のときは lag 判定せず常に `suspected_reflection_lag: false`
+
 ### 閾値
 
 既定 95%。環境変数 `USAGE_GUARD_THRESHOLD` で上書き可能（例 `USAGE_GUARD_THRESHOLD=80`）。
 
 ポストリセットの再開バッファは既定 300 秒。環境変数 `USAGE_GUARD_RESUME_BUFFER_SECONDS` で上書き可能（例 `USAGE_GUARD_RESUME_BUFFER_SECONDS=600`）。`0` で従来挙動（`resets_at` 丁度に再開）に戻せる。負値・非数値は既定 300 にフォールバックする。
+
+反映ラグ検知の閾値も env で上書きできる:
+
+- `USAGE_GUARD_LAG_EPSILON_SECONDS`（既定 900）: 境界直後とみなす経過秒数。これより `elapsed` が小さい超過枠を lag 疑いとする。負値・非数値・空は既定 900 にフォールバック
+- `USAGE_GUARD_LAG_RECHECK_SECONDS`（既定 180）: lag 疑い時の短い再チェック間隔。`0` 以下・非数値・空は既定 180 にフォールバック（busy-loop 防止）
 
 ## 軽量 wait-loop（共通ロジック）
 
@@ -93,9 +112,10 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
 2. **劣化チェック**: `source !== "endpoint"`（`cache` は endpoint 由来なので除外）なら劣化警告を出す。特に `source === "fail-open"` のときは「⚠️ usage-guard 劣化: source=fail-open、実際には監視していません」を**呼び出し側・ユーザーに明示**し、drive caller はレポートに残す（allow / 進行は維持。§環境要件 を案内）
 3. `ok` なら**通常進行**（継続コマンドを実行 / caller は次の checkpoint へ）
 4. `ok` が `false` なら再開トリガを選び（下記「再開トリガの選択」）、**待機する**
-   - `wait_seconds` には `resume_buffer_seconds`（既定 300）が折り込まれているので、待機は `resets_at + buffer` まで延びる
+   - **反映ラグ疑い時（`suspected_reflection_lag: true`）は短間隔で再チェック**する。`wait_seconds` は既に短い再チェック間隔（既定 180 秒）に縮退しているので、境界に長時間 CronCreate one-shot を張らず、`ScheduleWakeup(wait_seconds)` 等でこの短間隔だけ待って再び `usage-check.mjs` を叩く。ラグが解消すれば次チェックで実値（多くは `ok: true`）を拾い継続できる（前枠残像のまま ~5h 放置する偽陰性を回避）
+   - 通常の超過時は `wait_seconds` に `resume_buffer_seconds`（既定 300）が折り込まれているので、待機は `resets_at + buffer` まで延びる
    - **待機中は再入しない**（予算を一切消費しない）
-5. 起床したら再び `usage-check.mjs` を実行し、`ok` になるまで 2〜5 を繰り返す
+5. 起床したら再び `usage-check.mjs` を実行し、`ok` になるまで 2〜5 を繰り返す（lag 疑いの結果は cache に書かれないので、再チェックは endpoint 実値を即取得する）
 6. `ok` になったら継続コマンドへ進む
 
 > `wait_seconds` は `resets_at`（+ buffer）から算出するため秒精度ではない。ScheduleWakeup の発火も下限 + オーバーヘッドで多少遅れる（実機で 60s 要求に対し ~110s）。reset 待ちには十分な精度。

--- a/.claude/skills/usage-guard/usage-check.mjs
+++ b/.claude/skills/usage-guard/usage-check.mjs
@@ -15,16 +15,28 @@
 // functional path literal here is written in the rewritable skills-dir form.
 //
 // Output (stdout, single JSON line):
-//   { five_hour, seven_day, ok, wait_seconds, resets_at, resume_buffer_seconds, source }
+//   { five_hour, seven_day, ok, wait_seconds, resets_at, resume_buffer_seconds,
+//     suspected_reflection_lag, source }
 //   - five_hour / seven_day: { utilization (0-100), resets_at (ISO|null) }
 //   - ok:           both windows' utilization < threshold (default 95)
 //   - wait_seconds: seconds until the LATEST resets_at among exceeded windows
 //                   PLUS the post-reset resume buffer (0 when ok). Derived from
-//                   `resets_at` minus now, plus resume_buffer_seconds.
+//                   `resets_at` minus now, plus resume_buffer_seconds. When a
+//                   reflection lag is suspected (see below) this collapses to a
+//                   short recheck interval instead of a full window.
 //   - resets_at:    that same latest exceeded resets_at, UNCHANGED by the buffer
 //                   (the window edge; the planned resume = resets_at + buffer)
 //   - resume_buffer_seconds: the post-reset safety margin folded into
 //                   wait_seconds (default 300; 0 restores the legacy behaviour)
+//   - suspected_reflection_lag: true when an exceeded window is also barely past
+//                   its boundary (elapsed = period - (resets_at - now) < epsilon).
+//                   This is the "reset happened but the server-side utilization
+//                   still shows the previous window's residue" contradiction
+//                   (#133). When set, wait_seconds collapses to a SHORT recheck
+//                   interval so the caller re-fetches the real post-lag value
+//                   soon instead of idling a full window; resets_at stays the
+//                   raw window edge. Such results are NOT cached (so the next
+//                   check hits the live endpoint, not the stale lagged value).
 //   - source:       "endpoint" | "jsonl" | "fail-open" | "cache"
 //
 // Fail-open: if the endpoint fails AND the JSONL fallback fails, emit
@@ -50,6 +62,20 @@ const DEFAULT_RESUME_BUFFER_SECONDS = 300;
 const DEFAULT_CACHE_TTL_MS = 45_000; // 30–60s window so the #123 hook can share it.
 const FIVE_HOUR_MS = 5 * 60 * 60 * 1000;
 const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1000;
+// Reflection-lag detection (#133). After a window resets, the server-side
+// `utilization` can briefly still report the PREVIOUS window's residue (e.g.
+// 100% at 5 minutes into a fresh 5h window). An exceeded window whose elapsed
+// time since its boundary is below this epsilon is treated as "suspected
+// reflection lag" rather than a genuine throttle.
+const DEFAULT_LAG_EPSILON_SECONDS = 900; // 15 min boundary-proximity window.
+// When a lag is suspected we wait only this short interval before re-checking
+// (instead of a full window + buffer) so the real post-lag value is picked up
+// quickly. resets_at is left at the raw window edge (information preserved).
+const DEFAULT_LAG_RECHECK_SECONDS = 180; // 3 min recheck cadence.
+// Per-window period lengths in SECONDS, used to compute elapsed-since-boundary
+// for the lag check: elapsed = period - (resets_at - now).
+const FIVE_HOUR_PERIOD_S = FIVE_HOUR_MS / 1000; // 18000
+const SEVEN_DAY_PERIOD_S = SEVEN_DAY_MS / 1000; // 604800
 
 // HOME-anchored paths, built with path.join so no rewritable skills-dir literal
 // ever appears in source (M2).
@@ -88,6 +114,47 @@ export function resolveResumeBuffer(env = process.env) {
     return DEFAULT_RESUME_BUFFER_SECONDS;
   const n = Number(raw);
   if (!Number.isFinite(n) || n < 0) return DEFAULT_RESUME_BUFFER_SECONDS;
+  return n;
+}
+
+/**
+ * Resolve the reflection-lag epsilon in seconds (env override → default).
+ *
+ * `USAGE_GUARD_LAG_EPSILON_SECONDS` overrides the default (900). An exceeded
+ * window whose elapsed time since its boundary is below this value is treated
+ * as suspected reflection lag (#133). Negative/non-finite/blank → default.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {number}
+ */
+export function resolveLagEpsilon(env = process.env) {
+  const raw = env?.USAGE_GUARD_LAG_EPSILON_SECONDS;
+  if (raw === undefined || raw === null || String(raw).trim() === "")
+    return DEFAULT_LAG_EPSILON_SECONDS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_LAG_EPSILON_SECONDS;
+  return n;
+}
+
+/**
+ * Resolve the reflection-lag recheck interval in seconds (env override →
+ * default).
+ *
+ * `USAGE_GUARD_LAG_RECHECK_SECONDS` overrides the default (180). When a lag is
+ * suspected, `wait_seconds` collapses to this short cadence so the caller
+ * re-fetches the real value soon (#133). Negative/non-finite/blank → default.
+ * A value of 0 is rejected (collapses to default) because a zero recheck would
+ * busy-loop.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {number}
+ */
+export function resolveLagRecheck(env = process.env) {
+  const raw = env?.USAGE_GUARD_LAG_RECHECK_SECONDS;
+  if (raw === undefined || raw === null || String(raw).trim() === "")
+    return DEFAULT_LAG_RECHECK_SECONDS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_LAG_RECHECK_SECONDS;
   return n;
 }
 
@@ -165,29 +232,50 @@ export function normalizeWindows(payload) {
  * `utilization` can lag the reset). `resets_at` stays the raw window edge — the
  * planned resume time is `resets_at + resumeBuffer`, kept distinguishable.
  *
+ * Reflection-lag (#133): for each exceeded window we also compute how long it
+ * has been since that window's boundary
+ * (`elapsed = period - (resets_at - now)`). If ANY exceeded window is barely
+ * past its boundary (`elapsed < lagEpsilon`) the over-threshold reading is most
+ * likely the previous window's residue still echoing through the endpoint, not
+ * a genuine throttle. In that case `suspected_reflection_lag` is set and
+ * `wait_seconds` collapses to the short `lagRecheck` interval (instead of a
+ * full window + buffer) so the caller re-fetches the real value soon. `resets_at`
+ * is preserved as the raw window edge in both cases.
+ *
  * @param {{ five_hour: {utilization:number,resets_at:string|null}, seven_day: {utilization:number,resets_at:string|null} }} windows
  * @param {object} [opts]
  * @param {number} [opts.threshold]
  * @param {number} [opts.resumeBuffer] post-reset buffer in seconds (default 300)
+ * @param {number} [opts.lagEpsilon] boundary-proximity window in seconds (default 900)
+ * @param {number} [opts.lagRecheck] short recheck interval when lag suspected (default 180)
  * @param {() => number} [opts.now]
- * @returns {{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, resume_buffer_seconds: number }}
+ * @returns {{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, resume_buffer_seconds: number, suspected_reflection_lag: boolean }}
  */
 export function evaluate(
   windows,
   {
     threshold = DEFAULT_THRESHOLD,
     resumeBuffer = DEFAULT_RESUME_BUFFER_SECONDS,
+    lagEpsilon = DEFAULT_LAG_EPSILON_SECONDS,
+    lagRecheck = DEFAULT_LAG_RECHECK_SECONDS,
     now = Date.now,
   } = {},
 ) {
-  const exceeded = [windows.five_hour, windows.seven_day].filter((w) => w.utilization >= threshold);
+  // Pair each window with its period (seconds) so we can compute elapsed since
+  // the window boundary for the reflection-lag check.
+  const exceeded = [
+    { w: windows.five_hour, periodS: FIVE_HOUR_PERIOD_S },
+    { w: windows.seven_day, periodS: SEVEN_DAY_PERIOD_S },
+  ].filter(({ w }) => w.utilization >= threshold);
   const ok = exceeded.length === 0;
   let resetsAt = null;
   let waitSeconds = 0;
+  let suspectedReflectionLag = false;
+  const nowMs = now();
   if (!ok) {
     // Latest resets_at among exceeded windows (max epoch); ignore unparseable.
     let latestMs = null;
-    for (const w of exceeded) {
+    for (const { w, periodS } of exceeded) {
       if (!w.resets_at) continue;
       const ms = Date.parse(w.resets_at);
       if (Number.isNaN(ms)) continue;
@@ -195,10 +283,18 @@ export function evaluate(
         latestMs = ms;
         resetsAt = w.resets_at;
       }
+      // elapsed since this window's boundary = period - (resets_at - now).
+      // Small elapsed + over-threshold = the reset just happened but the
+      // endpoint is still echoing the prior window's residue → lag suspected.
+      const elapsedS = periodS - (ms - nowMs) / 1000;
+      if (elapsedS >= 0 && elapsedS < lagEpsilon) suspectedReflectionLag = true;
     }
-    if (latestMs !== null) {
+    if (suspectedReflectionLag) {
+      // Don't idle a full window on a likely-stale 100%; re-check soon.
+      waitSeconds = Math.max(1, Math.ceil(lagRecheck));
+    } else if (latestMs !== null) {
       // wait = time to the window edge + the post-reset safety buffer.
-      waitSeconds = Math.max(0, Math.ceil((latestMs - now()) / 1000)) + Math.max(0, resumeBuffer);
+      waitSeconds = Math.max(0, Math.ceil((latestMs - nowMs) / 1000)) + Math.max(0, resumeBuffer);
     }
   }
   return {
@@ -208,6 +304,7 @@ export function evaluate(
     wait_seconds: waitSeconds,
     resets_at: resetsAt,
     resume_buffer_seconds: Math.max(0, resumeBuffer),
+    suspected_reflection_lag: suspectedReflectionLag,
   };
 }
 
@@ -390,7 +487,7 @@ export async function writeCache(
  * cache, and clock. `warn` defaults to stderr.
  *
  * @param {object} [deps]
- * @returns {Promise<{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, source: string }>}
+ * @returns {Promise<{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, resume_buffer_seconds: number, suspected_reflection_lag: boolean, source: string }>}
  */
 export async function getUsage({
   fetchImpl = fetch,
@@ -408,28 +505,37 @@ export async function getUsage({
 } = {}) {
   const threshold = resolveThreshold(env);
   const resumeBuffer = resolveResumeBuffer(env);
+  const lagEpsilon = resolveLagEpsilon(env);
+  const lagRecheck = resolveLagRecheck(env);
 
   // 1. Fresh cache → return as-is (no endpoint re-fetch within TTL).
   const cached = await readCache({ readFileImpl, cachePath, ttlMs: cacheTtlMs, now });
   if (cached) return { ...cached, source: "cache" };
 
-  const evalOpts = { threshold, resumeBuffer, now };
+  const evalOpts = { threshold, resumeBuffer, lagEpsilon, lagRecheck, now };
+
+  // Cache-bypass (#133): a suspected reflection lag is a transient, likely-stale
+  // 100% reading. Persisting it would pin the false signal for the cache TTL and
+  // re-serve it on the next check, defeating the short recheck. So when the
+  // result flags a lag we skip the cache write — the next check hits the live
+  // endpoint and can observe the post-lag value immediately.
+  const maybeCache = async (result) => {
+    if (result.suspected_reflection_lag) return result; // do NOT cache a lagged read
+    await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
+    return result;
+  };
 
   // 2. Endpoint.
   try {
     const token = await readAccessToken({ readFileImpl, credentialsPath, now });
     if (!token) throw new Error("no usable OAuth access token");
     const windows = await fetchEndpointUsage(token, { fetchImpl });
-    const result = { ...evaluate(windows, evalOpts), source: "endpoint" };
-    await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
-    return result;
+    return await maybeCache({ ...evaluate(windows, evalOpts), source: "endpoint" });
   } catch (endpointErr) {
     // 3. JSONL fallback.
     try {
       const windows = await aggregateJsonlUsage({ readdirImpl, readFileImpl, projectsDir, now });
-      const result = { ...evaluate(windows, evalOpts), source: "jsonl" };
-      await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
-      return result;
+      return await maybeCache({ ...evaluate(windows, evalOpts), source: "jsonl" });
     } catch (jsonlErr) {
       // 4. Both failed → fail-open + warn (guard never hard-stops on its bug).
       warn(
@@ -442,6 +548,7 @@ export async function getUsage({
         wait_seconds: 0,
         resets_at: null,
         resume_buffer_seconds: resumeBuffer,
+        suspected_reflection_lag: false,
         source: "fail-open",
       };
     }
@@ -468,6 +575,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
         wait_seconds: 0,
         resets_at: null,
         resume_buffer_seconds: resolveResumeBuffer(),
+        suspected_reflection_lag: false,
         source: "fail-open",
       })}\n`,
     );

--- a/dist/claude-code-project/.claude/skills/drive/SKILL.md
+++ b/dist/claude-code-project/.claude/skills/drive/SKILL.md
@@ -69,6 +69,7 @@ usage-guard の取り扱い:
 3. `ok: false`（いずれかの枠が閾値超過）→ usage-guard の wait-loop に委譲する。`wait_seconds` にはポストリセットのバッファ（`resume_buffer_seconds`、既定 +300 秒）が折り込まれており、待機は `resets_at + buffer` まで延びる（リセット丁度の再突入による再ハネを回避）:
    - in-session・待機 ≤1h → `ScheduleWakeup(min(wait_seconds, 3600))` で heartbeat を仕込み、**待機する**（待機中は再入せず予算を消費しない）。`wait_seconds` が 3600 を超える場合は複数回に分けて再チェックする。
    - 非 /loop オーケストレーション（Agent tool / Workflow drive）・待機 >1h・再起動耐性が必要 → `CronCreate`（`recurring: false`, durable）を **`resets_at + resume_buffer_seconds`** にセットし、発火時に継続コマンドを再投入する（壁時計一発・再起動耐性。one-shot は発火後 auto-delete）。既定 ON によりこの経路（>1h・非 /loop）を踏みやすいため、該当時は `ScheduleWakeup` ではなく **`CronCreate`(one-shot, durable)** を優先する。詳細は usage-guard SKILL.md §軽量 wait-loop「再開トリガの選択」。
+   - **反映ラグ疑い時（`suspected_reflection_lag: true`）は境界に長時間 CronCreate を張らず、短間隔（`wait_seconds` ≈ 180 秒）で `ScheduleWakeup` 再チェック**する（境界直後の前枠残像による偽 100% を回復確認後に拾い、~5h 放置の偽陰性を回避。usage-guard SKILL.md §振る舞い: 反映ラグ検知 を参照）。
    - 起床したら継続コマンド **`/drive <元の引数>`** を自己再入する（既定 ON のため `--usage-guard` を強制付与しない。`--no-usage-guard` がユーザー指定されていた場合のみ引き継ぐ ── ただし `--no-usage-guard` 時はそもそも本節を実行しないため、実際の継続コマンドは元の引数をそのまま渡せばよい）。drive の冪等 resume が既存 PR / ブランチ / 完了済み worker を検出して**続きから再開**する（待機を挟んでも重複副作用を生まない）。
    - `usage-check.mjs` が `ok: true` を返すまで 3〜4 を繰り返す。
 

--- a/dist/claude-code-project/.claude/skills/usage-guard/SKILL.md
+++ b/dist/claude-code-project/.claude/skills/usage-guard/SKILL.md
@@ -50,6 +50,7 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
 - endpoint 失敗時は `~/.claude/projects/*/*.jsonl` の per-message `usage` + timestamp から 5h / 7d window を推定する JSONL フォールバック
 - endpoint と JSONL の**両方が失敗したら fail-open**（`ok: true`）+ stderr に警告（ガードが自バグで hard-stop しない）
 - 超過時の `wait_seconds` には**ポストリセットのバッファ**（既定 +300 秒）を加算する。サーバ側 `utilization` 反映の遅延・ScheduleWakeup の発火ブレを吸収し、リセット丁度に絞られた枠へ再突入して再ハネするのを防ぐ（後述「閾値」「振る舞い: 再開バッファ」）
+- **反映ラグ検知**（`suspected_reflection_lag`）: リセット直後はサーバ側 `utilization` が**前枠の残像**を返すことがある（リセット済みなのに 5h util 100% 等）。超過枠が**境界直後**（枠開始からの経過 `elapsed = period - (resets_at - now)` が epsilon=900 秒未満）なら矛盾とみなし、`wait_seconds` を full-window ではなく**短い再チェック間隔**（既定 180 秒）に切り替える。この結果は cache に書かない（後述「振る舞い: 反映ラグ検知」）
 
 ### 出力 JSON
 
@@ -61,14 +62,16 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
   "wait_seconds": 0,
   "resets_at": null,
   "resume_buffer_seconds": 300,
+  "suspected_reflection_lag": false,
   "source": "endpoint"
 }
 ```
 
 - `ok`: **両枠の `utilization` が閾値未満**なら `true`
-- `wait_seconds`: 超過枠の `resets_at` の**最遅**（最も遅くリセットする枠）までの秒数 **+ `resume_buffer_seconds`**。`ok` のときは `0`
-- `resets_at`: その最遅の超過枠の `resets_at`（**枠端のまま不変**。バッファは加算しない）。`ok` のときは `null`。再開予定 = `resets_at + resume_buffer_seconds` として区別できる
+- `wait_seconds`: 超過枠の `resets_at` の**最遅**（最も遅くリセットする枠）までの秒数 **+ `resume_buffer_seconds`**。`ok` のときは `0`。**`suspected_reflection_lag` が `true` のときは**短い再チェック間隔（`USAGE_GUARD_LAG_RECHECK_SECONDS`、既定 180 秒）に縮退する
+- `resets_at`: その最遅の超過枠の `resets_at`（**枠端のまま不変**。バッファ加算も lag 縮退もしない）。`ok` のときは `null`。再開予定 = `resets_at + resume_buffer_seconds` として区別できる
 - `resume_buffer_seconds`: `wait_seconds` に折り込まれたポストリセットのバッファ秒数（既定 300、0 で従来挙動）
+- `suspected_reflection_lag`: 反映ラグ（境界直後なのに超過）の疑いなら `true`。`true` のとき `wait_seconds` は短い再チェック間隔になり、この結果は **cache に書かれない**（次チェックが endpoint 実値を即取得できる）。`ok` のときは常に `false`。endpoint / jsonl 両経路でセットされる
 - `source`: `endpoint` / `jsonl` / `cache` / `fail-open`
 
 ### 振る舞い: 再開バッファ
@@ -79,11 +82,27 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
 - `ok`（未超過）時はバッファを加算しない（`wait_seconds: 0`）
 - PreToolUse hook の deny ヒント（「あと N 分」）も `wait_seconds` 由来なのでバッファ込みで提示され整合する
 
+### 振る舞い: 反映ラグ検知（境界直後の偽陰性回避）
+
+リセット直後はサーバ側 `utilization` が**前枠の残像**を引きずることがある（例: 5h 枠が 21:00 にリセット済みなのに 21:05 の endpoint が util 100% を返し、`resets_at` は既に次境界 02:00 を指す矛盾状態）。この状態をそのまま扱うと「回復済みの枠を ~5h 無駄に放置」する偽陰性になる。`resume_buffer`（#129）は「reset 未到来」前提の対策でこのケースには効かない。
+
+判定原理: 超過枠ごとに **枠開始からの経過** `elapsed = period - (resets_at - now)`（`five_hour` の period = 18000 秒、`seven_day` = 604800 秒）を算出する。`elapsed` が epsilon（`USAGE_GUARD_LAG_EPSILON_SECONDS`、既定 900 秒）未満かつ超過なら**矛盾** → 反映ラグの疑いとして `suspected_reflection_lag = true` をセットする。
+
+- lag 疑い時は `wait_seconds` を full-window+buffer ではなく**短い再チェック間隔**（`USAGE_GUARD_LAG_RECHECK_SECONDS`、既定 180 秒）にする。caller は長時間 CronCreate を境界に張らず、この短間隔で再 fetch すればラグ解消後の実値を拾える
+- `resets_at` は**枠端のまま不変**（情報を捨てない）
+- lag 疑いの結果は **cache に書かない**（前枠の偽 100% が TTL 間 cache に固定されて再チェックを潰すのを防ぐ。次チェックは endpoint 実値を即取得する）
+- `ok`（閾値未満）のときは lag 判定せず常に `suspected_reflection_lag: false`
+
 ### 閾値
 
 既定 95%。環境変数 `USAGE_GUARD_THRESHOLD` で上書き可能（例 `USAGE_GUARD_THRESHOLD=80`）。
 
 ポストリセットの再開バッファは既定 300 秒。環境変数 `USAGE_GUARD_RESUME_BUFFER_SECONDS` で上書き可能（例 `USAGE_GUARD_RESUME_BUFFER_SECONDS=600`）。`0` で従来挙動（`resets_at` 丁度に再開）に戻せる。負値・非数値は既定 300 にフォールバックする。
+
+反映ラグ検知の閾値も env で上書きできる:
+
+- `USAGE_GUARD_LAG_EPSILON_SECONDS`（既定 900）: 境界直後とみなす経過秒数。これより `elapsed` が小さい超過枠を lag 疑いとする。負値・非数値・空は既定 900 にフォールバック
+- `USAGE_GUARD_LAG_RECHECK_SECONDS`（既定 180）: lag 疑い時の短い再チェック間隔。`0` 以下・非数値・空は既定 180 にフォールバック（busy-loop 防止）
 
 ## 軽量 wait-loop（共通ロジック）
 
@@ -93,9 +112,10 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
 2. **劣化チェック**: `source !== "endpoint"`（`cache` は endpoint 由来なので除外）なら劣化警告を出す。特に `source === "fail-open"` のときは「⚠️ usage-guard 劣化: source=fail-open、実際には監視していません」を**呼び出し側・ユーザーに明示**し、drive caller はレポートに残す（allow / 進行は維持。§環境要件 を案内）
 3. `ok` なら**通常進行**（継続コマンドを実行 / caller は次の checkpoint へ）
 4. `ok` が `false` なら再開トリガを選び（下記「再開トリガの選択」）、**待機する**
-   - `wait_seconds` には `resume_buffer_seconds`（既定 300）が折り込まれているので、待機は `resets_at + buffer` まで延びる
+   - **反映ラグ疑い時（`suspected_reflection_lag: true`）は短間隔で再チェック**する。`wait_seconds` は既に短い再チェック間隔（既定 180 秒）に縮退しているので、境界に長時間 CronCreate one-shot を張らず、`ScheduleWakeup(wait_seconds)` 等でこの短間隔だけ待って再び `usage-check.mjs` を叩く。ラグが解消すれば次チェックで実値（多くは `ok: true`）を拾い継続できる（前枠残像のまま ~5h 放置する偽陰性を回避）
+   - 通常の超過時は `wait_seconds` に `resume_buffer_seconds`（既定 300）が折り込まれているので、待機は `resets_at + buffer` まで延びる
    - **待機中は再入しない**（予算を一切消費しない）
-5. 起床したら再び `usage-check.mjs` を実行し、`ok` になるまで 2〜5 を繰り返す
+5. 起床したら再び `usage-check.mjs` を実行し、`ok` になるまで 2〜5 を繰り返す（lag 疑いの結果は cache に書かれないので、再チェックは endpoint 実値を即取得する）
 6. `ok` になったら継続コマンドへ進む
 
 > `wait_seconds` は `resets_at`（+ buffer）から算出するため秒精度ではない。ScheduleWakeup の発火も下限 + オーバーヘッドで多少遅れる（実機で 60s 要求に対し ~110s）。reset 待ちには十分な精度。

--- a/dist/claude-code-project/.claude/skills/usage-guard/usage-check.mjs
+++ b/dist/claude-code-project/.claude/skills/usage-guard/usage-check.mjs
@@ -15,16 +15,28 @@
 // functional path literal here is written in the rewritable skills-dir form.
 //
 // Output (stdout, single JSON line):
-//   { five_hour, seven_day, ok, wait_seconds, resets_at, resume_buffer_seconds, source }
+//   { five_hour, seven_day, ok, wait_seconds, resets_at, resume_buffer_seconds,
+//     suspected_reflection_lag, source }
 //   - five_hour / seven_day: { utilization (0-100), resets_at (ISO|null) }
 //   - ok:           both windows' utilization < threshold (default 95)
 //   - wait_seconds: seconds until the LATEST resets_at among exceeded windows
 //                   PLUS the post-reset resume buffer (0 when ok). Derived from
-//                   `resets_at` minus now, plus resume_buffer_seconds.
+//                   `resets_at` minus now, plus resume_buffer_seconds. When a
+//                   reflection lag is suspected (see below) this collapses to a
+//                   short recheck interval instead of a full window.
 //   - resets_at:    that same latest exceeded resets_at, UNCHANGED by the buffer
 //                   (the window edge; the planned resume = resets_at + buffer)
 //   - resume_buffer_seconds: the post-reset safety margin folded into
 //                   wait_seconds (default 300; 0 restores the legacy behaviour)
+//   - suspected_reflection_lag: true when an exceeded window is also barely past
+//                   its boundary (elapsed = period - (resets_at - now) < epsilon).
+//                   This is the "reset happened but the server-side utilization
+//                   still shows the previous window's residue" contradiction
+//                   (#133). When set, wait_seconds collapses to a SHORT recheck
+//                   interval so the caller re-fetches the real post-lag value
+//                   soon instead of idling a full window; resets_at stays the
+//                   raw window edge. Such results are NOT cached (so the next
+//                   check hits the live endpoint, not the stale lagged value).
 //   - source:       "endpoint" | "jsonl" | "fail-open" | "cache"
 //
 // Fail-open: if the endpoint fails AND the JSONL fallback fails, emit
@@ -50,6 +62,20 @@ const DEFAULT_RESUME_BUFFER_SECONDS = 300;
 const DEFAULT_CACHE_TTL_MS = 45_000; // 30–60s window so the #123 hook can share it.
 const FIVE_HOUR_MS = 5 * 60 * 60 * 1000;
 const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1000;
+// Reflection-lag detection (#133). After a window resets, the server-side
+// `utilization` can briefly still report the PREVIOUS window's residue (e.g.
+// 100% at 5 minutes into a fresh 5h window). An exceeded window whose elapsed
+// time since its boundary is below this epsilon is treated as "suspected
+// reflection lag" rather than a genuine throttle.
+const DEFAULT_LAG_EPSILON_SECONDS = 900; // 15 min boundary-proximity window.
+// When a lag is suspected we wait only this short interval before re-checking
+// (instead of a full window + buffer) so the real post-lag value is picked up
+// quickly. resets_at is left at the raw window edge (information preserved).
+const DEFAULT_LAG_RECHECK_SECONDS = 180; // 3 min recheck cadence.
+// Per-window period lengths in SECONDS, used to compute elapsed-since-boundary
+// for the lag check: elapsed = period - (resets_at - now).
+const FIVE_HOUR_PERIOD_S = FIVE_HOUR_MS / 1000; // 18000
+const SEVEN_DAY_PERIOD_S = SEVEN_DAY_MS / 1000; // 604800
 
 // HOME-anchored paths, built with path.join so no rewritable skills-dir literal
 // ever appears in source (M2).
@@ -88,6 +114,47 @@ export function resolveResumeBuffer(env = process.env) {
     return DEFAULT_RESUME_BUFFER_SECONDS;
   const n = Number(raw);
   if (!Number.isFinite(n) || n < 0) return DEFAULT_RESUME_BUFFER_SECONDS;
+  return n;
+}
+
+/**
+ * Resolve the reflection-lag epsilon in seconds (env override → default).
+ *
+ * `USAGE_GUARD_LAG_EPSILON_SECONDS` overrides the default (900). An exceeded
+ * window whose elapsed time since its boundary is below this value is treated
+ * as suspected reflection lag (#133). Negative/non-finite/blank → default.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {number}
+ */
+export function resolveLagEpsilon(env = process.env) {
+  const raw = env?.USAGE_GUARD_LAG_EPSILON_SECONDS;
+  if (raw === undefined || raw === null || String(raw).trim() === "")
+    return DEFAULT_LAG_EPSILON_SECONDS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_LAG_EPSILON_SECONDS;
+  return n;
+}
+
+/**
+ * Resolve the reflection-lag recheck interval in seconds (env override →
+ * default).
+ *
+ * `USAGE_GUARD_LAG_RECHECK_SECONDS` overrides the default (180). When a lag is
+ * suspected, `wait_seconds` collapses to this short cadence so the caller
+ * re-fetches the real value soon (#133). Negative/non-finite/blank → default.
+ * A value of 0 is rejected (collapses to default) because a zero recheck would
+ * busy-loop.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {number}
+ */
+export function resolveLagRecheck(env = process.env) {
+  const raw = env?.USAGE_GUARD_LAG_RECHECK_SECONDS;
+  if (raw === undefined || raw === null || String(raw).trim() === "")
+    return DEFAULT_LAG_RECHECK_SECONDS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_LAG_RECHECK_SECONDS;
   return n;
 }
 
@@ -165,29 +232,50 @@ export function normalizeWindows(payload) {
  * `utilization` can lag the reset). `resets_at` stays the raw window edge — the
  * planned resume time is `resets_at + resumeBuffer`, kept distinguishable.
  *
+ * Reflection-lag (#133): for each exceeded window we also compute how long it
+ * has been since that window's boundary
+ * (`elapsed = period - (resets_at - now)`). If ANY exceeded window is barely
+ * past its boundary (`elapsed < lagEpsilon`) the over-threshold reading is most
+ * likely the previous window's residue still echoing through the endpoint, not
+ * a genuine throttle. In that case `suspected_reflection_lag` is set and
+ * `wait_seconds` collapses to the short `lagRecheck` interval (instead of a
+ * full window + buffer) so the caller re-fetches the real value soon. `resets_at`
+ * is preserved as the raw window edge in both cases.
+ *
  * @param {{ five_hour: {utilization:number,resets_at:string|null}, seven_day: {utilization:number,resets_at:string|null} }} windows
  * @param {object} [opts]
  * @param {number} [opts.threshold]
  * @param {number} [opts.resumeBuffer] post-reset buffer in seconds (default 300)
+ * @param {number} [opts.lagEpsilon] boundary-proximity window in seconds (default 900)
+ * @param {number} [opts.lagRecheck] short recheck interval when lag suspected (default 180)
  * @param {() => number} [opts.now]
- * @returns {{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, resume_buffer_seconds: number }}
+ * @returns {{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, resume_buffer_seconds: number, suspected_reflection_lag: boolean }}
  */
 export function evaluate(
   windows,
   {
     threshold = DEFAULT_THRESHOLD,
     resumeBuffer = DEFAULT_RESUME_BUFFER_SECONDS,
+    lagEpsilon = DEFAULT_LAG_EPSILON_SECONDS,
+    lagRecheck = DEFAULT_LAG_RECHECK_SECONDS,
     now = Date.now,
   } = {},
 ) {
-  const exceeded = [windows.five_hour, windows.seven_day].filter((w) => w.utilization >= threshold);
+  // Pair each window with its period (seconds) so we can compute elapsed since
+  // the window boundary for the reflection-lag check.
+  const exceeded = [
+    { w: windows.five_hour, periodS: FIVE_HOUR_PERIOD_S },
+    { w: windows.seven_day, periodS: SEVEN_DAY_PERIOD_S },
+  ].filter(({ w }) => w.utilization >= threshold);
   const ok = exceeded.length === 0;
   let resetsAt = null;
   let waitSeconds = 0;
+  let suspectedReflectionLag = false;
+  const nowMs = now();
   if (!ok) {
     // Latest resets_at among exceeded windows (max epoch); ignore unparseable.
     let latestMs = null;
-    for (const w of exceeded) {
+    for (const { w, periodS } of exceeded) {
       if (!w.resets_at) continue;
       const ms = Date.parse(w.resets_at);
       if (Number.isNaN(ms)) continue;
@@ -195,10 +283,18 @@ export function evaluate(
         latestMs = ms;
         resetsAt = w.resets_at;
       }
+      // elapsed since this window's boundary = period - (resets_at - now).
+      // Small elapsed + over-threshold = the reset just happened but the
+      // endpoint is still echoing the prior window's residue → lag suspected.
+      const elapsedS = periodS - (ms - nowMs) / 1000;
+      if (elapsedS >= 0 && elapsedS < lagEpsilon) suspectedReflectionLag = true;
     }
-    if (latestMs !== null) {
+    if (suspectedReflectionLag) {
+      // Don't idle a full window on a likely-stale 100%; re-check soon.
+      waitSeconds = Math.max(1, Math.ceil(lagRecheck));
+    } else if (latestMs !== null) {
       // wait = time to the window edge + the post-reset safety buffer.
-      waitSeconds = Math.max(0, Math.ceil((latestMs - now()) / 1000)) + Math.max(0, resumeBuffer);
+      waitSeconds = Math.max(0, Math.ceil((latestMs - nowMs) / 1000)) + Math.max(0, resumeBuffer);
     }
   }
   return {
@@ -208,6 +304,7 @@ export function evaluate(
     wait_seconds: waitSeconds,
     resets_at: resetsAt,
     resume_buffer_seconds: Math.max(0, resumeBuffer),
+    suspected_reflection_lag: suspectedReflectionLag,
   };
 }
 
@@ -390,7 +487,7 @@ export async function writeCache(
  * cache, and clock. `warn` defaults to stderr.
  *
  * @param {object} [deps]
- * @returns {Promise<{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, source: string }>}
+ * @returns {Promise<{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, resume_buffer_seconds: number, suspected_reflection_lag: boolean, source: string }>}
  */
 export async function getUsage({
   fetchImpl = fetch,
@@ -408,28 +505,37 @@ export async function getUsage({
 } = {}) {
   const threshold = resolveThreshold(env);
   const resumeBuffer = resolveResumeBuffer(env);
+  const lagEpsilon = resolveLagEpsilon(env);
+  const lagRecheck = resolveLagRecheck(env);
 
   // 1. Fresh cache → return as-is (no endpoint re-fetch within TTL).
   const cached = await readCache({ readFileImpl, cachePath, ttlMs: cacheTtlMs, now });
   if (cached) return { ...cached, source: "cache" };
 
-  const evalOpts = { threshold, resumeBuffer, now };
+  const evalOpts = { threshold, resumeBuffer, lagEpsilon, lagRecheck, now };
+
+  // Cache-bypass (#133): a suspected reflection lag is a transient, likely-stale
+  // 100% reading. Persisting it would pin the false signal for the cache TTL and
+  // re-serve it on the next check, defeating the short recheck. So when the
+  // result flags a lag we skip the cache write — the next check hits the live
+  // endpoint and can observe the post-lag value immediately.
+  const maybeCache = async (result) => {
+    if (result.suspected_reflection_lag) return result; // do NOT cache a lagged read
+    await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
+    return result;
+  };
 
   // 2. Endpoint.
   try {
     const token = await readAccessToken({ readFileImpl, credentialsPath, now });
     if (!token) throw new Error("no usable OAuth access token");
     const windows = await fetchEndpointUsage(token, { fetchImpl });
-    const result = { ...evaluate(windows, evalOpts), source: "endpoint" };
-    await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
-    return result;
+    return await maybeCache({ ...evaluate(windows, evalOpts), source: "endpoint" });
   } catch (endpointErr) {
     // 3. JSONL fallback.
     try {
       const windows = await aggregateJsonlUsage({ readdirImpl, readFileImpl, projectsDir, now });
-      const result = { ...evaluate(windows, evalOpts), source: "jsonl" };
-      await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
-      return result;
+      return await maybeCache({ ...evaluate(windows, evalOpts), source: "jsonl" });
     } catch (jsonlErr) {
       // 4. Both failed → fail-open + warn (guard never hard-stops on its bug).
       warn(
@@ -442,6 +548,7 @@ export async function getUsage({
         wait_seconds: 0,
         resets_at: null,
         resume_buffer_seconds: resumeBuffer,
+        suspected_reflection_lag: false,
         source: "fail-open",
       };
     }
@@ -468,6 +575,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
         wait_seconds: 0,
         resets_at: null,
         resume_buffer_seconds: resolveResumeBuffer(),
+        suspected_reflection_lag: false,
         source: "fail-open",
       })}\n`,
     );

--- a/dist/claude-code/.claude/skills/drive/SKILL.md
+++ b/dist/claude-code/.claude/skills/drive/SKILL.md
@@ -69,6 +69,7 @@ usage-guard の取り扱い:
 3. `ok: false`（いずれかの枠が閾値超過）→ usage-guard の wait-loop に委譲する。`wait_seconds` にはポストリセットのバッファ（`resume_buffer_seconds`、既定 +300 秒）が折り込まれており、待機は `resets_at + buffer` まで延びる（リセット丁度の再突入による再ハネを回避）:
    - in-session・待機 ≤1h → `ScheduleWakeup(min(wait_seconds, 3600))` で heartbeat を仕込み、**待機する**（待機中は再入せず予算を消費しない）。`wait_seconds` が 3600 を超える場合は複数回に分けて再チェックする。
    - 非 /loop オーケストレーション（Agent tool / Workflow drive）・待機 >1h・再起動耐性が必要 → `CronCreate`（`recurring: false`, durable）を **`resets_at + resume_buffer_seconds`** にセットし、発火時に継続コマンドを再投入する（壁時計一発・再起動耐性。one-shot は発火後 auto-delete）。既定 ON によりこの経路（>1h・非 /loop）を踏みやすいため、該当時は `ScheduleWakeup` ではなく **`CronCreate`(one-shot, durable)** を優先する。詳細は usage-guard SKILL.md §軽量 wait-loop「再開トリガの選択」。
+   - **反映ラグ疑い時（`suspected_reflection_lag: true`）は境界に長時間 CronCreate を張らず、短間隔（`wait_seconds` ≈ 180 秒）で `ScheduleWakeup` 再チェック**する（境界直後の前枠残像による偽 100% を回復確認後に拾い、~5h 放置の偽陰性を回避。usage-guard SKILL.md §振る舞い: 反映ラグ検知 を参照）。
    - 起床したら継続コマンド **`/drive <元の引数>`** を自己再入する（既定 ON のため `--usage-guard` を強制付与しない。`--no-usage-guard` がユーザー指定されていた場合のみ引き継ぐ ── ただし `--no-usage-guard` 時はそもそも本節を実行しないため、実際の継続コマンドは元の引数をそのまま渡せばよい）。drive の冪等 resume が既存 PR / ブランチ / 完了済み worker を検出して**続きから再開**する（待機を挟んでも重複副作用を生まない）。
    - `usage-check.mjs` が `ok: true` を返すまで 3〜4 を繰り返す。
 

--- a/dist/claude-code/.claude/skills/usage-guard/SKILL.md
+++ b/dist/claude-code/.claude/skills/usage-guard/SKILL.md
@@ -50,6 +50,7 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
 - endpoint 失敗時は `~/.claude/projects/*/*.jsonl` の per-message `usage` + timestamp から 5h / 7d window を推定する JSONL フォールバック
 - endpoint と JSONL の**両方が失敗したら fail-open**（`ok: true`）+ stderr に警告（ガードが自バグで hard-stop しない）
 - 超過時の `wait_seconds` には**ポストリセットのバッファ**（既定 +300 秒）を加算する。サーバ側 `utilization` 反映の遅延・ScheduleWakeup の発火ブレを吸収し、リセット丁度に絞られた枠へ再突入して再ハネするのを防ぐ（後述「閾値」「振る舞い: 再開バッファ」）
+- **反映ラグ検知**（`suspected_reflection_lag`）: リセット直後はサーバ側 `utilization` が**前枠の残像**を返すことがある（リセット済みなのに 5h util 100% 等）。超過枠が**境界直後**（枠開始からの経過 `elapsed = period - (resets_at - now)` が epsilon=900 秒未満）なら矛盾とみなし、`wait_seconds` を full-window ではなく**短い再チェック間隔**（既定 180 秒）に切り替える。この結果は cache に書かない（後述「振る舞い: 反映ラグ検知」）
 
 ### 出力 JSON
 
@@ -61,14 +62,16 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
   "wait_seconds": 0,
   "resets_at": null,
   "resume_buffer_seconds": 300,
+  "suspected_reflection_lag": false,
   "source": "endpoint"
 }
 ```
 
 - `ok`: **両枠の `utilization` が閾値未満**なら `true`
-- `wait_seconds`: 超過枠の `resets_at` の**最遅**（最も遅くリセットする枠）までの秒数 **+ `resume_buffer_seconds`**。`ok` のときは `0`
-- `resets_at`: その最遅の超過枠の `resets_at`（**枠端のまま不変**。バッファは加算しない）。`ok` のときは `null`。再開予定 = `resets_at + resume_buffer_seconds` として区別できる
+- `wait_seconds`: 超過枠の `resets_at` の**最遅**（最も遅くリセットする枠）までの秒数 **+ `resume_buffer_seconds`**。`ok` のときは `0`。**`suspected_reflection_lag` が `true` のときは**短い再チェック間隔（`USAGE_GUARD_LAG_RECHECK_SECONDS`、既定 180 秒）に縮退する
+- `resets_at`: その最遅の超過枠の `resets_at`（**枠端のまま不変**。バッファ加算も lag 縮退もしない）。`ok` のときは `null`。再開予定 = `resets_at + resume_buffer_seconds` として区別できる
 - `resume_buffer_seconds`: `wait_seconds` に折り込まれたポストリセットのバッファ秒数（既定 300、0 で従来挙動）
+- `suspected_reflection_lag`: 反映ラグ（境界直後なのに超過）の疑いなら `true`。`true` のとき `wait_seconds` は短い再チェック間隔になり、この結果は **cache に書かれない**（次チェックが endpoint 実値を即取得できる）。`ok` のときは常に `false`。endpoint / jsonl 両経路でセットされる
 - `source`: `endpoint` / `jsonl` / `cache` / `fail-open`
 
 ### 振る舞い: 再開バッファ
@@ -79,11 +82,27 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
 - `ok`（未超過）時はバッファを加算しない（`wait_seconds: 0`）
 - PreToolUse hook の deny ヒント（「あと N 分」）も `wait_seconds` 由来なのでバッファ込みで提示され整合する
 
+### 振る舞い: 反映ラグ検知（境界直後の偽陰性回避）
+
+リセット直後はサーバ側 `utilization` が**前枠の残像**を引きずることがある（例: 5h 枠が 21:00 にリセット済みなのに 21:05 の endpoint が util 100% を返し、`resets_at` は既に次境界 02:00 を指す矛盾状態）。この状態をそのまま扱うと「回復済みの枠を ~5h 無駄に放置」する偽陰性になる。`resume_buffer`（#129）は「reset 未到来」前提の対策でこのケースには効かない。
+
+判定原理: 超過枠ごとに **枠開始からの経過** `elapsed = period - (resets_at - now)`（`five_hour` の period = 18000 秒、`seven_day` = 604800 秒）を算出する。`elapsed` が epsilon（`USAGE_GUARD_LAG_EPSILON_SECONDS`、既定 900 秒）未満かつ超過なら**矛盾** → 反映ラグの疑いとして `suspected_reflection_lag = true` をセットする。
+
+- lag 疑い時は `wait_seconds` を full-window+buffer ではなく**短い再チェック間隔**（`USAGE_GUARD_LAG_RECHECK_SECONDS`、既定 180 秒）にする。caller は長時間 CronCreate を境界に張らず、この短間隔で再 fetch すればラグ解消後の実値を拾える
+- `resets_at` は**枠端のまま不変**（情報を捨てない）
+- lag 疑いの結果は **cache に書かない**（前枠の偽 100% が TTL 間 cache に固定されて再チェックを潰すのを防ぐ。次チェックは endpoint 実値を即取得する）
+- `ok`（閾値未満）のときは lag 判定せず常に `suspected_reflection_lag: false`
+
 ### 閾値
 
 既定 95%。環境変数 `USAGE_GUARD_THRESHOLD` で上書き可能（例 `USAGE_GUARD_THRESHOLD=80`）。
 
 ポストリセットの再開バッファは既定 300 秒。環境変数 `USAGE_GUARD_RESUME_BUFFER_SECONDS` で上書き可能（例 `USAGE_GUARD_RESUME_BUFFER_SECONDS=600`）。`0` で従来挙動（`resets_at` 丁度に再開）に戻せる。負値・非数値は既定 300 にフォールバックする。
+
+反映ラグ検知の閾値も env で上書きできる:
+
+- `USAGE_GUARD_LAG_EPSILON_SECONDS`（既定 900）: 境界直後とみなす経過秒数。これより `elapsed` が小さい超過枠を lag 疑いとする。負値・非数値・空は既定 900 にフォールバック
+- `USAGE_GUARD_LAG_RECHECK_SECONDS`（既定 180）: lag 疑い時の短い再チェック間隔。`0` 以下・非数値・空は既定 180 にフォールバック（busy-loop 防止）
 
 ## 軽量 wait-loop（共通ロジック）
 
@@ -93,9 +112,10 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
 2. **劣化チェック**: `source !== "endpoint"`（`cache` は endpoint 由来なので除外）なら劣化警告を出す。特に `source === "fail-open"` のときは「⚠️ usage-guard 劣化: source=fail-open、実際には監視していません」を**呼び出し側・ユーザーに明示**し、drive caller はレポートに残す（allow / 進行は維持。§環境要件 を案内）
 3. `ok` なら**通常進行**（継続コマンドを実行 / caller は次の checkpoint へ）
 4. `ok` が `false` なら再開トリガを選び（下記「再開トリガの選択」）、**待機する**
-   - `wait_seconds` には `resume_buffer_seconds`（既定 300）が折り込まれているので、待機は `resets_at + buffer` まで延びる
+   - **反映ラグ疑い時（`suspected_reflection_lag: true`）は短間隔で再チェック**する。`wait_seconds` は既に短い再チェック間隔（既定 180 秒）に縮退しているので、境界に長時間 CronCreate one-shot を張らず、`ScheduleWakeup(wait_seconds)` 等でこの短間隔だけ待って再び `usage-check.mjs` を叩く。ラグが解消すれば次チェックで実値（多くは `ok: true`）を拾い継続できる（前枠残像のまま ~5h 放置する偽陰性を回避）
+   - 通常の超過時は `wait_seconds` に `resume_buffer_seconds`（既定 300）が折り込まれているので、待機は `resets_at + buffer` まで延びる
    - **待機中は再入しない**（予算を一切消費しない）
-5. 起床したら再び `usage-check.mjs` を実行し、`ok` になるまで 2〜5 を繰り返す
+5. 起床したら再び `usage-check.mjs` を実行し、`ok` になるまで 2〜5 を繰り返す（lag 疑いの結果は cache に書かれないので、再チェックは endpoint 実値を即取得する）
 6. `ok` になったら継続コマンドへ進む
 
 > `wait_seconds` は `resets_at`（+ buffer）から算出するため秒精度ではない。ScheduleWakeup の発火も下限 + オーバーヘッドで多少遅れる（実機で 60s 要求に対し ~110s）。reset 待ちには十分な精度。

--- a/dist/claude-code/.claude/skills/usage-guard/usage-check.mjs
+++ b/dist/claude-code/.claude/skills/usage-guard/usage-check.mjs
@@ -15,16 +15,28 @@
 // functional path literal here is written in the rewritable skills-dir form.
 //
 // Output (stdout, single JSON line):
-//   { five_hour, seven_day, ok, wait_seconds, resets_at, resume_buffer_seconds, source }
+//   { five_hour, seven_day, ok, wait_seconds, resets_at, resume_buffer_seconds,
+//     suspected_reflection_lag, source }
 //   - five_hour / seven_day: { utilization (0-100), resets_at (ISO|null) }
 //   - ok:           both windows' utilization < threshold (default 95)
 //   - wait_seconds: seconds until the LATEST resets_at among exceeded windows
 //                   PLUS the post-reset resume buffer (0 when ok). Derived from
-//                   `resets_at` minus now, plus resume_buffer_seconds.
+//                   `resets_at` minus now, plus resume_buffer_seconds. When a
+//                   reflection lag is suspected (see below) this collapses to a
+//                   short recheck interval instead of a full window.
 //   - resets_at:    that same latest exceeded resets_at, UNCHANGED by the buffer
 //                   (the window edge; the planned resume = resets_at + buffer)
 //   - resume_buffer_seconds: the post-reset safety margin folded into
 //                   wait_seconds (default 300; 0 restores the legacy behaviour)
+//   - suspected_reflection_lag: true when an exceeded window is also barely past
+//                   its boundary (elapsed = period - (resets_at - now) < epsilon).
+//                   This is the "reset happened but the server-side utilization
+//                   still shows the previous window's residue" contradiction
+//                   (#133). When set, wait_seconds collapses to a SHORT recheck
+//                   interval so the caller re-fetches the real post-lag value
+//                   soon instead of idling a full window; resets_at stays the
+//                   raw window edge. Such results are NOT cached (so the next
+//                   check hits the live endpoint, not the stale lagged value).
 //   - source:       "endpoint" | "jsonl" | "fail-open" | "cache"
 //
 // Fail-open: if the endpoint fails AND the JSONL fallback fails, emit
@@ -50,6 +62,20 @@ const DEFAULT_RESUME_BUFFER_SECONDS = 300;
 const DEFAULT_CACHE_TTL_MS = 45_000; // 30–60s window so the #123 hook can share it.
 const FIVE_HOUR_MS = 5 * 60 * 60 * 1000;
 const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1000;
+// Reflection-lag detection (#133). After a window resets, the server-side
+// `utilization` can briefly still report the PREVIOUS window's residue (e.g.
+// 100% at 5 minutes into a fresh 5h window). An exceeded window whose elapsed
+// time since its boundary is below this epsilon is treated as "suspected
+// reflection lag" rather than a genuine throttle.
+const DEFAULT_LAG_EPSILON_SECONDS = 900; // 15 min boundary-proximity window.
+// When a lag is suspected we wait only this short interval before re-checking
+// (instead of a full window + buffer) so the real post-lag value is picked up
+// quickly. resets_at is left at the raw window edge (information preserved).
+const DEFAULT_LAG_RECHECK_SECONDS = 180; // 3 min recheck cadence.
+// Per-window period lengths in SECONDS, used to compute elapsed-since-boundary
+// for the lag check: elapsed = period - (resets_at - now).
+const FIVE_HOUR_PERIOD_S = FIVE_HOUR_MS / 1000; // 18000
+const SEVEN_DAY_PERIOD_S = SEVEN_DAY_MS / 1000; // 604800
 
 // HOME-anchored paths, built with path.join so no rewritable skills-dir literal
 // ever appears in source (M2).
@@ -88,6 +114,47 @@ export function resolveResumeBuffer(env = process.env) {
     return DEFAULT_RESUME_BUFFER_SECONDS;
   const n = Number(raw);
   if (!Number.isFinite(n) || n < 0) return DEFAULT_RESUME_BUFFER_SECONDS;
+  return n;
+}
+
+/**
+ * Resolve the reflection-lag epsilon in seconds (env override → default).
+ *
+ * `USAGE_GUARD_LAG_EPSILON_SECONDS` overrides the default (900). An exceeded
+ * window whose elapsed time since its boundary is below this value is treated
+ * as suspected reflection lag (#133). Negative/non-finite/blank → default.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {number}
+ */
+export function resolveLagEpsilon(env = process.env) {
+  const raw = env?.USAGE_GUARD_LAG_EPSILON_SECONDS;
+  if (raw === undefined || raw === null || String(raw).trim() === "")
+    return DEFAULT_LAG_EPSILON_SECONDS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_LAG_EPSILON_SECONDS;
+  return n;
+}
+
+/**
+ * Resolve the reflection-lag recheck interval in seconds (env override →
+ * default).
+ *
+ * `USAGE_GUARD_LAG_RECHECK_SECONDS` overrides the default (180). When a lag is
+ * suspected, `wait_seconds` collapses to this short cadence so the caller
+ * re-fetches the real value soon (#133). Negative/non-finite/blank → default.
+ * A value of 0 is rejected (collapses to default) because a zero recheck would
+ * busy-loop.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {number}
+ */
+export function resolveLagRecheck(env = process.env) {
+  const raw = env?.USAGE_GUARD_LAG_RECHECK_SECONDS;
+  if (raw === undefined || raw === null || String(raw).trim() === "")
+    return DEFAULT_LAG_RECHECK_SECONDS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_LAG_RECHECK_SECONDS;
   return n;
 }
 
@@ -165,29 +232,50 @@ export function normalizeWindows(payload) {
  * `utilization` can lag the reset). `resets_at` stays the raw window edge — the
  * planned resume time is `resets_at + resumeBuffer`, kept distinguishable.
  *
+ * Reflection-lag (#133): for each exceeded window we also compute how long it
+ * has been since that window's boundary
+ * (`elapsed = period - (resets_at - now)`). If ANY exceeded window is barely
+ * past its boundary (`elapsed < lagEpsilon`) the over-threshold reading is most
+ * likely the previous window's residue still echoing through the endpoint, not
+ * a genuine throttle. In that case `suspected_reflection_lag` is set and
+ * `wait_seconds` collapses to the short `lagRecheck` interval (instead of a
+ * full window + buffer) so the caller re-fetches the real value soon. `resets_at`
+ * is preserved as the raw window edge in both cases.
+ *
  * @param {{ five_hour: {utilization:number,resets_at:string|null}, seven_day: {utilization:number,resets_at:string|null} }} windows
  * @param {object} [opts]
  * @param {number} [opts.threshold]
  * @param {number} [opts.resumeBuffer] post-reset buffer in seconds (default 300)
+ * @param {number} [opts.lagEpsilon] boundary-proximity window in seconds (default 900)
+ * @param {number} [opts.lagRecheck] short recheck interval when lag suspected (default 180)
  * @param {() => number} [opts.now]
- * @returns {{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, resume_buffer_seconds: number }}
+ * @returns {{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, resume_buffer_seconds: number, suspected_reflection_lag: boolean }}
  */
 export function evaluate(
   windows,
   {
     threshold = DEFAULT_THRESHOLD,
     resumeBuffer = DEFAULT_RESUME_BUFFER_SECONDS,
+    lagEpsilon = DEFAULT_LAG_EPSILON_SECONDS,
+    lagRecheck = DEFAULT_LAG_RECHECK_SECONDS,
     now = Date.now,
   } = {},
 ) {
-  const exceeded = [windows.five_hour, windows.seven_day].filter((w) => w.utilization >= threshold);
+  // Pair each window with its period (seconds) so we can compute elapsed since
+  // the window boundary for the reflection-lag check.
+  const exceeded = [
+    { w: windows.five_hour, periodS: FIVE_HOUR_PERIOD_S },
+    { w: windows.seven_day, periodS: SEVEN_DAY_PERIOD_S },
+  ].filter(({ w }) => w.utilization >= threshold);
   const ok = exceeded.length === 0;
   let resetsAt = null;
   let waitSeconds = 0;
+  let suspectedReflectionLag = false;
+  const nowMs = now();
   if (!ok) {
     // Latest resets_at among exceeded windows (max epoch); ignore unparseable.
     let latestMs = null;
-    for (const w of exceeded) {
+    for (const { w, periodS } of exceeded) {
       if (!w.resets_at) continue;
       const ms = Date.parse(w.resets_at);
       if (Number.isNaN(ms)) continue;
@@ -195,10 +283,18 @@ export function evaluate(
         latestMs = ms;
         resetsAt = w.resets_at;
       }
+      // elapsed since this window's boundary = period - (resets_at - now).
+      // Small elapsed + over-threshold = the reset just happened but the
+      // endpoint is still echoing the prior window's residue → lag suspected.
+      const elapsedS = periodS - (ms - nowMs) / 1000;
+      if (elapsedS >= 0 && elapsedS < lagEpsilon) suspectedReflectionLag = true;
     }
-    if (latestMs !== null) {
+    if (suspectedReflectionLag) {
+      // Don't idle a full window on a likely-stale 100%; re-check soon.
+      waitSeconds = Math.max(1, Math.ceil(lagRecheck));
+    } else if (latestMs !== null) {
       // wait = time to the window edge + the post-reset safety buffer.
-      waitSeconds = Math.max(0, Math.ceil((latestMs - now()) / 1000)) + Math.max(0, resumeBuffer);
+      waitSeconds = Math.max(0, Math.ceil((latestMs - nowMs) / 1000)) + Math.max(0, resumeBuffer);
     }
   }
   return {
@@ -208,6 +304,7 @@ export function evaluate(
     wait_seconds: waitSeconds,
     resets_at: resetsAt,
     resume_buffer_seconds: Math.max(0, resumeBuffer),
+    suspected_reflection_lag: suspectedReflectionLag,
   };
 }
 
@@ -390,7 +487,7 @@ export async function writeCache(
  * cache, and clock. `warn` defaults to stderr.
  *
  * @param {object} [deps]
- * @returns {Promise<{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, source: string }>}
+ * @returns {Promise<{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, resume_buffer_seconds: number, suspected_reflection_lag: boolean, source: string }>}
  */
 export async function getUsage({
   fetchImpl = fetch,
@@ -408,28 +505,37 @@ export async function getUsage({
 } = {}) {
   const threshold = resolveThreshold(env);
   const resumeBuffer = resolveResumeBuffer(env);
+  const lagEpsilon = resolveLagEpsilon(env);
+  const lagRecheck = resolveLagRecheck(env);
 
   // 1. Fresh cache → return as-is (no endpoint re-fetch within TTL).
   const cached = await readCache({ readFileImpl, cachePath, ttlMs: cacheTtlMs, now });
   if (cached) return { ...cached, source: "cache" };
 
-  const evalOpts = { threshold, resumeBuffer, now };
+  const evalOpts = { threshold, resumeBuffer, lagEpsilon, lagRecheck, now };
+
+  // Cache-bypass (#133): a suspected reflection lag is a transient, likely-stale
+  // 100% reading. Persisting it would pin the false signal for the cache TTL and
+  // re-serve it on the next check, defeating the short recheck. So when the
+  // result flags a lag we skip the cache write — the next check hits the live
+  // endpoint and can observe the post-lag value immediately.
+  const maybeCache = async (result) => {
+    if (result.suspected_reflection_lag) return result; // do NOT cache a lagged read
+    await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
+    return result;
+  };
 
   // 2. Endpoint.
   try {
     const token = await readAccessToken({ readFileImpl, credentialsPath, now });
     if (!token) throw new Error("no usable OAuth access token");
     const windows = await fetchEndpointUsage(token, { fetchImpl });
-    const result = { ...evaluate(windows, evalOpts), source: "endpoint" };
-    await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
-    return result;
+    return await maybeCache({ ...evaluate(windows, evalOpts), source: "endpoint" });
   } catch (endpointErr) {
     // 3. JSONL fallback.
     try {
       const windows = await aggregateJsonlUsage({ readdirImpl, readFileImpl, projectsDir, now });
-      const result = { ...evaluate(windows, evalOpts), source: "jsonl" };
-      await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
-      return result;
+      return await maybeCache({ ...evaluate(windows, evalOpts), source: "jsonl" });
     } catch (jsonlErr) {
       // 4. Both failed → fail-open + warn (guard never hard-stops on its bug).
       warn(
@@ -442,6 +548,7 @@ export async function getUsage({
         wait_seconds: 0,
         resets_at: null,
         resume_buffer_seconds: resumeBuffer,
+        suspected_reflection_lag: false,
         source: "fail-open",
       };
     }
@@ -468,6 +575,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
         wait_seconds: 0,
         resets_at: null,
         resume_buffer_seconds: resolveResumeBuffer(),
+        suspected_reflection_lag: false,
         source: "fail-open",
       })}\n`,
     );

--- a/docs/usage-guard-verification.md
+++ b/docs/usage-guard-verification.md
@@ -36,7 +36,7 @@ Cases exercised:
 | 4 | hook + empty home (no cache/creds) | exit 0 (fail-open), stderr warns `unavailable` / `failing open` + `DEGRADED` `source=fail-open` |
 | 5 | hook + `USAGE_GUARD_THRESHOLD=10` over an `ok:false` cache | exit 2, deny names `≥ 10%` |
 | 6 | usage-check CLI + over cache | exit 0, stdout JSON `source:"cache"`, `ok:false` |
-| 7 | usage-check CLI + empty home | exit 0, stdout JSON `ok:true`, `source:"fail-open"`, `resume_buffer_seconds:300` |
+| 7 | usage-check CLI + empty home | exit 0, stdout JSON `ok:true`, `source:"fail-open"`, `resume_buffer_seconds:300`, `suspected_reflection_lag:false` |
 | 8 | usage-check CLI + over cache (buffered) | exit 0, JSON `source:"cache"`, `wait_seconds`/`resume_buffer_seconds` round-trip |
 
 ### Post-reset resume buffer & fail-open visibility (issue #129)
@@ -54,6 +54,40 @@ In-process unit coverage adds:
   (the `fail-open` wording flags that the guard is **not actually monitoring**);
   `endpoint` / `cache` stay silent. The deny "~N min" hint is derived from the
   buffered `wait_seconds`.
+
+### Reflection-lag detection & cache bypass (issue #133)
+
+After a window resets, the endpoint can briefly echo the PREVIOUS window's
+residue: the reset already happened (`resets_at` points at the *next* boundary)
+yet `utilization` still reads ~100%. Treating that at face value would propose a
+~full-window (~5h) wait for an already-recovered budget — a false negative the
+`resume_buffer` (#129, a "reset hasn't arrived yet" mitigation) does not cover.
+
+`evaluate()` now computes, per exceeded window, how long it has been since that
+window's boundary (`elapsed = period - (resets_at - now)`; period 18000s for 5h,
+604800s for 7d). If an exceeded window is barely past its boundary
+(`elapsed < USAGE_GUARD_LAG_EPSILON_SECONDS`, default 900) it is flagged
+`suspected_reflection_lag: true`, and `wait_seconds` collapses to a short recheck
+interval (`USAGE_GUARD_LAG_RECHECK_SECONDS`, default 180) instead of a full
+window + buffer. `resets_at` is left at the raw window edge (information
+preserved). A suspected-lag result is **not written to the cache**, so the next
+check hits the live endpoint and can pick up the real post-lag value immediately.
+
+In-process unit coverage (`tests/usage-check.test.mjs`) asserts:
+
+- boundary-just-passed + util 100% → `suspected_reflection_lag:true`,
+  `wait_seconds == recheck (180)`, `ok:false`, `resets_at` unchanged;
+- well past the boundary + util 100% → `suspected_reflection_lag:false`, legacy
+  `wait_seconds == full window + buffer`;
+- `ok:true` (under threshold) → never flags a lag;
+- `USAGE_GUARD_LAG_EPSILON_SECONDS` / `USAGE_GUARD_LAG_RECHECK_SECONDS` overrides
+  take effect (a tight epsilon disables the flag; a custom recheck sets the wait);
+- `getUsage` threads the lag env through the endpoint result AND does **not**
+  cache a lagged read, while a normal over-threshold result still caches.
+
+The CLI integration test (`tests/usage-guard-integration.test.mjs`, fail-open
+case) additionally asserts the `suspected_reflection_lag` field is present
+(false) on the real spawned process output.
 
 See the skill's `SKILL.md` §環境要件 for why the endpoint path can be blocked
 (api.anthropic.com egress + `~/.claude/.credentials.json` read) and how to

--- a/scripts/usage-guard-smoke.mjs
+++ b/scripts/usage-guard-smoke.mjs
@@ -79,6 +79,7 @@ async function seedOver(seconds) {
     wait_seconds: seconds + resumeBuffer,
     resets_at: resetsAt,
     resume_buffer_seconds: resumeBuffer,
+    suspected_reflection_lag: false,
     source: "endpoint",
   });
   console.log(`seeded OVER cache → ${CACHE_PATH}`);
@@ -95,6 +96,7 @@ async function seedOk() {
     wait_seconds: 0,
     resets_at: null,
     resume_buffer_seconds: 300,
+    suspected_reflection_lag: false,
     source: "endpoint",
   });
   console.log(`seeded OK cache → ${CACHE_PATH} (5h 40%, 7d 50%, ok:true)`);

--- a/src/skills/drive/SKILL.claude-code.md
+++ b/src/skills/drive/SKILL.claude-code.md
@@ -69,6 +69,7 @@ usage-guard の取り扱い:
 3. `ok: false`（いずれかの枠が閾値超過）→ usage-guard の wait-loop に委譲する。`wait_seconds` にはポストリセットのバッファ（`resume_buffer_seconds`、既定 +300 秒）が折り込まれており、待機は `resets_at + buffer` まで延びる（リセット丁度の再突入による再ハネを回避）:
    - in-session・待機 ≤1h → `ScheduleWakeup(min(wait_seconds, 3600))` で heartbeat を仕込み、**待機する**（待機中は再入せず予算を消費しない）。`wait_seconds` が 3600 を超える場合は複数回に分けて再チェックする。
    - 非 /loop オーケストレーション（Agent tool / Workflow drive）・待機 >1h・再起動耐性が必要 → `CronCreate`（`recurring: false`, durable）を **`resets_at + resume_buffer_seconds`** にセットし、発火時に継続コマンドを再投入する（壁時計一発・再起動耐性。one-shot は発火後 auto-delete）。既定 ON によりこの経路（>1h・非 /loop）を踏みやすいため、該当時は `ScheduleWakeup` ではなく **`CronCreate`(one-shot, durable)** を優先する。詳細は usage-guard SKILL.md §軽量 wait-loop「再開トリガの選択」。
+   - **反映ラグ疑い時（`suspected_reflection_lag: true`）は境界に長時間 CronCreate を張らず、短間隔（`wait_seconds` ≈ 180 秒）で `ScheduleWakeup` 再チェック**する（境界直後の前枠残像による偽 100% を回復確認後に拾い、~5h 放置の偽陰性を回避。usage-guard SKILL.md §振る舞い: 反映ラグ検知 を参照）。
    - 起床したら継続コマンド **`/drive <元の引数>`** を自己再入する（既定 ON のため `--usage-guard` を強制付与しない。`--no-usage-guard` がユーザー指定されていた場合のみ引き継ぐ ── ただし `--no-usage-guard` 時はそもそも本節を実行しないため、実際の継続コマンドは元の引数をそのまま渡せばよい）。drive の冪等 resume が既存 PR / ブランチ / 完了済み worker を検出して**続きから再開**する（待機を挟んでも重複副作用を生まない）。
    - `usage-check.mjs` が `ok: true` を返すまで 3〜4 を繰り返す。
 

--- a/src/skills/usage-guard/SKILL.md
+++ b/src/skills/usage-guard/SKILL.md
@@ -50,6 +50,7 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
 - endpoint 失敗時は `~/.claude/projects/*/*.jsonl` の per-message `usage` + timestamp から 5h / 7d window を推定する JSONL フォールバック
 - endpoint と JSONL の**両方が失敗したら fail-open**（`ok: true`）+ stderr に警告（ガードが自バグで hard-stop しない）
 - 超過時の `wait_seconds` には**ポストリセットのバッファ**（既定 +300 秒）を加算する。サーバ側 `utilization` 反映の遅延・ScheduleWakeup の発火ブレを吸収し、リセット丁度に絞られた枠へ再突入して再ハネするのを防ぐ（後述「閾値」「振る舞い: 再開バッファ」）
+- **反映ラグ検知**（`suspected_reflection_lag`）: リセット直後はサーバ側 `utilization` が**前枠の残像**を返すことがある（リセット済みなのに 5h util 100% 等）。超過枠が**境界直後**（枠開始からの経過 `elapsed = period - (resets_at - now)` が epsilon=900 秒未満）なら矛盾とみなし、`wait_seconds` を full-window ではなく**短い再チェック間隔**（既定 180 秒）に切り替える。この結果は cache に書かない（後述「振る舞い: 反映ラグ検知」）
 
 ### 出力 JSON
 
@@ -61,14 +62,16 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
   "wait_seconds": 0,
   "resets_at": null,
   "resume_buffer_seconds": 300,
+  "suspected_reflection_lag": false,
   "source": "endpoint"
 }
 ```
 
 - `ok`: **両枠の `utilization` が閾値未満**なら `true`
-- `wait_seconds`: 超過枠の `resets_at` の**最遅**（最も遅くリセットする枠）までの秒数 **+ `resume_buffer_seconds`**。`ok` のときは `0`
-- `resets_at`: その最遅の超過枠の `resets_at`（**枠端のまま不変**。バッファは加算しない）。`ok` のときは `null`。再開予定 = `resets_at + resume_buffer_seconds` として区別できる
+- `wait_seconds`: 超過枠の `resets_at` の**最遅**（最も遅くリセットする枠）までの秒数 **+ `resume_buffer_seconds`**。`ok` のときは `0`。**`suspected_reflection_lag` が `true` のときは**短い再チェック間隔（`USAGE_GUARD_LAG_RECHECK_SECONDS`、既定 180 秒）に縮退する
+- `resets_at`: その最遅の超過枠の `resets_at`（**枠端のまま不変**。バッファ加算も lag 縮退もしない）。`ok` のときは `null`。再開予定 = `resets_at + resume_buffer_seconds` として区別できる
 - `resume_buffer_seconds`: `wait_seconds` に折り込まれたポストリセットのバッファ秒数（既定 300、0 で従来挙動）
+- `suspected_reflection_lag`: 反映ラグ（境界直後なのに超過）の疑いなら `true`。`true` のとき `wait_seconds` は短い再チェック間隔になり、この結果は **cache に書かれない**（次チェックが endpoint 実値を即取得できる）。`ok` のときは常に `false`。endpoint / jsonl 両経路でセットされる
 - `source`: `endpoint` / `jsonl` / `cache` / `fail-open`
 
 ### 振る舞い: 再開バッファ
@@ -79,11 +82,27 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
 - `ok`（未超過）時はバッファを加算しない（`wait_seconds: 0`）
 - PreToolUse hook の deny ヒント（「あと N 分」）も `wait_seconds` 由来なのでバッファ込みで提示され整合する
 
+### 振る舞い: 反映ラグ検知（境界直後の偽陰性回避）
+
+リセット直後はサーバ側 `utilization` が**前枠の残像**を引きずることがある（例: 5h 枠が 21:00 にリセット済みなのに 21:05 の endpoint が util 100% を返し、`resets_at` は既に次境界 02:00 を指す矛盾状態）。この状態をそのまま扱うと「回復済みの枠を ~5h 無駄に放置」する偽陰性になる。`resume_buffer`（#129）は「reset 未到来」前提の対策でこのケースには効かない。
+
+判定原理: 超過枠ごとに **枠開始からの経過** `elapsed = period - (resets_at - now)`（`five_hour` の period = 18000 秒、`seven_day` = 604800 秒）を算出する。`elapsed` が epsilon（`USAGE_GUARD_LAG_EPSILON_SECONDS`、既定 900 秒）未満かつ超過なら**矛盾** → 反映ラグの疑いとして `suspected_reflection_lag = true` をセットする。
+
+- lag 疑い時は `wait_seconds` を full-window+buffer ではなく**短い再チェック間隔**（`USAGE_GUARD_LAG_RECHECK_SECONDS`、既定 180 秒）にする。caller は長時間 CronCreate を境界に張らず、この短間隔で再 fetch すればラグ解消後の実値を拾える
+- `resets_at` は**枠端のまま不変**（情報を捨てない）
+- lag 疑いの結果は **cache に書かない**（前枠の偽 100% が TTL 間 cache に固定されて再チェックを潰すのを防ぐ。次チェックは endpoint 実値を即取得する）
+- `ok`（閾値未満）のときは lag 判定せず常に `suspected_reflection_lag: false`
+
 ### 閾値
 
 既定 95%。環境変数 `USAGE_GUARD_THRESHOLD` で上書き可能（例 `USAGE_GUARD_THRESHOLD=80`）。
 
 ポストリセットの再開バッファは既定 300 秒。環境変数 `USAGE_GUARD_RESUME_BUFFER_SECONDS` で上書き可能（例 `USAGE_GUARD_RESUME_BUFFER_SECONDS=600`）。`0` で従来挙動（`resets_at` 丁度に再開）に戻せる。負値・非数値は既定 300 にフォールバックする。
+
+反映ラグ検知の閾値も env で上書きできる:
+
+- `USAGE_GUARD_LAG_EPSILON_SECONDS`（既定 900）: 境界直後とみなす経過秒数。これより `elapsed` が小さい超過枠を lag 疑いとする。負値・非数値・空は既定 900 にフォールバック
+- `USAGE_GUARD_LAG_RECHECK_SECONDS`（既定 180）: lag 疑い時の短い再チェック間隔。`0` 以下・非数値・空は既定 180 にフォールバック（busy-loop 防止）
 
 ## 軽量 wait-loop（共通ロジック）
 
@@ -93,9 +112,10 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
 2. **劣化チェック**: `source !== "endpoint"`（`cache` は endpoint 由来なので除外）なら劣化警告を出す。特に `source === "fail-open"` のときは「⚠️ usage-guard 劣化: source=fail-open、実際には監視していません」を**呼び出し側・ユーザーに明示**し、drive caller はレポートに残す（allow / 進行は維持。§環境要件 を案内）
 3. `ok` なら**通常進行**（継続コマンドを実行 / caller は次の checkpoint へ）
 4. `ok` が `false` なら再開トリガを選び（下記「再開トリガの選択」）、**待機する**
-   - `wait_seconds` には `resume_buffer_seconds`（既定 300）が折り込まれているので、待機は `resets_at + buffer` まで延びる
+   - **反映ラグ疑い時（`suspected_reflection_lag: true`）は短間隔で再チェック**する。`wait_seconds` は既に短い再チェック間隔（既定 180 秒）に縮退しているので、境界に長時間 CronCreate one-shot を張らず、`ScheduleWakeup(wait_seconds)` 等でこの短間隔だけ待って再び `usage-check.mjs` を叩く。ラグが解消すれば次チェックで実値（多くは `ok: true`）を拾い継続できる（前枠残像のまま ~5h 放置する偽陰性を回避）
+   - 通常の超過時は `wait_seconds` に `resume_buffer_seconds`（既定 300）が折り込まれているので、待機は `resets_at + buffer` まで延びる
    - **待機中は再入しない**（予算を一切消費しない）
-5. 起床したら再び `usage-check.mjs` を実行し、`ok` になるまで 2〜5 を繰り返す
+5. 起床したら再び `usage-check.mjs` を実行し、`ok` になるまで 2〜5 を繰り返す（lag 疑いの結果は cache に書かれないので、再チェックは endpoint 実値を即取得する）
 6. `ok` になったら継続コマンドへ進む
 
 > `wait_seconds` は `resets_at`（+ buffer）から算出するため秒精度ではない。ScheduleWakeup の発火も下限 + オーバーヘッドで多少遅れる（実機で 60s 要求に対し ~110s）。reset 待ちには十分な精度。

--- a/src/skills/usage-guard/usage-check.mjs
+++ b/src/skills/usage-guard/usage-check.mjs
@@ -15,16 +15,28 @@
 // functional path literal here is written in the rewritable skills-dir form.
 //
 // Output (stdout, single JSON line):
-//   { five_hour, seven_day, ok, wait_seconds, resets_at, resume_buffer_seconds, source }
+//   { five_hour, seven_day, ok, wait_seconds, resets_at, resume_buffer_seconds,
+//     suspected_reflection_lag, source }
 //   - five_hour / seven_day: { utilization (0-100), resets_at (ISO|null) }
 //   - ok:           both windows' utilization < threshold (default 95)
 //   - wait_seconds: seconds until the LATEST resets_at among exceeded windows
 //                   PLUS the post-reset resume buffer (0 when ok). Derived from
-//                   `resets_at` minus now, plus resume_buffer_seconds.
+//                   `resets_at` minus now, plus resume_buffer_seconds. When a
+//                   reflection lag is suspected (see below) this collapses to a
+//                   short recheck interval instead of a full window.
 //   - resets_at:    that same latest exceeded resets_at, UNCHANGED by the buffer
 //                   (the window edge; the planned resume = resets_at + buffer)
 //   - resume_buffer_seconds: the post-reset safety margin folded into
 //                   wait_seconds (default 300; 0 restores the legacy behaviour)
+//   - suspected_reflection_lag: true when an exceeded window is also barely past
+//                   its boundary (elapsed = period - (resets_at - now) < epsilon).
+//                   This is the "reset happened but the server-side utilization
+//                   still shows the previous window's residue" contradiction
+//                   (#133). When set, wait_seconds collapses to a SHORT recheck
+//                   interval so the caller re-fetches the real post-lag value
+//                   soon instead of idling a full window; resets_at stays the
+//                   raw window edge. Such results are NOT cached (so the next
+//                   check hits the live endpoint, not the stale lagged value).
 //   - source:       "endpoint" | "jsonl" | "fail-open" | "cache"
 //
 // Fail-open: if the endpoint fails AND the JSONL fallback fails, emit
@@ -50,6 +62,20 @@ const DEFAULT_RESUME_BUFFER_SECONDS = 300;
 const DEFAULT_CACHE_TTL_MS = 45_000; // 30–60s window so the #123 hook can share it.
 const FIVE_HOUR_MS = 5 * 60 * 60 * 1000;
 const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1000;
+// Reflection-lag detection (#133). After a window resets, the server-side
+// `utilization` can briefly still report the PREVIOUS window's residue (e.g.
+// 100% at 5 minutes into a fresh 5h window). An exceeded window whose elapsed
+// time since its boundary is below this epsilon is treated as "suspected
+// reflection lag" rather than a genuine throttle.
+const DEFAULT_LAG_EPSILON_SECONDS = 900; // 15 min boundary-proximity window.
+// When a lag is suspected we wait only this short interval before re-checking
+// (instead of a full window + buffer) so the real post-lag value is picked up
+// quickly. resets_at is left at the raw window edge (information preserved).
+const DEFAULT_LAG_RECHECK_SECONDS = 180; // 3 min recheck cadence.
+// Per-window period lengths in SECONDS, used to compute elapsed-since-boundary
+// for the lag check: elapsed = period - (resets_at - now).
+const FIVE_HOUR_PERIOD_S = FIVE_HOUR_MS / 1000; // 18000
+const SEVEN_DAY_PERIOD_S = SEVEN_DAY_MS / 1000; // 604800
 
 // HOME-anchored paths, built with path.join so no rewritable skills-dir literal
 // ever appears in source (M2).
@@ -88,6 +114,47 @@ export function resolveResumeBuffer(env = process.env) {
     return DEFAULT_RESUME_BUFFER_SECONDS;
   const n = Number(raw);
   if (!Number.isFinite(n) || n < 0) return DEFAULT_RESUME_BUFFER_SECONDS;
+  return n;
+}
+
+/**
+ * Resolve the reflection-lag epsilon in seconds (env override → default).
+ *
+ * `USAGE_GUARD_LAG_EPSILON_SECONDS` overrides the default (900). An exceeded
+ * window whose elapsed time since its boundary is below this value is treated
+ * as suspected reflection lag (#133). Negative/non-finite/blank → default.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {number}
+ */
+export function resolveLagEpsilon(env = process.env) {
+  const raw = env?.USAGE_GUARD_LAG_EPSILON_SECONDS;
+  if (raw === undefined || raw === null || String(raw).trim() === "")
+    return DEFAULT_LAG_EPSILON_SECONDS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_LAG_EPSILON_SECONDS;
+  return n;
+}
+
+/**
+ * Resolve the reflection-lag recheck interval in seconds (env override →
+ * default).
+ *
+ * `USAGE_GUARD_LAG_RECHECK_SECONDS` overrides the default (180). When a lag is
+ * suspected, `wait_seconds` collapses to this short cadence so the caller
+ * re-fetches the real value soon (#133). Negative/non-finite/blank → default.
+ * A value of 0 is rejected (collapses to default) because a zero recheck would
+ * busy-loop.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {number}
+ */
+export function resolveLagRecheck(env = process.env) {
+  const raw = env?.USAGE_GUARD_LAG_RECHECK_SECONDS;
+  if (raw === undefined || raw === null || String(raw).trim() === "")
+    return DEFAULT_LAG_RECHECK_SECONDS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_LAG_RECHECK_SECONDS;
   return n;
 }
 
@@ -165,29 +232,50 @@ export function normalizeWindows(payload) {
  * `utilization` can lag the reset). `resets_at` stays the raw window edge — the
  * planned resume time is `resets_at + resumeBuffer`, kept distinguishable.
  *
+ * Reflection-lag (#133): for each exceeded window we also compute how long it
+ * has been since that window's boundary
+ * (`elapsed = period - (resets_at - now)`). If ANY exceeded window is barely
+ * past its boundary (`elapsed < lagEpsilon`) the over-threshold reading is most
+ * likely the previous window's residue still echoing through the endpoint, not
+ * a genuine throttle. In that case `suspected_reflection_lag` is set and
+ * `wait_seconds` collapses to the short `lagRecheck` interval (instead of a
+ * full window + buffer) so the caller re-fetches the real value soon. `resets_at`
+ * is preserved as the raw window edge in both cases.
+ *
  * @param {{ five_hour: {utilization:number,resets_at:string|null}, seven_day: {utilization:number,resets_at:string|null} }} windows
  * @param {object} [opts]
  * @param {number} [opts.threshold]
  * @param {number} [opts.resumeBuffer] post-reset buffer in seconds (default 300)
+ * @param {number} [opts.lagEpsilon] boundary-proximity window in seconds (default 900)
+ * @param {number} [opts.lagRecheck] short recheck interval when lag suspected (default 180)
  * @param {() => number} [opts.now]
- * @returns {{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, resume_buffer_seconds: number }}
+ * @returns {{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, resume_buffer_seconds: number, suspected_reflection_lag: boolean }}
  */
 export function evaluate(
   windows,
   {
     threshold = DEFAULT_THRESHOLD,
     resumeBuffer = DEFAULT_RESUME_BUFFER_SECONDS,
+    lagEpsilon = DEFAULT_LAG_EPSILON_SECONDS,
+    lagRecheck = DEFAULT_LAG_RECHECK_SECONDS,
     now = Date.now,
   } = {},
 ) {
-  const exceeded = [windows.five_hour, windows.seven_day].filter((w) => w.utilization >= threshold);
+  // Pair each window with its period (seconds) so we can compute elapsed since
+  // the window boundary for the reflection-lag check.
+  const exceeded = [
+    { w: windows.five_hour, periodS: FIVE_HOUR_PERIOD_S },
+    { w: windows.seven_day, periodS: SEVEN_DAY_PERIOD_S },
+  ].filter(({ w }) => w.utilization >= threshold);
   const ok = exceeded.length === 0;
   let resetsAt = null;
   let waitSeconds = 0;
+  let suspectedReflectionLag = false;
+  const nowMs = now();
   if (!ok) {
     // Latest resets_at among exceeded windows (max epoch); ignore unparseable.
     let latestMs = null;
-    for (const w of exceeded) {
+    for (const { w, periodS } of exceeded) {
       if (!w.resets_at) continue;
       const ms = Date.parse(w.resets_at);
       if (Number.isNaN(ms)) continue;
@@ -195,10 +283,18 @@ export function evaluate(
         latestMs = ms;
         resetsAt = w.resets_at;
       }
+      // elapsed since this window's boundary = period - (resets_at - now).
+      // Small elapsed + over-threshold = the reset just happened but the
+      // endpoint is still echoing the prior window's residue → lag suspected.
+      const elapsedS = periodS - (ms - nowMs) / 1000;
+      if (elapsedS >= 0 && elapsedS < lagEpsilon) suspectedReflectionLag = true;
     }
-    if (latestMs !== null) {
+    if (suspectedReflectionLag) {
+      // Don't idle a full window on a likely-stale 100%; re-check soon.
+      waitSeconds = Math.max(1, Math.ceil(lagRecheck));
+    } else if (latestMs !== null) {
       // wait = time to the window edge + the post-reset safety buffer.
-      waitSeconds = Math.max(0, Math.ceil((latestMs - now()) / 1000)) + Math.max(0, resumeBuffer);
+      waitSeconds = Math.max(0, Math.ceil((latestMs - nowMs) / 1000)) + Math.max(0, resumeBuffer);
     }
   }
   return {
@@ -208,6 +304,7 @@ export function evaluate(
     wait_seconds: waitSeconds,
     resets_at: resetsAt,
     resume_buffer_seconds: Math.max(0, resumeBuffer),
+    suspected_reflection_lag: suspectedReflectionLag,
   };
 }
 
@@ -390,7 +487,7 @@ export async function writeCache(
  * cache, and clock. `warn` defaults to stderr.
  *
  * @param {object} [deps]
- * @returns {Promise<{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, source: string }>}
+ * @returns {Promise<{ five_hour: object, seven_day: object, ok: boolean, wait_seconds: number, resets_at: string|null, resume_buffer_seconds: number, suspected_reflection_lag: boolean, source: string }>}
  */
 export async function getUsage({
   fetchImpl = fetch,
@@ -408,28 +505,37 @@ export async function getUsage({
 } = {}) {
   const threshold = resolveThreshold(env);
   const resumeBuffer = resolveResumeBuffer(env);
+  const lagEpsilon = resolveLagEpsilon(env);
+  const lagRecheck = resolveLagRecheck(env);
 
   // 1. Fresh cache → return as-is (no endpoint re-fetch within TTL).
   const cached = await readCache({ readFileImpl, cachePath, ttlMs: cacheTtlMs, now });
   if (cached) return { ...cached, source: "cache" };
 
-  const evalOpts = { threshold, resumeBuffer, now };
+  const evalOpts = { threshold, resumeBuffer, lagEpsilon, lagRecheck, now };
+
+  // Cache-bypass (#133): a suspected reflection lag is a transient, likely-stale
+  // 100% reading. Persisting it would pin the false signal for the cache TTL and
+  // re-serve it on the next check, defeating the short recheck. So when the
+  // result flags a lag we skip the cache write — the next check hits the live
+  // endpoint and can observe the post-lag value immediately.
+  const maybeCache = async (result) => {
+    if (result.suspected_reflection_lag) return result; // do NOT cache a lagged read
+    await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
+    return result;
+  };
 
   // 2. Endpoint.
   try {
     const token = await readAccessToken({ readFileImpl, credentialsPath, now });
     if (!token) throw new Error("no usable OAuth access token");
     const windows = await fetchEndpointUsage(token, { fetchImpl });
-    const result = { ...evaluate(windows, evalOpts), source: "endpoint" };
-    await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
-    return result;
+    return await maybeCache({ ...evaluate(windows, evalOpts), source: "endpoint" });
   } catch (endpointErr) {
     // 3. JSONL fallback.
     try {
       const windows = await aggregateJsonlUsage({ readdirImpl, readFileImpl, projectsDir, now });
-      const result = { ...evaluate(windows, evalOpts), source: "jsonl" };
-      await writeCache(result, { writeFileImpl, mkdirImpl, cachePath, now });
-      return result;
+      return await maybeCache({ ...evaluate(windows, evalOpts), source: "jsonl" });
     } catch (jsonlErr) {
       // 4. Both failed → fail-open + warn (guard never hard-stops on its bug).
       warn(
@@ -442,6 +548,7 @@ export async function getUsage({
         wait_seconds: 0,
         resets_at: null,
         resume_buffer_seconds: resumeBuffer,
+        suspected_reflection_lag: false,
         source: "fail-open",
       };
     }
@@ -468,6 +575,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
         wait_seconds: 0,
         resets_at: null,
         resume_buffer_seconds: resolveResumeBuffer(),
+        suspected_reflection_lag: false,
         source: "fail-open",
       })}\n`,
     );

--- a/tests/usage-check.test.mjs
+++ b/tests/usage-check.test.mjs
@@ -22,6 +22,8 @@ import {
   getUsage,
   normalizeWindows,
   readAccessToken,
+  resolveLagEpsilon,
+  resolveLagRecheck,
   resolveResumeBuffer,
   resolveThreshold,
 } from "../src/skills/usage-guard/usage-check.mjs";
@@ -415,6 +417,152 @@ test("aggregateJsonlUsage windows tokens by 5h / 7d age", async () => {
   // 7d window: (2000 + 2000) = 4000 / 10000 = 40% (10d-old row excluded)
   assert.equal(Math.round(windows.seven_day.utilization), 40);
   assert.ok(windows.five_hour.resets_at, "5h resets_at derived from oldest counted message");
+});
+
+// --- reflection-lag detection (issue #133) -----------------------------------
+//
+// After a window resets, the endpoint can briefly echo the PREVIOUS window's
+// residue (e.g. 5h utilization 100% only ~5 min into a fresh window). That
+// "reset happened but util still 100%" contradiction is a suspected reflection
+// lag → short recheck instead of a ~full-window wait.
+
+const FIVE_HOUR_S = 18000;
+
+// resets_at JUST past the boundary: elapsed = 18000 - (resets_at - now) small.
+// elapsed ≈ 326s (5.4 min) like the issue example → resets_at ≈ now + 17674s.
+const lagWindows = (util = 100) =>
+  normalizeWindows({
+    five_hour: {
+      utilization: util,
+      resets_at: new Date(FIXED_NOW + (FIVE_HOUR_S - 326) * 1000).toISOString(),
+    },
+    seven_day: { utilization: 10, resets_at: null },
+  });
+
+test("(#133) boundary-just-passed + util 100 → suspected lag, wait==recheck, resets_at unchanged", () => {
+  const edge = new Date(FIXED_NOW + (FIVE_HOUR_S - 326) * 1000).toISOString();
+  const res = evaluate(lagWindows(100), { now });
+  assert.equal(res.ok, false, "100% ≥ 95 → not ok");
+  assert.equal(res.suspected_reflection_lag, true, "barely past boundary + over → lag suspected");
+  assert.equal(
+    res.wait_seconds,
+    180,
+    "lag → short recheck interval (default 180s), not full window",
+  );
+  assert.equal(res.resets_at, edge, "resets_at stays the raw window edge (info preserved)");
+});
+
+test("(#133) well past boundary + util 100 → NO lag, legacy full-window + buffer", () => {
+  // resets_at far in the future → elapsed since boundary is large (not near 0).
+  const farEdge = new Date(FIXED_NOW + 4 * 60 * 60 * 1000).toISOString(); // +4h
+  const res = evaluate(
+    normalizeWindows({
+      five_hour: { utilization: 100, resets_at: farEdge },
+      seven_day: { utilization: 10, resets_at: null },
+    }),
+    { now },
+  );
+  assert.equal(res.suspected_reflection_lag, false, "elapsed >> epsilon → no lag");
+  const expected = Math.ceil((Date.parse(farEdge) - FIXED_NOW) / 1000) + 300;
+  assert.equal(res.wait_seconds, expected, "legacy full window + 300s buffer");
+  assert.equal(res.resets_at, farEdge);
+});
+
+test("(#133) ok:true (under threshold) → never flags lag even just past boundary", () => {
+  const res = evaluate(lagWindows(40), { now });
+  assert.equal(res.ok, true, "40% < 95 → ok");
+  assert.equal(res.suspected_reflection_lag, false, "ok → no lag judgement");
+  assert.equal(res.wait_seconds, 0);
+});
+
+test("(#133) env overrides for epsilon and recheck take effect", () => {
+  assert.equal(resolveLagEpsilon({ USAGE_GUARD_LAG_EPSILON_SECONDS: "60" }), 60);
+  assert.equal(resolveLagEpsilon({}), 900, "unset → default 900");
+  assert.equal(
+    resolveLagEpsilon({ USAGE_GUARD_LAG_EPSILON_SECONDS: "-5" }),
+    900,
+    "negative → default",
+  );
+  assert.equal(resolveLagRecheck({ USAGE_GUARD_LAG_RECHECK_SECONDS: "30" }), 30);
+  assert.equal(resolveLagRecheck({}), 180, "unset → default 180");
+  assert.equal(
+    resolveLagRecheck({ USAGE_GUARD_LAG_RECHECK_SECONDS: "0" }),
+    180,
+    "0 → default (no busy loop)",
+  );
+
+  // elapsed ≈ 326s. With epsilon=60 (< 326) it should NOT flag a lag.
+  const tightEpsilon = evaluate(lagWindows(100), { now, lagEpsilon: 60 });
+  assert.equal(tightEpsilon.suspected_reflection_lag, false, "epsilon 60 < elapsed 326 → no lag");
+  assert.ok(tightEpsilon.wait_seconds > 180, "falls back to full-window wait");
+
+  // With a larger epsilon and a custom recheck the wait equals that recheck.
+  const customRecheck = evaluate(lagWindows(100), { now, lagEpsilon: 900, lagRecheck: 45 });
+  assert.equal(customRecheck.suspected_reflection_lag, true);
+  assert.equal(customRecheck.wait_seconds, 45, "custom recheck interval used");
+});
+
+test("(#133) getUsage threads lag env into the endpoint result + does NOT cache a lagged read", async () => {
+  let wrote = false;
+  const result = await getUsage({
+    fetchImpl: fetchOk({
+      five_hour: {
+        utilization: 100,
+        resets_at: new Date(FIXED_NOW + (FIVE_HOUR_S - 326) * 1000).toISOString(),
+      },
+      seven_day: { utilization: 10, resets_at: null },
+    }),
+    readFileImpl: credsReader(),
+    writeFileImpl: async () => {
+      wrote = true;
+    },
+    mkdirImpl: async () => {},
+    now,
+    cachePath: "/nonexistent/cache.json",
+    credentialsPath: "/fake/.credentials.json",
+  });
+  assert.equal(result.source, "endpoint");
+  assert.equal(result.suspected_reflection_lag, true);
+  assert.equal(result.ok, false);
+  assert.equal(result.wait_seconds, 180, "lag → short recheck");
+  assert.equal(wrote, false, "a suspected-lag result must NOT be written to cache (#133)");
+});
+
+test("(#133) getUsage DOES cache a normal (non-lag) over-threshold result", async () => {
+  let wrote = false;
+  const result = await getUsage({
+    fetchImpl: fetchOk({
+      five_hour: {
+        utilization: 99,
+        resets_at: new Date(FIXED_NOW + 4 * 60 * 60 * 1000).toISOString(),
+      },
+      seven_day: { utilization: 10, resets_at: null },
+    }),
+    readFileImpl: credsReader(),
+    writeFileImpl: async () => {
+      wrote = true;
+    },
+    mkdirImpl: async () => {},
+    now,
+    cachePath: "/nonexistent/cache.json",
+    credentialsPath: "/fake/.credentials.json",
+  });
+  assert.equal(result.suspected_reflection_lag, false);
+  assert.equal(wrote, true, "non-lag results still cache normally");
+});
+
+test("(#133) endpoint OK (ok:true) result carries suspected_reflection_lag:false", async () => {
+  const result = await getUsage({
+    fetchImpl: fetchOk({
+      five_hour: { utilization: 40, resets_at: "2026-06-15T04:00:00.000Z" },
+      seven_day: { utilization: 60, resets_at: "2026-06-20T00:00:00.000Z" },
+    }),
+    readFileImpl: credsReader(),
+    now,
+    cachePath: "/nonexistent/cache.json",
+    credentialsPath: "/fake/.credentials.json",
+  });
+  assert.equal(result.suspected_reflection_lag, false);
 });
 
 // --- structural assert on the BUILT SKILL.md ---------------------------------

--- a/tests/usage-guard-integration.test.mjs
+++ b/tests/usage-guard-integration.test.mjs
@@ -210,6 +210,8 @@ test("usage-check CLI: no cache / creds / projects → exit 0, JSON ok=true, sou
   assert.equal(json.source, "fail-open", "both endpoint and JSONL unavailable → fail-open");
   // Issue #129: the new resume_buffer_seconds field is present on every result.
   assert.equal(json.resume_buffer_seconds, 300, "default resume buffer is reported");
+  // Issue #133: suspected_reflection_lag is present on every result (false here).
+  assert.equal(json.suspected_reflection_lag, false, "fail-open carries the lag flag (false)");
 });
 
 // ── Case 8: usage-check CLI + over cache + RESUME_BUFFER env → buffered wait ──


### PR DESCRIPTION
## 概要

Closes #133。reset 直後の反映ラグ（サーバ側 `utilization` が前枠の残像を返す）による偽陰性を検知し、full-window 待ちではなく短間隔再チェックへ切り替える。

## 背景

5h 枠が 21:00 JST にリセット済みなのに 21:05 の endpoint が `five_hour.utilization:100%` を返し、`resets_at` は既に次境界（翌 02:00）を指す矛盾状態を実運用で観測（#129 の `resume_buffer` は「reset 未到来」前提で効かない）。そのままだと回復済みの枠を ~5h 放置する偽陰性になり、30–60s cache が偽 100% を保持し続けた。

## 変更（`src/skills/usage-guard/usage-check.mjs` `evaluate()`）

1. **境界直後検知**: 超過枠ごとに `elapsed = period - (resetMs - now)/1000`（5h=18000s, 7d=604800s）を算出。`elapsed < epsilon`（`USAGE_GUARD_LAG_EPSILON_SECONDS`、既定 900）かつ超過なら `suspected_reflection_lag = true`。
2. **短い再チェックへ切替**: lag 疑い時は `wait_seconds` を full-window+buffer ではなく短い再チェック間隔（`USAGE_GUARD_LAG_RECHECK_SECONDS`、既定 180）に縮退。`resets_at` は枠端のまま不変。
3. **cache バイパス**: lag 疑いの結果は cache に書かない（次チェックが endpoint 実値を即取得）。
4. **出力 JSON**: `suspected_reflection_lag`（bool）を追加。endpoint / jsonl / fail-open 全経路でセット。

## docs / SKILL

- `usage-guard/SKILL.md`: §振る舞い・§出力 JSON・§振る舞い: 反映ラグ検知・§軽量 wait-loop・§閾値（新 env 2 つ）を追記。
- `docs/usage-guard-verification.md`: 反映ラグ検証ケースを追記。
- `drive/SKILL.claude-code.md`: wait-loop に lag 疑い時の短間隔再チェック 1 行を反映。
- 生成物（`.claude/`, `dist/`）を `pnpm build` で更新。

## テスト

- `tests/usage-check.test.mjs`: 境界直後+util100→lag true / wait==recheck / ok false / resets_at 不変、十分経過+util100→lag false（従来 full+buffer）、ok:true→lag false、env 上書き（epsilon/recheck）、lag 疑い時 cache 非書き込み / 通常超過は cache 書き込み。
- `tests/usage-guard-integration.test.mjs`: fail-open CLI 出力に `suspected_reflection_lag:false` を確認。
- 全 239 tests green / biome / markdownlint 緑。smoke harness（`usage-guard-smoke.mjs`）も新フィールド込みで通る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)