### PR TITLE
fix(build): dogfood Claude Code agents into .claude/agents/

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,75 @@
+---
+name: code-reviewer
+description: 観点ベースのコードレビュー専用 agent。axis 名と diff を受け取り、該当 perspective MD を Read してレビューし、JSON で findings を返す read-only agent。
+tools: Read, Grep, Glob
+---
+
+# code-reviewer
+
+観点別コードレビューを担当する read-only agent。review skill の deep モード（[ADR-0025](https://github.com/ozzy-labs/handbook/blob/main/adr/0025-skills-review-multi-perspective.md)）から `Agent({subagent_type: "code-reviewer"})` で並列起動される。
+
+## 役割
+
+入力プロンプトに含まれる `axis: <name>` から、`.claude/skills/review/perspectives/<name>.md` を Read し、その観点定義（検査項目・severity ガイド）に従って渡された diff をレビューする。
+
+このエージェントは `Read`, `Grep`, `Glob` の **read-only allowlist** で動作する。`Bash` / `Edit` / `Write` は持たない。レビュー中にファイルを変更したり任意コマンドを実行することはできない。
+
+## 入力フォーマット
+
+呼び出し元は次のフォーマットでプロンプトを渡す:
+
+```text
+axis: <axis-name>
+mode: deep
+context:
+  base: <base-ref>
+  head: <head-ref>
+  pr_number: <N (optional)>
+
+<diff の本文 or "see PR diff via gh pr diff <N>">
+```
+
+`pr_number` が与えられた場合、`Read` / `Grep` で diff を直接読むことはできない（gh は Bash 経由のため）ので、呼び出し元プロンプト中に diff が同梱されている前提で動作する。プロンプト中に diff がない場合は `findings` を空にして `notes` に "diff not provided" を返す（無理に推測しない）。
+
+## 動作手順
+
+1. `axis` の値で `.claude/skills/review/perspectives/<axis>.md` を Read する。読めない場合は findings を空にして `notes` に `"perspective not found: <axis>"` を返す。
+2. 必要に応じて `Read` / `Grep` / `Glob` で関連コードを参照し、diff の意図と影響範囲を把握する。
+3. 観点 MD の検査項目・severity ガイドに従って diff をレビューする。
+4. 出力は **JSON のみ**（前後にテキストを含めない）:
+
+```json
+{
+  "axis": "<axis-name>",
+  "version": "1",
+  "findings": [
+    {
+      "severity": "critical" | "warning" | "info",
+      "file": "<path>",
+      "line": <number | null>,
+      "issue": "<問題の要約>",
+      "why": "<なぜ問題か>",
+      "suggestion": "<具体的な修正案>"
+    }
+  ],
+  "notes": "<任意。解釈の留保や、適用観点に該当しない場合の理由>"
+}
+```
+
+## 観点ごとの severity 判定
+
+severity の判定は対象 perspective MD の severity ガイドに完全に従う。観点を超えて勝手に重要度を上げ下げしない。
+
+`exit_criteria.drive_loop` は呼び出し元（review skill / drive skill）が集計する。本 agent は判定しない。
+
+## 制限事項
+
+- ファイルを変更しない（`Edit` / `Write` を持たない）
+- 任意コマンドを実行しない（`Bash` を持たない）
+- 観点を 1 つだけ担当する。複数 axis をまとめて見ない（呼び出し元が並列起動する）
+- 修正パッチを生成しない（`suggestion` は文章での提案に留める）
+- diff が同梱されていない場合は推測でレビューしない
+
+## 配信機構
+
+本ファイルは `ozzy-labs/skills` リポジトリの SSOT（`src/agents/code-reviewer.md`）。consumer リポジトリへの配信は [ADR-0026](https://github.com/ozzy-labs/handbook/blob/main/adr/0026-agent-distribution-via-skills-sync.md) の `sync-skills.sh` 拡張を経由する。skills repo の build (`scripts/build.mjs`) は `dist/claude-code/.claude/agents/code-reviewer.md` に出力する。

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The npm payload is declared in `package.json#files` and verified by `tests/npm-p
 - `schemas/` — sync-target schemas
 - `README.md`, `LICENSE`, `action.yaml`
 
-In-repo dogfood mirrors (`.agents/skills/`, `.claude/skills/`) and source layout (`src/`, `scripts/`, `tests/`) are intentionally excluded.
+In-repo dogfood mirrors (`.agents/skills/`, `.claude/skills/`, `.claude/agents/`) and source layout (`src/`, `scripts/`, `tests/`) are intentionally excluded.
 
 ### Trusted Publishers setup
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -250,8 +250,8 @@ async function writeClaudeAgentsDogfood(agents) {
     out.relativePath.startsWith(".claude/agents/"),
   );
   for (const out of outputs) {
-    // out.relativePath is `.claude/agents/<name>.md`; strip the `.claude/`
-    // prefix since CLAUDE_AGENTS_DOGFOOD_TARGET already points at `.claude/agents`.
+    // out.relativePath is repo-root-relative (`.claude/agents/<name>.md`), so
+    // join it onto ROOT directly — this lands under CLAUDE_AGENTS_DOGFOOD_TARGET.
     const file = join(ROOT, out.relativePath);
     await mkdir(dirname(file), { recursive: true });
     await writeFile(file, out.content);

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -8,9 +8,13 @@
 //      `package.json#files`):
 //        - .agents/skills/{name}/SKILL.md        (Codex CLI / Gemini CLI dogfood)
 //        - .claude/skills/{name}/SKILL.md        (Claude Code dogfood)
+//        - .claude/agents/{name}.md              (Claude Code dogfood, agents)
 //      Plus any non-SKILL.* files under each skill dir (e.g. perspectives/).
 //      These are kept because skills repo dogfoods its own skill bundle via
-//      slash commands, but they are not shipped to npm consumers.
+//      slash commands, but they are not shipped to npm consumers. Agents are
+//      Claude Code only, so they mirror only into `.claude/agents/` (never the
+//      codex/gemini `.agents/` dogfood) and reuse the ClaudeCodeAdapter's
+//      `.claude/agents/<name>.md` output path verbatim (no second transform).
 //
 //   2. Adapter outputs under dist/{adapter-id}/, produced by AdapterBase
 //      subclasses. These are the canonical npm payload for consumers — each
@@ -48,6 +52,11 @@ const DIST = join(ROOT, "dist");
 // slash commands (e.g. `/drive`, `/lint`). They are NOT shipped to npm —
 // `package.json#files` only includes `dist/`, `bin/`, `schemas/`, etc.
 const CLAUDE_DOGFOOD_TARGET = join(ROOT, ".claude", "skills");
+// Claude Code agents dogfood target. Agents are Claude Code only (ADR-0026),
+// so unlike skills they have a single dogfood destination (`.claude/agents/`,
+// never the codex/gemini `.agents/` tree). Mirrored from the ClaudeCodeAdapter
+// output so this matches `dist/claude-code/.claude/agents/` verbatim (issue #137).
+const CLAUDE_AGENTS_DOGFOOD_TARGET = join(ROOT, ".claude", "agents");
 // Each dogfood target mirrors the canonical skills for the adapter(s) that
 // read from it: `.agents/skills/` feeds Codex CLI + Gemini CLI, `.claude/skills/`
 // feeds Claude Code. A skill restricted via frontmatter `adapters` is mirrored
@@ -189,7 +198,7 @@ async function loadAgents() {
   return agents;
 }
 
-async function writeDogfoodTargets(skills) {
+async function writeDogfoodTargets(skills, agents) {
   // Write in-repo dogfood mirrors at `.agents/skills/` and `.claude/skills/`.
   // These are excluded from the npm payload by `package.json#files` but kept
   // in the repo so skills repo can use its own slash commands.
@@ -220,6 +229,32 @@ async function writeDogfoodTargets(skills) {
         await writeFile(dest, extra.content);
       }
     }
+  }
+  await writeClaudeAgentsDogfood(agents);
+}
+
+async function writeClaudeAgentsDogfood(agents) {
+  // Mirror Claude Code agents into the in-repo `.claude/agents/` dogfood.
+  // Agents are Claude Code only (ADR-0026), so they go solely into the
+  // `.claude/` tree (never the codex/gemini `.agents/` dogfood). The output
+  // is produced by the ClaudeCodeAdapter and filtered to `.claude/agents/`,
+  // so the dogfood mirror shares the exact same conversion path (and verbatim
+  // content) as the `dist/claude-code/.claude/agents/` npm payload — no second
+  // implementation. The destination root (`.claude/agents/`) is fully removed
+  // first so stale agents (renamed/deleted in src/agents/) do not linger.
+  if (existsSync(CLAUDE_AGENTS_DOGFOOD_TARGET)) {
+    await rm(CLAUDE_AGENTS_DOGFOOD_TARGET, { recursive: true, force: true });
+  }
+  if ((agents ?? []).length === 0) return;
+  const outputs = (await new ClaudeCodeAdapter().generate([], { agents })).filter((out) =>
+    out.relativePath.startsWith(".claude/agents/"),
+  );
+  for (const out of outputs) {
+    // out.relativePath is `.claude/agents/<name>.md`; strip the `.claude/`
+    // prefix since CLAUDE_AGENTS_DOGFOOD_TARGET already points at `.claude/agents`.
+    const file = join(ROOT, out.relativePath);
+    await mkdir(dirname(file), { recursive: true });
+    await writeFile(file, out.content);
   }
 }
 
@@ -312,7 +347,7 @@ async function main() {
   const skills = await loadSkills();
   const agents = await loadAgents();
   await cleanupRemovedLegacyTargets();
-  await writeDogfoodTargets(skills);
+  await writeDogfoodTargets(skills, agents);
   const publicSkills = skills.filter((s) => !INTERNAL_SKILLS.has(s.name));
   await writeAdapterOutputs(publicSkills, agents);
   await writeProjectScopeOutput(publicSkills, agents);
@@ -323,6 +358,9 @@ async function main() {
   console.log("In-repo dogfood (excluded from npm payload):");
   for (const target of DOGFOOD_TARGETS) {
     console.log(`  ${target.dir.replace(ROOT, "").replace(/^\//, "")}`);
+  }
+  if (agents.length > 0) {
+    console.log(`  ${CLAUDE_AGENTS_DOGFOOD_TARGET.replace(ROOT, "").replace(/^\//, "")}`);
   }
   console.log(`Adapters (npm payload, ${publicSkills.length} public skill(s)):`);
   for (const adapter of ADAPTERS) {

--- a/tests/agents.test.mjs
+++ b/tests/agents.test.mjs
@@ -90,6 +90,40 @@ test("Claude Code adapter throws when agent is missing required field", async ()
   );
 });
 
+test("dogfood mirrors each agent into .claude/agents/<name>.md (issue #137)", async () => {
+  // The build pipeline (writeClaudeAgentsDogfood) mirrors src/agents/<name>.md
+  // into the in-repo `.claude/agents/<name>.md` dogfood so cloud / project-scope
+  // sessions can resolve agents (e.g. code-reviewer for `/review --deep`). The
+  // dogfood is a committed build artifact and must equal the canonical src
+  // verbatim (relative refs preserved — same as the `.claude/skills/` dogfood,
+  // unlike `dist/claude-code/` which applies the user-scope rewrite).
+  const agents = await loadAgents();
+  for (const agent of agents) {
+    const dogfood = join(ROOT, ".claude", "agents", `${agent.name}.md`);
+    assert.ok(
+      existsSync(dogfood),
+      `expected dogfood .claude/agents/${agent.name}.md (run \`pnpm build\`)`,
+    );
+    const content = await readFile(dogfood, "utf8");
+    assert.equal(
+      content,
+      agent.raw,
+      `dogfood .claude/agents/${agent.name}.md must match src/agents/${agent.name}.md verbatim`,
+    );
+  }
+});
+
+test("dogfood mirrors the code-reviewer agent specifically (issue #137)", async () => {
+  const src = join(AGENTS_DIR, "code-reviewer.md");
+  assert.ok(existsSync(src), "src/agents/code-reviewer.md must exist");
+  const dogfood = join(ROOT, ".claude", "agents", "code-reviewer.md");
+  assert.ok(
+    existsSync(dogfood),
+    "expected dogfood .claude/agents/code-reviewer.md (run `pnpm build`)",
+  );
+  assert.equal(await readFile(dogfood, "utf8"), await readFile(src, "utf8"));
+});
+
 test("code-reviewer agent declares read-only tool allowlist (ADR-0025)", async () => {
   const agents = await loadAgents();
   const reviewer = agents.find((a) => a.name === "code-reviewer");


### PR DESCRIPTION
## 背景

`sync-project` を skills repo 自体に流したところ `.claude/agents/code-reviewer.md` だけが純増（untracked）した。原因は build の dogfood が skills のみミラーし agents をミラーしていないこと。結果 skills repo 自身の `.claude/agents/` が空で、cloud / project-scope セッションが `/review --deep` 用の code-reviewer agent を解決できなかった。

## 変更内容

- `scripts/build.mjs` に `writeClaudeAgentsDogfood` を追加。`ClaudeCodeAdapter` が生成する `.claude/agents/<name>.md` 出力を verbatim で再利用（**同じ変換経路を共有・二重実装なし**）し、in-repo `.claude/agents/` dogfood へミラーする。
- agents は Claude Code 専用（ADR-0026）なので単一の destination のみ（codex/gemini の `.agents/` ツリーには出さない）。
- stale agent 残留防止に出力前にディレクトリ全削除。npm payload には `package.json#files`（`dist/` のみ）により他の dogfood 同様除外。
- 生成物 `.claude/agents/code-reviewer.md` を commit（`src/agents/code-reviewer.md` と verbatim 一致、相対 ref 保持 = `.claude/skills/` dogfood と同様で `dist/claude-code/` の user-scope rewrite とは別）。

## テスト

- `tests/agents.test.mjs` に「dogfood `.claude/agents/<name>.md` が `src/agents/<name>.md` と verbatim 一致」「code-reviewer 固有」の assertion を追加。
- `pnpm test`（246）/ `pnpm run lint` / `pnpm run lint:md` 全緑。

## docs

- `scripts/build.mjs` 冒頭コメントの dogfood 説明に `.claude/agents/` を追記。
- README の dogfood 除外リストに `.claude/agents/` を追加。

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)