### PR TITLE
fix(usage-guard): bypass shared cache for non-zero dispatch headroom

### DIFF
--- a/.claude/skills/usage-guard/SKILL.md
+++ b/.claude/skills/usage-guard/SKILL.md
@@ -101,6 +101,7 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
 
 - `headroom` は**閾値比較にのみ**作用する。`wait_seconds` / `resets_at` / 反映ラグの算出は**不変**で、headroom の大小でスケールしない（トリップした枠の待機は枠端 + buffer のみ。複数の headroom 値が同じ枠を超えさせるなら待機は同一）
 - 既定 `headroom=0` は従来挙動（現在値で gate）。**後方互換**。単一モードの Phase1 / review-loop checkpoint は headroom=0 のまま
+- **shared cache をまたがない**: `headroom > 0`（dispatch checkpoint）は `~/.claude/usage-guard/cache.json`（headroom=0 で算出され #123 hook と共有）を **read も write もしない**。さもないと headroom=0 の `ok:true` を見込み超過に誤って返したり（gate を無効化）、headroom 超過の `ok:false` を hook 経路に汚染したりする。`headroom > 0` の結果は常に `source` が `cache` 以外になる
 - 負値・非数値は 0 にクランプ（誤設定でガードを現在値より緩めない）
 - 解決順は **CLI `--headroom <pct>` > env `USAGE_GUARD_DISPATCH_HEADROOM` > 既定 0**
 

--- a/.claude/skills/usage-guard/usage-check.mjs
+++ b/.claude/skills/usage-guard/usage-check.mjs
@@ -45,6 +45,10 @@
 //                   raw window edge. Such results are NOT cached (so the next
 //                   check hits the live endpoint, not the stale lagged value).
 //   - source:       "endpoint" | "jsonl" | "fail-open" | "cache"
+//                   A non-zero headroom NEVER reports "cache": it bypasses the
+//                   shared (headroom-0) cache for both read and write so a
+//                   projected gate is never served — nor poisons — a headroom-0
+//                   reading (#141 follow-up).
 //
 // Fail-open: if the endpoint fails AND the JSONL fallback fails, emit
 // { ok: true, ... source: "fail-open" } and a warning on stderr so the guard
@@ -591,9 +595,27 @@ export async function getUsage({
   const lagRecheck = resolveLagRecheck(env);
   const dispatchHeadroom = headroom === undefined ? resolveDispatchHeadroom(env) : headroom;
 
-  // 1. Fresh cache → return as-is (no endpoint re-fetch within TTL).
-  const cached = await readCache({ readFileImpl, cachePath, ttlMs: cacheTtlMs, now });
-  if (cached) return { ...cached, source: "cache" };
+  // Headroom + shared cache (#141 follow-up): the cache at CACHE_PATH is shared
+  // with the #123 PreToolUse hook and every headroom-0 caller, and it stores a
+  // result whose `ok` was computed WITHOUT headroom. A dispatch checkpoint
+  // passing a non-zero headroom must therefore NOT:
+  //   (a) be served that cached headroom-0 result — it would report ok:true on a
+  //       projected over-threshold and silently defeat the gate (observed:
+  //       `--headroom 90` returned source:cache ok:true right after a headroom-0
+  //       check), nor
+  //   (b) write its headroom-tripped result back — it would poison the shared
+  //       headroom-0 path (the hook) with a false over-threshold reading.
+  // So a non-zero headroom bypasses BOTH the cache read and write; only the
+  // headroom-0 path shares the cache. (Negative headroom clamps to 0 in
+  // evaluate(), so treat <= 0 as the shared-cache path.)
+  const useSharedCache = dispatchHeadroom <= 0;
+
+  // 1. Fresh cache → return as-is (no endpoint re-fetch within TTL). Only the
+  //    headroom-0 path reads the shared cache (see above).
+  if (useSharedCache) {
+    const cached = await readCache({ readFileImpl, cachePath, ttlMs: cacheTtlMs, now });
+    if (cached) return { ...cached, source: "cache" };
+  }
 
   const evalOpts = {
     threshold,
@@ -610,6 +632,7 @@ export async function getUsage({
   // result flags a lag we skip the cache write — the next check hits the live
   // endpoint and can observe the post-lag value immediately.
   const maybeCache = async (result) => {
+    if (!useSharedCache) return result; // headroom>0: never read NOR write the shared cache
     if (result.suspected_reflection_lag) return result; // do NOT cache a lagged read
     // (#139 (e)) Over-threshold reads get a SHORTENED TTL so a transient spike /
     // residual lag just outside the epsilon is re-verified soon (the next check

--- a/dist/claude-code-project/.claude/skills/usage-guard/SKILL.md
+++ b/dist/claude-code-project/.claude/skills/usage-guard/SKILL.md
@@ -101,6 +101,7 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
 
 - `headroom` は**閾値比較にのみ**作用する。`wait_seconds` / `resets_at` / 反映ラグの算出は**不変**で、headroom の大小でスケールしない（トリップした枠の待機は枠端 + buffer のみ。複数の headroom 値が同じ枠を超えさせるなら待機は同一）
 - 既定 `headroom=0` は従来挙動（現在値で gate）。**後方互換**。単一モードの Phase1 / review-loop checkpoint は headroom=0 のまま
+- **shared cache をまたがない**: `headroom > 0`（dispatch checkpoint）は `~/.claude/usage-guard/cache.json`（headroom=0 で算出され #123 hook と共有）を **read も write もしない**。さもないと headroom=0 の `ok:true` を見込み超過に誤って返したり（gate を無効化）、headroom 超過の `ok:false` を hook 経路に汚染したりする。`headroom > 0` の結果は常に `source` が `cache` 以外になる
 - 負値・非数値は 0 にクランプ（誤設定でガードを現在値より緩めない）
 - 解決順は **CLI `--headroom <pct>` > env `USAGE_GUARD_DISPATCH_HEADROOM` > 既定 0**
 

--- a/dist/claude-code-project/.claude/skills/usage-guard/usage-check.mjs
+++ b/dist/claude-code-project/.claude/skills/usage-guard/usage-check.mjs
@@ -45,6 +45,10 @@
 //                   raw window edge. Such results are NOT cached (so the next
 //                   check hits the live endpoint, not the stale lagged value).
 //   - source:       "endpoint" | "jsonl" | "fail-open" | "cache"
+//                   A non-zero headroom NEVER reports "cache": it bypasses the
+//                   shared (headroom-0) cache for both read and write so a
+//                   projected gate is never served — nor poisons — a headroom-0
+//                   reading (#141 follow-up).
 //
 // Fail-open: if the endpoint fails AND the JSONL fallback fails, emit
 // { ok: true, ... source: "fail-open" } and a warning on stderr so the guard
@@ -591,9 +595,27 @@ export async function getUsage({
   const lagRecheck = resolveLagRecheck(env);
   const dispatchHeadroom = headroom === undefined ? resolveDispatchHeadroom(env) : headroom;
 
-  // 1. Fresh cache → return as-is (no endpoint re-fetch within TTL).
-  const cached = await readCache({ readFileImpl, cachePath, ttlMs: cacheTtlMs, now });
-  if (cached) return { ...cached, source: "cache" };
+  // Headroom + shared cache (#141 follow-up): the cache at CACHE_PATH is shared
+  // with the #123 PreToolUse hook and every headroom-0 caller, and it stores a
+  // result whose `ok` was computed WITHOUT headroom. A dispatch checkpoint
+  // passing a non-zero headroom must therefore NOT:
+  //   (a) be served that cached headroom-0 result — it would report ok:true on a
+  //       projected over-threshold and silently defeat the gate (observed:
+  //       `--headroom 90` returned source:cache ok:true right after a headroom-0
+  //       check), nor
+  //   (b) write its headroom-tripped result back — it would poison the shared
+  //       headroom-0 path (the hook) with a false over-threshold reading.
+  // So a non-zero headroom bypasses BOTH the cache read and write; only the
+  // headroom-0 path shares the cache. (Negative headroom clamps to 0 in
+  // evaluate(), so treat <= 0 as the shared-cache path.)
+  const useSharedCache = dispatchHeadroom <= 0;
+
+  // 1. Fresh cache → return as-is (no endpoint re-fetch within TTL). Only the
+  //    headroom-0 path reads the shared cache (see above).
+  if (useSharedCache) {
+    const cached = await readCache({ readFileImpl, cachePath, ttlMs: cacheTtlMs, now });
+    if (cached) return { ...cached, source: "cache" };
+  }
 
   const evalOpts = {
     threshold,
@@ -610,6 +632,7 @@ export async function getUsage({
   // result flags a lag we skip the cache write — the next check hits the live
   // endpoint and can observe the post-lag value immediately.
   const maybeCache = async (result) => {
+    if (!useSharedCache) return result; // headroom>0: never read NOR write the shared cache
     if (result.suspected_reflection_lag) return result; // do NOT cache a lagged read
     // (#139 (e)) Over-threshold reads get a SHORTENED TTL so a transient spike /
     // residual lag just outside the epsilon is re-verified soon (the next check

--- a/dist/claude-code/.claude/skills/usage-guard/SKILL.md
+++ b/dist/claude-code/.claude/skills/usage-guard/SKILL.md
@@ -101,6 +101,7 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
 
 - `headroom` は**閾値比較にのみ**作用する。`wait_seconds` / `resets_at` / 反映ラグの算出は**不変**で、headroom の大小でスケールしない（トリップした枠の待機は枠端 + buffer のみ。複数の headroom 値が同じ枠を超えさせるなら待機は同一）
 - 既定 `headroom=0` は従来挙動（現在値で gate）。**後方互換**。単一モードの Phase1 / review-loop checkpoint は headroom=0 のまま
+- **shared cache をまたがない**: `headroom > 0`（dispatch checkpoint）は `~/.claude/usage-guard/cache.json`（headroom=0 で算出され #123 hook と共有）を **read も write もしない**。さもないと headroom=0 の `ok:true` を見込み超過に誤って返したり（gate を無効化）、headroom 超過の `ok:false` を hook 経路に汚染したりする。`headroom > 0` の結果は常に `source` が `cache` 以外になる
 - 負値・非数値は 0 にクランプ（誤設定でガードを現在値より緩めない）
 - 解決順は **CLI `--headroom <pct>` > env `USAGE_GUARD_DISPATCH_HEADROOM` > 既定 0**
 

--- a/dist/claude-code/.claude/skills/usage-guard/usage-check.mjs
+++ b/dist/claude-code/.claude/skills/usage-guard/usage-check.mjs
@@ -45,6 +45,10 @@
 //                   raw window edge. Such results are NOT cached (so the next
 //                   check hits the live endpoint, not the stale lagged value).
 //   - source:       "endpoint" | "jsonl" | "fail-open" | "cache"
+//                   A non-zero headroom NEVER reports "cache": it bypasses the
+//                   shared (headroom-0) cache for both read and write so a
+//                   projected gate is never served — nor poisons — a headroom-0
+//                   reading (#141 follow-up).
 //
 // Fail-open: if the endpoint fails AND the JSONL fallback fails, emit
 // { ok: true, ... source: "fail-open" } and a warning on stderr so the guard
@@ -591,9 +595,27 @@ export async function getUsage({
   const lagRecheck = resolveLagRecheck(env);
   const dispatchHeadroom = headroom === undefined ? resolveDispatchHeadroom(env) : headroom;
 
-  // 1. Fresh cache → return as-is (no endpoint re-fetch within TTL).
-  const cached = await readCache({ readFileImpl, cachePath, ttlMs: cacheTtlMs, now });
-  if (cached) return { ...cached, source: "cache" };
+  // Headroom + shared cache (#141 follow-up): the cache at CACHE_PATH is shared
+  // with the #123 PreToolUse hook and every headroom-0 caller, and it stores a
+  // result whose `ok` was computed WITHOUT headroom. A dispatch checkpoint
+  // passing a non-zero headroom must therefore NOT:
+  //   (a) be served that cached headroom-0 result — it would report ok:true on a
+  //       projected over-threshold and silently defeat the gate (observed:
+  //       `--headroom 90` returned source:cache ok:true right after a headroom-0
+  //       check), nor
+  //   (b) write its headroom-tripped result back — it would poison the shared
+  //       headroom-0 path (the hook) with a false over-threshold reading.
+  // So a non-zero headroom bypasses BOTH the cache read and write; only the
+  // headroom-0 path shares the cache. (Negative headroom clamps to 0 in
+  // evaluate(), so treat <= 0 as the shared-cache path.)
+  const useSharedCache = dispatchHeadroom <= 0;
+
+  // 1. Fresh cache → return as-is (no endpoint re-fetch within TTL). Only the
+  //    headroom-0 path reads the shared cache (see above).
+  if (useSharedCache) {
+    const cached = await readCache({ readFileImpl, cachePath, ttlMs: cacheTtlMs, now });
+    if (cached) return { ...cached, source: "cache" };
+  }
 
   const evalOpts = {
     threshold,
@@ -610,6 +632,7 @@ export async function getUsage({
   // result flags a lag we skip the cache write — the next check hits the live
   // endpoint and can observe the post-lag value immediately.
   const maybeCache = async (result) => {
+    if (!useSharedCache) return result; // headroom>0: never read NOR write the shared cache
     if (result.suspected_reflection_lag) return result; // do NOT cache a lagged read
     // (#139 (e)) Over-threshold reads get a SHORTENED TTL so a transient spike /
     // residual lag just outside the epsilon is re-verified soon (the next check

--- a/src/skills/usage-guard/SKILL.md
+++ b/src/skills/usage-guard/SKILL.md
@@ -101,6 +101,7 @@ node ~/.claude/skills/usage-guard/usage-check.mjs
 
 - `headroom` は**閾値比較にのみ**作用する。`wait_seconds` / `resets_at` / 反映ラグの算出は**不変**で、headroom の大小でスケールしない（トリップした枠の待機は枠端 + buffer のみ。複数の headroom 値が同じ枠を超えさせるなら待機は同一）
 - 既定 `headroom=0` は従来挙動（現在値で gate）。**後方互換**。単一モードの Phase1 / review-loop checkpoint は headroom=0 のまま
+- **shared cache をまたがない**: `headroom > 0`（dispatch checkpoint）は `~/.claude/usage-guard/cache.json`（headroom=0 で算出され #123 hook と共有）を **read も write もしない**。さもないと headroom=0 の `ok:true` を見込み超過に誤って返したり（gate を無効化）、headroom 超過の `ok:false` を hook 経路に汚染したりする。`headroom > 0` の結果は常に `source` が `cache` 以外になる
 - 負値・非数値は 0 にクランプ（誤設定でガードを現在値より緩めない）
 - 解決順は **CLI `--headroom <pct>` > env `USAGE_GUARD_DISPATCH_HEADROOM` > 既定 0**
 

--- a/src/skills/usage-guard/usage-check.mjs
+++ b/src/skills/usage-guard/usage-check.mjs
@@ -45,6 +45,10 @@
 //                   raw window edge. Such results are NOT cached (so the next
 //                   check hits the live endpoint, not the stale lagged value).
 //   - source:       "endpoint" | "jsonl" | "fail-open" | "cache"
+//                   A non-zero headroom NEVER reports "cache": it bypasses the
+//                   shared (headroom-0) cache for both read and write so a
+//                   projected gate is never served — nor poisons — a headroom-0
+//                   reading (#141 follow-up).
 //
 // Fail-open: if the endpoint fails AND the JSONL fallback fails, emit
 // { ok: true, ... source: "fail-open" } and a warning on stderr so the guard
@@ -591,9 +595,27 @@ export async function getUsage({
   const lagRecheck = resolveLagRecheck(env);
   const dispatchHeadroom = headroom === undefined ? resolveDispatchHeadroom(env) : headroom;
 
-  // 1. Fresh cache → return as-is (no endpoint re-fetch within TTL).
-  const cached = await readCache({ readFileImpl, cachePath, ttlMs: cacheTtlMs, now });
-  if (cached) return { ...cached, source: "cache" };
+  // Headroom + shared cache (#141 follow-up): the cache at CACHE_PATH is shared
+  // with the #123 PreToolUse hook and every headroom-0 caller, and it stores a
+  // result whose `ok` was computed WITHOUT headroom. A dispatch checkpoint
+  // passing a non-zero headroom must therefore NOT:
+  //   (a) be served that cached headroom-0 result — it would report ok:true on a
+  //       projected over-threshold and silently defeat the gate (observed:
+  //       `--headroom 90` returned source:cache ok:true right after a headroom-0
+  //       check), nor
+  //   (b) write its headroom-tripped result back — it would poison the shared
+  //       headroom-0 path (the hook) with a false over-threshold reading.
+  // So a non-zero headroom bypasses BOTH the cache read and write; only the
+  // headroom-0 path shares the cache. (Negative headroom clamps to 0 in
+  // evaluate(), so treat <= 0 as the shared-cache path.)
+  const useSharedCache = dispatchHeadroom <= 0;
+
+  // 1. Fresh cache → return as-is (no endpoint re-fetch within TTL). Only the
+  //    headroom-0 path reads the shared cache (see above).
+  if (useSharedCache) {
+    const cached = await readCache({ readFileImpl, cachePath, ttlMs: cacheTtlMs, now });
+    if (cached) return { ...cached, source: "cache" };
+  }
 
   const evalOpts = {
     threshold,
@@ -610,6 +632,7 @@ export async function getUsage({
   // result flags a lag we skip the cache write — the next check hits the live
   // endpoint and can observe the post-lag value immediately.
   const maybeCache = async (result) => {
+    if (!useSharedCache) return result; // headroom>0: never read NOR write the shared cache
     if (result.suspected_reflection_lag) return result; // do NOT cache a lagged read
     // (#139 (e)) Over-threshold reads get a SHORTENED TTL so a transient spike /
     // residual lag just outside the epsilon is re-verified soon (the next check

--- a/tests/usage-check.test.mjs
+++ b/tests/usage-check.test.mjs
@@ -418,6 +418,99 @@ test("(#141) getUsage: CLI headroom param wins over env; undefined falls back to
   assert.equal(legacy.ok, true, "no headroom → 86 < 95 → ok (backward compatible)");
 });
 
+test("(#141) headroom>0 does NOT read the shared headroom-0 cache (re-evaluates)", async () => {
+  // A fresh cached headroom-0 result says ok:true. A dispatch checkpoint passing
+  // a large headroom must NOT be served that cached ok:true — it would defeat the
+  // projected gate. It re-evaluates the live windows instead and trips.
+  let fetchCalls = 0;
+  const cached = {
+    five_hour: { utilization: 86, resets_at: "2026-06-15T02:00:00.000Z" },
+    seven_day: { utilization: 10, resets_at: null },
+    ok: true,
+    wait_seconds: 0,
+    resets_at: null,
+  };
+  const readFileImpl = async (path) => {
+    if (path.endsWith("cache.json")) {
+      return JSON.stringify({ cached_at: FIXED_NOW - 10_000, result: cached }); // fresh (10s < 45s TTL)
+    }
+    if (path.endsWith(".credentials.json")) {
+      return JSON.stringify({ claudeAiOauth: { accessToken: "t", expiresAt: FIXED_NOW + 1000 } });
+    }
+    throw new Error(`unexpected ${path}`);
+  };
+  const result = await getUsage({
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          five_hour: { utilization: 86, resets_at: "2026-06-15T02:00:00.000Z" },
+          seven_day: { utilization: 10, resets_at: null },
+        }),
+      };
+    },
+    readFileImpl,
+    headroom: 12, // projected 86 + 12 = 98 >= 95 → must trip
+    now,
+    cachePath: "/fake/cache.json",
+  });
+  assert.notEqual(result.source, "cache", "headroom>0 must bypass the shared cache read");
+  assert.equal(fetchCalls, 1, "headroom>0 re-evaluates against the live endpoint");
+  assert.equal(result.ok, false, "projected 98 >= 95 trips despite a fresh ok:true cache");
+});
+
+test("(#141) headroom>0 result is NOT written back to the shared cache", async () => {
+  // The headroom-tripped (ok:false) result must not poison the shared cache that
+  // the #123 hook / headroom-0 callers read.
+  const writes = [];
+  const result = await getUsage({
+    fetchImpl: fetchOk({
+      five_hour: { utilization: 86, resets_at: "2026-06-15T02:00:00.000Z" },
+      seven_day: { utilization: 10, resets_at: null },
+    }),
+    readFileImpl: credsReader(),
+    writeFileImpl: async (p, c) => writes.push([p, c]),
+    mkdirImpl: async () => {},
+    headroom: 12,
+    now,
+    cachePath: "/fake/cache.json",
+    credentialsPath: "/fake/.credentials.json",
+  });
+  assert.equal(result.ok, false, "projected 98 trips");
+  assert.equal(writes.length, 0, "headroom>0 must not write the shared cache");
+});
+
+test("(#141) headroom-0 path still shares the cache (regression guard)", async () => {
+  // The shared-cache behaviour for the default/hook path (headroom 0) is intact.
+  let fetchCalls = 0;
+  const cached = {
+    five_hour: { utilization: 50, resets_at: null },
+    seven_day: { utilization: 50, resets_at: null },
+    ok: true,
+    wait_seconds: 0,
+    resets_at: null,
+  };
+  const readFileImpl = async (path) => {
+    if (path.endsWith("cache.json")) {
+      return JSON.stringify({ cached_at: FIXED_NOW - 10_000, result: cached });
+    }
+    throw new Error(`unexpected ${path}`);
+  };
+  const result = await getUsage({
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return { ok: true, status: 200, json: async () => ({}) };
+    },
+    readFileImpl,
+    now,
+    cachePath: "/fake/cache.json",
+  });
+  assert.equal(result.source, "cache", "headroom 0 still reads the shared cache");
+  assert.equal(fetchCalls, 0, "headroom 0 still avoids the endpoint within TTL");
+});
+
 test("getUsage reports resume_buffer_seconds on the fail-open result", async () => {
   const result = await getUsage({
     fetchImpl: async () => {


### PR DESCRIPTION
## 概要

#142 で導入した dispatch headroom gate が、**共有キャッシュによって無効化される**バグの修正。

`getUsage` は評価結果を時刻のみで keying してキャッシュするが、その結果の `ok` は **headroom なし**で算出されている。dispatch checkpoint が 45s TTL 内に `--headroom` 付きで呼ぶと、stale な headroom-0 の `ok:true`（`source:cache`）を返してしまい、**見込み超過の gate が発火しない**。これは feature が狙う orchestration シナリオ（headroom-0 の Phase/worker check の直後に wave/worker dispatch checkpoint が走る）でまさに踏む。

実機再現:
```
$ node usage-check.mjs                # headroom-0、ok:true をキャッシュ
$ node usage-check.mjs --headroom 90  # ok:True source:cache  ← 誤り（projected 104% なのに通過）
$ rm cache.json && node usage-check.mjs --headroom 90
                                      # ok:False source:endpoint  ← 正しい
```

## 修正

`headroom > 0`（dispatch checkpoint）は共有キャッシュ（`~/.claude/usage-guard/cache.json`、#123 hook と共有・headroom-0 で算出）を **read も write もしない**:

- **read しない**: headroom-0 の結果を返すと見込み gate を無効化するため
- **write しない**: headroom 超過の `ok:false` を hook 経路（headroom-0）に汚染するため

`headroom=0`（既定 + #123 hook）のみが従来どおりキャッシュを共有。`headroom > 0` の結果は `source` が常に `cache` 以外になる。

## テスト

- 追加 3 ケース: headroom>0 は cache を read しない（再評価して trip）/ write しない / headroom-0 は従来どおり共有（regression guard）
- **全 273 tests pass**、biome / markdownlint / gitleaks / trivy クリーン
- 実機 dogfood で warm cache 後も `--headroom 90` → `ok:false source:endpoint` を確認

## 関連

- #141（headroom gate）/ #142（実装 PR、本バグの混入元）
- 検証中（`/drive` 完了後の user-scope 反映時）に発覚

🤖 Generated with [Claude Code](https://claude.com/claude-code)
