### PR TITLE
fix(usage-guard): stop inflating a 1% usage reading to 100%

### DIFF
--- a/.claude/skills/usage-guard/usage-check.mjs
+++ b/.claude/skills/usage-guard/usage-check.mjs
@@ -251,8 +251,14 @@ export async function readAccessToken({
 
 /**
  * Normalize one raw usage window (`{ utilization, resets_at }`-ish) into a
- * stable `{ utilization, resets_at }` shape. Tolerates missing fields and
- * `utilization` expressed as a 0–1 fraction (scaled to 0–100).
+ * stable `{ utilization, resets_at }` shape. Tolerates missing fields.
+ *
+ * `utilization` is taken verbatim as a 0–100 percentage — the OAuth usage
+ * endpoint reports percentages (e.g. `11.0`, `2.0`, and fractional values like
+ * `94.9`), never a 0–1 fraction. An earlier "scale 0–1 fractions to percent"
+ * heuristic (`util <= 1 → util * 100`) inflated a genuine 1% reading to 100%
+ * (and would turn 0.5% into 50%), hard-stopping the guard whenever a window sat
+ * at exactly 1%. There is no fraction form to detect here, so we never scale.
  *
  * @param {any} raw
  * @returns {{ utilization: number, resets_at: string|null }}
@@ -261,7 +267,6 @@ export function normalizeWindow(raw) {
   if (!raw || typeof raw !== "object") return { utilization: 0, resets_at: null };
   let util = Number(raw.utilization);
   if (!Number.isFinite(util)) util = 0;
-  if (util > 0 && util <= 1) util *= 100; // fraction → percent
   const resetsAt = raw.resets_at ?? raw.resetsAt ?? null;
   return { utilization: util, resets_at: typeof resetsAt === "string" ? resetsAt : null };
 }

--- a/dist/claude-code-project/.claude/skills/usage-guard/usage-check.mjs
+++ b/dist/claude-code-project/.claude/skills/usage-guard/usage-check.mjs
@@ -251,8 +251,14 @@ export async function readAccessToken({
 
 /**
  * Normalize one raw usage window (`{ utilization, resets_at }`-ish) into a
- * stable `{ utilization, resets_at }` shape. Tolerates missing fields and
- * `utilization` expressed as a 0–1 fraction (scaled to 0–100).
+ * stable `{ utilization, resets_at }` shape. Tolerates missing fields.
+ *
+ * `utilization` is taken verbatim as a 0–100 percentage — the OAuth usage
+ * endpoint reports percentages (e.g. `11.0`, `2.0`, and fractional values like
+ * `94.9`), never a 0–1 fraction. An earlier "scale 0–1 fractions to percent"
+ * heuristic (`util <= 1 → util * 100`) inflated a genuine 1% reading to 100%
+ * (and would turn 0.5% into 50%), hard-stopping the guard whenever a window sat
+ * at exactly 1%. There is no fraction form to detect here, so we never scale.
  *
  * @param {any} raw
  * @returns {{ utilization: number, resets_at: string|null }}
@@ -261,7 +267,6 @@ export function normalizeWindow(raw) {
   if (!raw || typeof raw !== "object") return { utilization: 0, resets_at: null };
   let util = Number(raw.utilization);
   if (!Number.isFinite(util)) util = 0;
-  if (util > 0 && util <= 1) util *= 100; // fraction → percent
   const resetsAt = raw.resets_at ?? raw.resetsAt ?? null;
   return { utilization: util, resets_at: typeof resetsAt === "string" ? resetsAt : null };
 }

--- a/dist/claude-code/.claude/skills/usage-guard/usage-check.mjs
+++ b/dist/claude-code/.claude/skills/usage-guard/usage-check.mjs
@@ -251,8 +251,14 @@ export async function readAccessToken({
 
 /**
  * Normalize one raw usage window (`{ utilization, resets_at }`-ish) into a
- * stable `{ utilization, resets_at }` shape. Tolerates missing fields and
- * `utilization` expressed as a 0–1 fraction (scaled to 0–100).
+ * stable `{ utilization, resets_at }` shape. Tolerates missing fields.
+ *
+ * `utilization` is taken verbatim as a 0–100 percentage — the OAuth usage
+ * endpoint reports percentages (e.g. `11.0`, `2.0`, and fractional values like
+ * `94.9`), never a 0–1 fraction. An earlier "scale 0–1 fractions to percent"
+ * heuristic (`util <= 1 → util * 100`) inflated a genuine 1% reading to 100%
+ * (and would turn 0.5% into 50%), hard-stopping the guard whenever a window sat
+ * at exactly 1%. There is no fraction form to detect here, so we never scale.
  *
  * @param {any} raw
  * @returns {{ utilization: number, resets_at: string|null }}
@@ -261,7 +267,6 @@ export function normalizeWindow(raw) {
   if (!raw || typeof raw !== "object") return { utilization: 0, resets_at: null };
   let util = Number(raw.utilization);
   if (!Number.isFinite(util)) util = 0;
-  if (util > 0 && util <= 1) util *= 100; // fraction → percent
   const resetsAt = raw.resets_at ?? raw.resetsAt ?? null;
   return { utilization: util, resets_at: typeof resetsAt === "string" ? resetsAt : null };
 }

--- a/src/skills/usage-guard/usage-check.mjs
+++ b/src/skills/usage-guard/usage-check.mjs
@@ -251,8 +251,14 @@ export async function readAccessToken({
 
 /**
  * Normalize one raw usage window (`{ utilization, resets_at }`-ish) into a
- * stable `{ utilization, resets_at }` shape. Tolerates missing fields and
- * `utilization` expressed as a 0–1 fraction (scaled to 0–100).
+ * stable `{ utilization, resets_at }` shape. Tolerates missing fields.
+ *
+ * `utilization` is taken verbatim as a 0–100 percentage — the OAuth usage
+ * endpoint reports percentages (e.g. `11.0`, `2.0`, and fractional values like
+ * `94.9`), never a 0–1 fraction. An earlier "scale 0–1 fractions to percent"
+ * heuristic (`util <= 1 → util * 100`) inflated a genuine 1% reading to 100%
+ * (and would turn 0.5% into 50%), hard-stopping the guard whenever a window sat
+ * at exactly 1%. There is no fraction form to detect here, so we never scale.
  *
  * @param {any} raw
  * @returns {{ utilization: number, resets_at: string|null }}
@@ -261,7 +267,6 @@ export function normalizeWindow(raw) {
   if (!raw || typeof raw !== "object") return { utilization: 0, resets_at: null };
   let util = Number(raw.utilization);
   if (!Number.isFinite(util)) util = 0;
-  if (util > 0 && util <= 1) util *= 100; // fraction → percent
   const resetsAt = raw.resets_at ?? raw.resetsAt ?? null;
   return { utilization: util, resets_at: typeof resetsAt === "string" ? resetsAt : null };
 }

--- a/tests/usage-check.test.mjs
+++ b/tests/usage-check.test.mjs
@@ -172,6 +172,44 @@ test("(4b) threshold env override changes the boundary", () => {
   assert.equal(at85.ok, false, "85 >= 80 → not ok at threshold 80");
 });
 
+// --- percentages are taken verbatim (no 0–1 fraction scaling) ----------------
+//
+// Regression: the OAuth endpoint reports utilization as a 0–100 percentage. An
+// earlier `util <= 1 → util * 100` heuristic inflated a genuine 1% reading to
+// 100% (and 0.5% to 50%), which hard-stopped the guard whenever a window sat at
+// exactly 1% even though the session was nowhere near its cap.
+
+test("normalizeWindows keeps a 1% reading as 1 (not 100)", () => {
+  const w = normalizeWindows({
+    five_hour: { utilization: 11, resets_at: "2026-06-23T12:10:00.000Z" },
+    seven_day: { utilization: 1, resets_at: "2026-06-30T07:00:00.000Z" },
+  });
+  assert.equal(w.five_hour.utilization, 11);
+  assert.equal(w.seven_day.utilization, 1, "1% must stay 1%, not inflate to 100%");
+});
+
+test("a 1% window stays well below threshold → ok (the real incident)", () => {
+  // The observed endpoint payload that previously tripped the guard: 5h=11%,
+  // 7d=1%. With verbatim percentages both windows are far below 95 → ok.
+  const result = evaluate(
+    normalizeWindows({
+      five_hour: { utilization: 11, resets_at: "2026-06-23T12:10:00.000Z" },
+      seven_day: { utilization: 1, resets_at: "2026-06-30T07:00:00.000Z" },
+    }),
+    { now },
+  );
+  assert.equal(result.ok, true, "11% / 1% are both < 95 → ok");
+  assert.equal(result.wait_seconds, 0);
+});
+
+test("a fractional percentage below 1 is not scaled up (0.5 stays 0.5)", () => {
+  const w = normalizeWindows({
+    five_hour: { utilization: 0.5, resets_at: null },
+    seven_day: { utilization: 0, resets_at: null },
+  });
+  assert.equal(w.five_hour.utilization, 0.5, "0.5% must stay 0.5%, not become 50%");
+});
+
 // --- (5) wait_seconds = latest exceeded resets_at ----------------------------
 
 test("(5) wait_seconds derives from the LATEST resets_at among exceeded windows", () => {


### PR DESCRIPTION
## 背景

usage-guard の `usage-check.mjs` の `normalizeWindow` が、利用率を「0–1 の割合」とみなして `util * 100` するヒューリスティックを持っていた:

```js
if (util > 0 && util <= 1) util *= 100; // fraction → percent
```

しかし OAuth usage エンドポイント (`GET /api/oauth/usage`) は利用率を **0–100 のパーセント**で返す（実測: `five_hour=11.0` / `seven_day=2.0`、`94.9` のような小数%もある）。割合(0–1)形式は存在しない。

その結果、ある window の真値が **ちょうど `1`（=1%）** のとき `1 <= 1` に引っかかり **`1 → 100%`** に化け、PreToolUse の ceiling フックが `ok=false` で**全ツールを hard-stop** していた（5h は 11% 程度なのに 7d が一瞬 1% を指しただけで発火）。同じ式は `0.5%` も `50%` に誤拡大する。

## 切り分け

「本当に 100% なら API がセッション自体を弾くはず。だがツール呼び出しは通っていた」→ API は正常、集計側の誤りと判明。raw payload で `seven_day.utilization` が `1`（その後 `2`）であることを確認し、web UI 表示（1%→2%）と一致した。

## 変更

- `normalizeWindow`: fraction スケーリング行を削除し、利用率を **verbatim**（0–100%）で扱う。docstring も更新。
- 回帰テスト 3 件追加:
  - `1%` が `1` のまま（100 にならない）
  - 観測された `5h=11 / 7d=1` payload が `ok:true` に評価される
  - `0.5%` が `0.5` のまま（50 にならない）

## 検証

- `pnpm test` → 276 pass（新規3件含む）
- `pnpm run lint` クリーン、build で `.claude/skills` mirror と `dist/` を再生成

🤖 Generated with [Claude Code](https://claude.com/claude-code)