### PR TITLE
chore(build): strip build-control frontmatter; document sidecars

### DIFF
--- a/.claude/skills/usage-guard/SKILL.md
+++ b/.claude/skills/usage-guard/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: usage-guard
 description: Claude Code の Usage Limit（5 時間 = Current / 週次 = Weekly）を監視し、95% 超過で作業を一時停止、リセットで枠が回復したら自動再開する pause/resume エンジン。drive 等の caller が checkpoint で Read するエンジン形態と、`/usage-guard "<継続コマンド>"` で任意作業を guard する単体形態を同梱。Claude 専用（OAuth 使用率エンドポイント + ScheduleWakeup 依存）。
-adapters: claude-code
 user-invocable: true
 argument-hint: "<継続コマンド>（空欄で status 確認のみ）"
 disable-model-invocation: true

--- a/README.md
+++ b/README.md
@@ -161,21 +161,27 @@ Consumers that previously consumed skills as **project skills** via the legacy p
 | `gemini-cli` | `dist/gemini-cli/.agents/skills/{name}/SKILL.md` + `.gemini/settings.json` + `AGENTS.md.snippet` | canonical `SKILL.md` |
 | `copilot` | `dist/copilot/.agents/skills/{name}/SKILL.md` + `copilot-instructions.md.snippet` | canonical `SKILL.md` |
 
-### Claude Code companion file
+### Claude Code companion file (overlay)
 
-A skill may ship `.agents/skills/{name}/SKILL.claude-code.md` alongside the canonical `SKILL.md`. The Claude Code adapter emits the companion verbatim when present, so each skill can carry a Claude-Code-specific wrapper (next-action `AskUserQuestion` menus, `argument-hint`, `disable-model-invocation`, `allowed-tools`, etc.) without polluting the canonical `SKILL.md` other adapters consume.
+A skill may ship `.agents/skills/{name}/SKILL.claude-code.md` alongside the canonical `SKILL.md`. It is an **overlay**: it carries only Claude-Code-specific frontmatter plus a body (next-action `AskUserQuestion` menus, argument parsing, etc.). At build time the Claude Code adapter injects the canonical `description` as the first frontmatter key, so the two can never drift — the companion **must not** duplicate `description`.
 
 Companion frontmatter contract:
 
 | Field | Required | Notes |
 | --- | --- | --- |
-| `description` | yes | May be a Claude-Code-tailored shortening of canonical `description` |
+| `description` | — | Must be **absent**; injected from the canonical `SKILL.md` |
 | `disable-model-invocation` | optional | Boolean — opt out of automatic invocation |
 | `allowed-tools` | optional | Comma-separated tool list |
 | `argument-hint` | optional | Display hint for `/skill-name <hint>` |
 | `user-invocable` | optional | `false` for reference-only skills |
 
 `name` is derived from the directory and must not appear in companion frontmatter.
+
+### Adapter-specific sidecars
+
+Any non-`SKILL.*` file under a skill directory is copied verbatim into each adapter payload that ships the skill (e.g. `review/perspectives/<axis>.md`). This is also the extension point for adapter-native config: a Codex skill can carry `agents/openai.yaml` (approval policy / implicit-invocation control) and it rides along to `.agents/skills/{name}/agents/openai.yaml`, which Codex reads and the other tools ignore. No skill in this repo uses one yet.
+
+Build-control frontmatter (`adapters`) is stripped from every emitted `SKILL.md` — it never reaches consumer payloads.
 
 ### Adapter gating
 

--- a/dist/claude-code-project/.claude/skills/usage-guard/SKILL.md
+++ b/dist/claude-code-project/.claude/skills/usage-guard/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: usage-guard
 description: Claude Code の Usage Limit（5 時間 = Current / 週次 = Weekly）を監視し、95% 超過で作業を一時停止、リセットで枠が回復したら自動再開する pause/resume エンジン。drive 等の caller が checkpoint で Read するエンジン形態と、`/usage-guard "<継続コマンド>"` で任意作業を guard する単体形態を同梱。Claude 専用（OAuth 使用率エンドポイント + ScheduleWakeup 依存）。
-adapters: claude-code
 user-invocable: true
 argument-hint: "<継続コマンド>（空欄で status 確認のみ）"
 disable-model-invocation: true

--- a/dist/claude-code/.claude/skills/usage-guard/SKILL.md
+++ b/dist/claude-code/.claude/skills/usage-guard/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: usage-guard
 description: Claude Code の Usage Limit（5 時間 = Current / 週次 = Weekly）を監視し、95% 超過で作業を一時停止、リセットで枠が回復したら自動再開する pause/resume エンジン。drive 等の caller が checkpoint で Read するエンジン形態と、`/usage-guard "<継続コマンド>"` で任意作業を guard する単体形態を同梱。Claude 専用（OAuth 使用率エンドポイント + ScheduleWakeup 依存）。
-adapters: claude-code
 user-invocable: true
 argument-hint: "<継続コマンド>（空欄で status 確認のみ）"
 disable-model-invocation: true

--- a/scripts/adapters/claude-code.mjs
+++ b/scripts/adapters/claude-code.mjs
@@ -22,7 +22,11 @@
 
 import { AdapterBase } from "../lib/adapter-base.mjs";
 import { filterSkillsForAdapter } from "../lib/adapter-gating.mjs";
-import { assertRequiredFields, serializeFrontmatter } from "../lib/frontmatter.mjs";
+import {
+  assertRequiredFields,
+  serializeFrontmatter,
+  stripBuildControlFrontmatter,
+} from "../lib/frontmatter.mjs";
 
 /**
  * @typedef {import("../lib/types.mjs").Skill} Skill
@@ -64,7 +68,7 @@ export class ClaudeCodeAdapter extends AdapterBase {
       } else {
         outputs.push({
           relativePath: `.claude/skills/${skill.name}/SKILL.md`,
-          content: skill.raw,
+          content: stripBuildControlFrontmatter(skill.raw, canonicalLabel),
         });
       }
       for (const extra of skill.extraFiles ?? []) {

--- a/scripts/lib/agents-skills-tree.mjs
+++ b/scripts/lib/agents-skills-tree.mjs
@@ -5,7 +5,7 @@
 // read natively. Each of those adapters emits the SAME tree (differing only in
 // their AGENTS.md / instructions aggregation), so the tree is rendered here once.
 
-import { assertRequiredFields } from "./frontmatter.mjs";
+import { assertRequiredFields, stripBuildControlFrontmatter } from "./frontmatter.mjs";
 
 /**
  * @typedef {import("./types.mjs").Skill} Skill
@@ -30,7 +30,10 @@ export function renderAgentsSkillsTree(skills) {
     );
     outputs.push({
       relativePath: `.agents/skills/${skill.name}/SKILL.md`,
-      content: skill.raw,
+      content: stripBuildControlFrontmatter(
+        skill.raw,
+        `.agents/skills/${skill.name}/SKILL.md`,
+      ),
     });
     for (const extra of skill.extraFiles ?? []) {
       outputs.push({

--- a/scripts/lib/frontmatter.mjs
+++ b/scripts/lib/frontmatter.mjs
@@ -47,6 +47,31 @@ export function serializeFrontmatter(frontmatter) {
   return lines.join("\n");
 }
 
+// Frontmatter keys that control the build pipeline and must NOT leak into the
+// SKILL.md files shipped to consumers (they are build-time metadata only).
+const BUILD_CONTROL_KEYS = new Set(["adapters"]);
+
+/**
+ * Remove build-control frontmatter keys (e.g. `adapters`) from a raw SKILL.md
+ * before it is emitted to a consumer. Returns the input verbatim when there is
+ * nothing to strip, so skills without such keys stay byte-identical.
+ *
+ * @param {string} raw        Raw SKILL.md text.
+ * @param {string} fileLabel  Path used in error messages.
+ * @returns {string}
+ */
+export function stripBuildControlFrontmatter(raw, fileLabel) {
+  const { frontmatter, body } = parseSkillDocument(raw, fileLabel);
+  if (!Object.keys(frontmatter).some((k) => BUILD_CONTROL_KEYS.has(k))) {
+    return raw;
+  }
+  const cleaned = {};
+  for (const [key, value] of Object.entries(frontmatter)) {
+    if (!BUILD_CONTROL_KEYS.has(key)) cleaned[key] = value;
+  }
+  return serializeFrontmatter(cleaned) + body;
+}
+
 /**
  * Validate required frontmatter fields.
  *

--- a/tests/frontmatter.test.mjs
+++ b/tests/frontmatter.test.mjs
@@ -4,7 +4,24 @@ import {
   assertRequiredFields,
   parseSkillDocument,
   serializeFrontmatter,
+  stripBuildControlFrontmatter,
 } from "../scripts/lib/frontmatter.mjs";
+
+test("stripBuildControlFrontmatter removes `adapters` but keeps everything else", () => {
+  const input =
+    "---\nname: foo\ndescription: bar\nadapters: claude-code\ndisable-model-invocation: true\n---\nbody\n";
+  const out = stripBuildControlFrontmatter(input, "foo/SKILL.md");
+  assert.doesNotMatch(out, /^adapters:/m);
+  assert.match(out, /name: foo/);
+  assert.match(out, /description: bar/);
+  assert.match(out, /disable-model-invocation: true/);
+  assert.match(out, /\nbody\n$/);
+});
+
+test("stripBuildControlFrontmatter returns input verbatim when nothing to strip", () => {
+  const input = "---\nname: foo\ndescription: bar\n---\nbody\n";
+  assert.equal(stripBuildControlFrontmatter(input, "foo/SKILL.md"), input);
+});
 
 test("parseSkillDocument extracts frontmatter and body", () => {
   const input = "---\nname: foo\ndescription: bar\n---\n# heading\n\nbody\n";

--- a/tests/usage-check.test.mjs
+++ b/tests/usage-check.test.mjs
@@ -1065,7 +1065,9 @@ test("built claude-code usage-guard SKILL.md is user-invocable + has standalone-
   const fm = built.match(/^---\n([\s\S]*?)\n---\n/);
   assert.ok(fm, "SKILL.md must have frontmatter");
   assert.match(fm[1], /user-invocable:\s*true/, "frontmatter must declare user-invocable: true");
-  assert.match(fm[1], /adapters:\s*claude-code/, "frontmatter must be gated to claude-code");
+  // Build-control `adapters` is stripped from emitted SKILL.md — gating that the
+  // skill is claude-code-only is verified at the dist-payload level elsewhere.
+  assert.doesNotMatch(fm[1], /^adapters:/m, "build-control `adapters` must be stripped");
   assert.match(fm[1], /argument-hint:/, "frontmatter must declare argument-hint");
   // standalone form section
   assert.match(built, /単体形態/, "body must document the standalone /usage-guard form");


### PR DESCRIPTION
改善ステップ **5**（仕上げ）。frontmatter strip（P5）＋ドキュメント整合（companion overlay / Codex sidecar）。

## P5: build 制御 frontmatter の strip
`adapters:` キーが usage-guard の emitted SKILL.md（`dist/claude-code` / project-scope / dogfood の 3 箇所）に漏れていた。共通ヘルパ `stripBuildControlFrontmatter()` を追加し、Claude Code adapter（no-companion 経路）と共通 `.agents/skills/` renderer で emit 時に除去。該当キーを持たない skill は **byte 同一**。

## ドキュメント整合
- companion セクションを **overlay モデル**（#148: description を重複させない）に更新。
- **adapter-specific sidecar** の拡張ポイントを明記（Codex `agents/openai.yaml` は extra-files 機構で `.agents/skills/{name}/agents/openai.yaml` に流れる。他ツールは無視。現状未使用＝投機実装なし）。
- `adapters` が consumer payload に届かないことを明記。

## 検証
- 全 282 テスト green（strip の単体テスト 2 件追加）/ build 決定的 / lint clean
- 出荷物から `adapters:` 完全除去を確認（変更は usage-guard wrapper 3 ファイルのみ）

`#145`→`#146`→`#148`→`#149` に続く最終ステップ5。

🤖 Generated with [Claude Code](https://claude.com/claude-code)