### PR TITLE
feat(cli): per-item provenance marker foundation (#151 PR2)

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -5,7 +5,7 @@ node = "24"
 uv = "0.11.10"
 
 # Linters & formatters
-biome = "2"
+biome = "2.4.16"
 shellcheck = "0.11"
 shfmt = "3"
 taplo = "0.10"

--- a/bin/lib/marker.mjs
+++ b/bin/lib/marker.mjs
@@ -1,0 +1,127 @@
+// Per-item provenance markers — the single source of truth for what the CLI
+// installed (see ozzy-labs/skills#151).
+//
+// Each materialized skill directory carries a co-located `.ozzylabs-skills.json`
+// recording that it is ours, which bundle version produced it, and which adapters
+// need it (the reference count for the shared `.agents/skills/<name>` base).
+// Agents are single files, so they get a sidecar `<name>.md.ozzylabs-skills.json`.
+// Markers are filesystem-resident: deleting an item removes its marker, so the
+// state can't drift independently and survives a wiped central cache. There is
+// NO central registry.
+//
+// Markers are written by the CLI at install time — never by the build pipeline.
+// `scripts/build.mjs` excludes `*ozzylabs-skills.json` from the shipped payload
+// (`isMarkerFile` is the shared predicate) so a marker can never leak into dist.
+
+import { readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export const MARKER_NAME = ".ozzylabs-skills.json";
+export const MARKER_SCHEMA = 1;
+export const MARKER_SOURCE = "@ozzylabs/skills";
+
+/**
+ * True for any provenance marker path — the dir marker `.ozzylabs-skills.json`
+ * and the agent sidecar `<name>.md.ozzylabs-skills.json`. Used both by the CLI
+ * and by the build pipeline (to keep markers out of dist).
+ *
+ * @param {string} relOrName
+ * @returns {boolean}
+ */
+export function isMarkerFile(relOrName) {
+  return /ozzylabs-skills\.json$/.test(relOrName);
+}
+
+/** Path of the marker inside a skill directory. */
+export function markerPathForDir(dir) {
+  return join(dir, MARKER_NAME);
+}
+
+/** Path of the sidecar marker for a single-file item (e.g. an agent .md). */
+export function markerPathForFile(filePath) {
+  return `${filePath}${MARKER_NAME}`;
+}
+
+/**
+ * @param {{ bundleVersion: string, adapters?: string[], extra?: object }} fields
+ * @returns {object}
+ */
+function buildMarker({ bundleVersion, adapters, extra }) {
+  const marker = {
+    schema: MARKER_SCHEMA,
+    source: MARKER_SOURCE,
+    bundleVersion,
+  };
+  if (adapters) marker.adapters = [...new Set(adapters)].sort();
+  return { ...marker, ...extra };
+}
+
+/**
+ * Read a marker from an exact path. Returns null when absent or unparseable
+ * (a corrupt marker is treated as "not ours" — never throws).
+ *
+ * @param {string} markerPath
+ * @returns {Promise<object | null>}
+ */
+export async function readMarker(markerPath) {
+  if (!existsSync(markerPath)) return null;
+  try {
+    const parsed = JSON.parse(await readFile(markerPath, "utf8"));
+    return parsed && parsed.source === MARKER_SOURCE ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Read the marker for a skill directory. */
+export function readDirMarker(dir) {
+  return readMarker(markerPathForDir(dir));
+}
+
+/**
+ * Write/refresh a marker at an exact path. JSON is stable (sorted adapters,
+ * 2-space indent, trailing newline) so re-installs and project-scope commits
+ * produce minimal diffs.
+ *
+ * @param {string} markerPath
+ * @param {{ bundleVersion: string, adapters?: string[], extra?: object }} fields
+ * @returns {Promise<object>} the written marker
+ */
+export async function writeMarker(markerPath, fields) {
+  const marker = buildMarker(fields);
+  await writeFile(markerPath, `${JSON.stringify(marker, null, 2)}\n`);
+  return marker;
+}
+
+/** Write the marker into a skill directory. */
+export function writeDirMarker(dir, fields) {
+  return writeMarker(markerPathForDir(dir), fields);
+}
+
+/**
+ * Reference-count helper for the shared `.agents/skills/<name>` base: merge an
+ * adapter into an existing marker's `adapters[]` (or seed a fresh one).
+ *
+ * @param {object | null} existing
+ * @param {string} adapter
+ * @param {string} bundleVersion
+ * @returns {object} the merged marker fields ({ bundleVersion, adapters })
+ */
+export function withAdapterAdded(existing, adapter, bundleVersion) {
+  const adapters = new Set(existing?.adapters ?? []);
+  adapters.add(adapter);
+  return { bundleVersion, adapters: [...adapters].sort() };
+}
+
+/**
+ * Remove an adapter from a marker's `adapters[]`. Returns the remaining adapter
+ * list — when empty, the caller deletes the shared base (last reference gone).
+ *
+ * @param {object | null} existing
+ * @param {string} adapter
+ * @returns {string[]} remaining adapters
+ */
+export function withAdapterRemoved(existing, adapter) {
+  return (existing?.adapters ?? []).filter((a) => a !== adapter).sort();
+}

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "files": {
     "includes": [
       "src/**",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -134,6 +134,10 @@ async function loadExtraFiles(skillName) {
     const rel = relative(skillDir, file);
     if (rel === "SKILL.md") continue;
     if (/^SKILL\.[a-z0-9-]+\.md$/.test(rel)) continue;
+    // Provenance markers (`.ozzylabs-skills.json`, agent sidecars) are written
+    // by the CLI at install time and must never ship in the dist payload
+    // (ozzy-labs/skills#151). Keep them out of every adapter output.
+    if (/ozzylabs-skills\.json$/.test(rel)) continue;
     const content = await readFile(file, "utf8");
     extras.push({ relativePath: rel, content });
   }

--- a/tests/marker.test.mjs
+++ b/tests/marker.test.mjs
@@ -27,7 +27,10 @@ test("isMarkerFile matches dir markers, agent sidecars, and nested markers", () 
 });
 
 test("markerPathForFile appends the marker suffix (agent sidecar)", () => {
-  assert.equal(markerPathForFile("/x/.claude/agents/foo.md"), `/x/.claude/agents/foo.md${MARKER_NAME}`);
+  assert.equal(
+    markerPathForFile("/x/.claude/agents/foo.md"),
+    `/x/.claude/agents/foo.md${MARKER_NAME}`,
+  );
 });
 
 test("writeDirMarker / readDirMarker round-trip with sorted adapters + schema", async () => {
@@ -87,5 +90,9 @@ test("the build never ships a provenance marker into dist/", async () => {
       else if (isMarkerFile(entry.name)) offenders.push(full);
     }
   }
-  assert.deepEqual(offenders, [], `dist must not contain provenance markers:\n${offenders.join("\n")}`);
+  assert.deepEqual(
+    offenders,
+    [],
+    `dist must not contain provenance markers:\n${offenders.join("\n")}`,
+  );
 });

--- a/tests/marker.test.mjs
+++ b/tests/marker.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  isMarkerFile,
+  MARKER_NAME,
+  markerPathForDir,
+  markerPathForFile,
+  readDirMarker,
+  readMarker,
+  withAdapterAdded,
+  withAdapterRemoved,
+  writeDirMarker,
+} from "../bin/lib/marker.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+test("isMarkerFile matches dir markers, agent sidecars, and nested markers", () => {
+  assert.ok(isMarkerFile(".ozzylabs-skills.json"));
+  assert.ok(isMarkerFile("code-reviewer.md.ozzylabs-skills.json"));
+  assert.ok(isMarkerFile("review/.ozzylabs-skills.json"));
+  assert.ok(!isMarkerFile("SKILL.md"));
+  assert.ok(!isMarkerFile("perspectives/security.md"));
+});
+
+test("markerPathForFile appends the marker suffix (agent sidecar)", () => {
+  assert.equal(markerPathForFile("/x/.claude/agents/foo.md"), `/x/.claude/agents/foo.md${MARKER_NAME}`);
+});
+
+test("writeDirMarker / readDirMarker round-trip with sorted adapters + schema", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "marker-"));
+  try {
+    const written = await writeDirMarker(dir, {
+      bundleVersion: "1.4.2",
+      adapters: ["codex-cli", "claude-code", "codex-cli"],
+    });
+    assert.deepEqual(written.adapters, ["claude-code", "codex-cli"]);
+    assert.equal(written.schema, 1);
+    assert.equal(written.source, "@ozzylabs/skills");
+    const read = await readDirMarker(dir);
+    assert.deepEqual(read, written);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("readMarker returns null for absent, corrupt, or foreign markers", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "marker-"));
+  try {
+    assert.equal(await readMarker(markerPathForDir(dir)), null, "absent");
+    await writeFile(markerPathForDir(dir), "{ not json");
+    assert.equal(await readMarker(markerPathForDir(dir)), null, "corrupt");
+    await writeFile(markerPathForDir(dir), JSON.stringify({ source: "someone-else" }));
+    assert.equal(await readMarker(markerPathForDir(dir)), null, "foreign source");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("withAdapterAdded / withAdapterRemoved reference-count the shared base", () => {
+  const seed = withAdapterAdded(null, "codex-cli", "1.0.0");
+  assert.deepEqual(seed.adapters, ["codex-cli"]);
+  const merged = withAdapterAdded({ adapters: ["codex-cli"] }, "claude-code", "1.0.0");
+  assert.deepEqual(merged.adapters, ["claude-code", "codex-cli"]);
+  // Re-adding is idempotent.
+  assert.deepEqual(withAdapterAdded(merged, "codex-cli", "1.0.0").adapters, [
+    "claude-code",
+    "codex-cli",
+  ]);
+  // Removing the last reference yields an empty list → caller deletes the base.
+  assert.deepEqual(withAdapterRemoved({ adapters: ["codex-cli"] }, "codex-cli"), []);
+  assert.deepEqual(withAdapterRemoved(merged, "codex-cli"), ["claude-code"]);
+});
+
+test("the build never ships a provenance marker into dist/", async () => {
+  const { readdir } = await import("node:fs/promises");
+  const stack = [join(ROOT, "dist")];
+  const offenders = [];
+  while (stack.length) {
+    const dir = stack.pop();
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (isMarkerFile(entry.name)) offenders.push(full);
+    }
+  }
+  assert.deepEqual(offenders, [], `dist must not contain provenance markers:\n${offenders.join("\n")}`);
+});


### PR DESCRIPTION
**[#151](https://github.com/ozzy-labs/skills/issues/151) の PR2**。`list`/`remove`/`update` が依存する **state 層**を追加。state は co-locate した `.ozzylabs-skills.json` マーカー（**中央 registry なし**）が唯一の正本。

## 変更
- **`bin/lib/marker.mjs`**: マーカーの read/write（dir マーカー＋agent サイドカー）、安定 JSON（`{schema, source, bundleVersion, adapters[]}`）、**壊れた/他者のマーカーは null 扱い**（never ours・never throws）、共有 `.agents/skills/<name>` base の**参照カウントヘルパ**（`withAdapterAdded`/`withAdapterRemoved`）。
- **`scripts/build.mjs`**: extra-files 収集から **`*ozzylabs-skills.json` を除外**（dist 自己汚染防止）。
- テスト: round-trip / null ケース / refcount / `isMarkerFile` predicate / **dist にマーカーが 1 件も無いことの guard**。

## 検証
- 全 283 テスト green / build 決定的 / lint clean

PR1（#152）に続く基盤。次は PR3（`add` 完成: 検出・衝突ガード・マーカー書込）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)