### PR TITLE
feat(cli): markers + collision guard on `add` (#151 PR3)

### DIFF
--- a/bin/lib/add.mjs
+++ b/bin/lib/add.mjs
@@ -15,6 +15,7 @@ import {
   planInstall,
   SUPPORTED_ADAPTERS,
 } from "./install.mjs";
+import { findCollisions, getBundleVersion, writeMarkers } from "./install-markers.mjs";
 import { executeSyncProject, planSyncProject } from "./sync-project.mjs";
 
 const HELP = `npx @ozzylabs/skills add [options]
@@ -167,9 +168,32 @@ export async function runAdd(argv, opts = {}) {
     process.stdout.write(`${JSON.stringify(out, null, 2)}\n`);
     return 0;
   }
+
+  // Collision guard: refuse to claim a pre-existing skill directory that is NOT
+  // ours (carries no provenance marker) unless --force is given.
+  if (!force) {
+    const collisions = [];
+    for (const plan of plans) {
+      const skills = skillsFilter ?? plan.skills_available;
+      collisions.push(...(await findCollisions({ home, adapter: plan.adapter, skills })));
+    }
+    if (collisions.length > 0) {
+      process.stderr.write(
+        `error: refusing to overwrite ${collisions.length} existing skill ` +
+          `director${collisions.length === 1 ? "y" : "ies"} not installed by @ozzylabs/skills ` +
+          `(pass --force to overwrite):\n  ${collisions.join("\n  ")}\n`,
+      );
+      return 1;
+    }
+  }
+
+  const bundleVersion = await getBundleVersion(packageRoot);
   const summaries = [];
   for (const plan of plans) {
     const result = await executeInstall(plan, { upgrade: force, force });
+    // Mark every skill this adapter actually wrote (installed or upgraded).
+    const installed = [...new Set([...result.installed, ...result.upgraded])];
+    await writeMarkers({ home, adapter: plan.adapter, skills: installed, bundleVersion });
     summaries.push({ scope: "user", adapter: plan.adapter, ...result });
   }
   const out = summaries.length === 1 ? summaries[0] : summaries;

--- a/bin/lib/install-markers.mjs
+++ b/bin/lib/install-markers.mjs
@@ -1,0 +1,73 @@
+// Provenance-marker integration for `skills add` (ozzy-labs/skills#151 PR3).
+//
+// After files are materialized, each installed skill directory gets a marker
+// recording it is ours, the bundle version, and (for the shared
+// `.agents/skills/<name>` base) the reference-counted set of adapters that need
+// it. Before installing, a collision guard refuses to claim a pre-existing skill
+// directory that is NOT ours (no marker) unless `--force` is given.
+
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { ADAPTER_LAYOUT } from "./install.mjs";
+import { readDirMarker, withAdapterAdded, writeDirMarker } from "./marker.mjs";
+
+// The cross-tool base root is shared by every adapter; its marker carries the
+// adapter reference count. Other roots (e.g. `.claude/skills`) are adapter-owned.
+const SHARED_BASE_ROOT = ".agents/skills";
+
+/** Read the installed bundle version from the package root's package.json. */
+export async function getBundleVersion(packageRoot) {
+  try {
+    const pkg = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8"));
+    return pkg.version ?? "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+/**
+ * Every (root, skill) directory a given adapter materializes.
+ * @returns {Array<{ dir: string, root: string }>}
+ */
+function skillDirs(home, adapter, skills) {
+  const roots = ADAPTER_LAYOUT[adapter]?.skillsRoots ?? [];
+  const out = [];
+  for (const skill of skills) {
+    for (const root of roots) out.push({ dir: join(home, root, skill), root });
+  }
+  return out;
+}
+
+/**
+ * Find skill directories that already exist but are NOT ours (no marker) — these
+ * would be clobbered. The caller blocks unless `--force`.
+ *
+ * @returns {Promise<string[]>} offending absolute paths
+ */
+export async function findCollisions({ home, adapter, skills }) {
+  const offenders = [];
+  for (const { dir } of skillDirs(home, adapter, skills)) {
+    if (existsSync(dir) && (await readDirMarker(dir)) === null) offenders.push(dir);
+  }
+  return offenders;
+}
+
+/**
+ * Write/refresh provenance markers for the skills just installed by one adapter.
+ * The shared base marker is reference-count-merged (adds this adapter to the
+ * existing `adapters[]`); adapter-owned roots get a fresh single-adapter marker.
+ */
+export async function writeMarkers({ home, adapter, skills, bundleVersion }) {
+  for (const { dir, root } of skillDirs(home, adapter, skills)) {
+    if (!existsSync(dir)) continue;
+    if (root === SHARED_BASE_ROOT) {
+      const existing = await readDirMarker(dir);
+      await writeDirMarker(dir, withAdapterAdded(existing, adapter, bundleVersion));
+    } else {
+      await writeDirMarker(dir, { bundleVersion, adapters: [adapter] });
+    }
+  }
+}
+
+export { SHARED_BASE_ROOT };

--- a/tests/cli-e2e.test.mjs
+++ b/tests/cli-e2e.test.mjs
@@ -123,3 +123,63 @@ test("e2e: not-yet-implemented verbs exit non-zero with the #151 pointer", () =>
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /#151/);
 });
+
+test("e2e: add writes provenance markers (base marker carries the adapter)", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    const r = runCli(["add", "--adapter=codex-cli", "--skills=drive", "--force"], { home });
+    assert.equal(r.status, 0, `cli failed: ${r.stderr}`);
+    const marker = JSON.parse(
+      readFileSync(join(home, ".agents", "skills", "drive", ".ozzylabs-skills.json"), "utf8"),
+    );
+    assert.equal(marker.source, "@ozzylabs/skills");
+    assert.deepEqual(marker.adapters, ["codex-cli"]);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: a second adapter reference-counts the shared base marker", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    runCli(["add", "--adapter=codex-cli", "--skills=drive", "--force"], { home });
+    runCli(["add", "--adapter=claude-code", "--skills=drive", "--force"], { home });
+    const marker = JSON.parse(
+      readFileSync(join(home, ".agents", "skills", "drive", ".ozzylabs-skills.json"), "utf8"),
+    );
+    assert.deepEqual(
+      marker.adapters,
+      ["claude-code", "codex-cli"],
+      "base ref-counts both adapters",
+    );
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: add refuses to overwrite an unmarked (foreign) skill dir without --force", async () => {
+  const { mkdirSync, writeFileSync } = await import("node:fs");
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    // Pre-existing, user-authored skill dir with no provenance marker.
+    const foreign = join(home, ".agents", "skills", "drive");
+    mkdirSync(foreign, { recursive: true });
+    writeFileSync(join(foreign, "SKILL.md"), "mine\n");
+
+    const blocked = runCli(["add", "--adapter=codex-cli", "--skills=drive"], { home });
+    assert.notEqual(blocked.status, 0);
+    assert.match(blocked.stderr, /refusing to overwrite|--force/);
+    assert.equal(
+      readFileSync(join(foreign, "SKILL.md"), "utf8"),
+      "mine\n",
+      "foreign file untouched",
+    );
+
+    // --force overwrites and claims it.
+    const forced = runCli(["add", "--adapter=codex-cli", "--skills=drive", "--force"], { home });
+    assert.equal(forced.status, 0, `forced add failed: ${forced.stderr}`);
+    assert.notEqual(readFileSync(join(foreign, "SKILL.md"), "utf8"), "mine\n");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
**[#151](https://github.com/ozzy-labs/skills/issues/151) の PR3**。PR2 のマーカー層を `add`（user scope）に統合。

- install 後、各 skill dir に `.ozzylabs-skills.json` を書込。共有 `.agents/skills/<name>` base マーカーは **adapter を参照カウント**（codex→claude の順に add すると `adapters: [claude-code, codex-cli]`）。adapter 専有 root（`.claude/skills`）は単一 adapter マーカー。
- **衝突ガード**: マーカーの無い既存 skill dir（ユーザー自作/他者）は `--force` 無しに上書きしない。
- e2e: マーカー内容・2 adapter の参照カウント・foreign dir 衝突ガード（--force 無=block / 有=上書き）を検証。

全 286 テスト green / lint clean。次は PR4（`list`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)