### PR TITLE
feat(cli): implement `remove` (#151 PR5)

### DIFF
--- a/bin/lib/prompt.mjs
+++ b/bin/lib/prompt.mjs
@@ -1,0 +1,29 @@
+// Tiny interactive confirmation helper shared by the CLI verbs.
+
+/**
+ * Ask a yes/no question. Returns true when `force` is set, or when stdin is a
+ * TTY and the user answers y/yes. Non-TTY sessions return false (never block).
+ *
+ * @param {string} message
+ * @param {boolean} [force]
+ * @returns {Promise<boolean>}
+ */
+export async function confirm(message, force = false) {
+  if (force) return true;
+  if (!process.stdin.isTTY) return false;
+  process.stdout.write(`${message} [y/N] `);
+  return await new Promise((resolve) => {
+    let buf = "";
+    const onData = (chunk) => {
+      buf += chunk.toString();
+      if (buf.includes("\n")) {
+        process.stdin.off("data", onData);
+        process.stdin.pause();
+        const answer = buf.trim().toLowerCase();
+        resolve(answer === "y" || answer === "yes");
+      }
+    };
+    process.stdin.resume();
+    process.stdin.on("data", onData);
+  });
+}

--- a/bin/lib/remove.mjs
+++ b/bin/lib/remove.mjs
@@ -1,0 +1,197 @@
+// `skills remove` (alias: uninstall) — uninstall skills (ozzy-labs/skills#151 PR5).
+//
+// Only directories carrying our provenance marker are ever touched (a skill the
+// user authored, or one from another source, is left alone). The shared
+// `.agents/skills/<name>` base is reference-counted: removing one adapter drops
+// it from the marker's `adapters[]`; the base directory is deleted only when the
+// last adapter is gone. Removal is destructive, so it previews the plan and
+// requires confirmation (a TTY prompt, or `--yes` in non-interactive runs).
+
+import { existsSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { parseFlags } from "./args.mjs";
+import { didYouMean } from "./detect.mjs";
+import { ADAPTER_LAYOUT, findPackageRoot, SUPPORTED_ADAPTERS } from "./install.mjs";
+import { readDirMarker, writeDirMarker } from "./marker.mjs";
+import { confirm } from "./prompt.mjs";
+
+const SHARED_BASE_ROOT = ".agents/skills";
+
+const HELP = `npx @ozzylabs/skills remove --skills <list> [options]
+
+Uninstall skills. Only directories installed by @ozzylabs/skills are touched.
+
+Options:
+  --skills=<list>  REQUIRED. Comma-separated skill names to remove.
+  --adapter=<list> Limit removal to these adapters (default: all).
+  --target=<dir>   Remove from a project repo instead of user scope ($HOME).
+  --dry-run        Print the removal plan as JSON and exit.
+  --yes            Skip the confirmation prompt (required in non-interactive runs).
+  -h, --help       Show this help.
+
+Alias: \`uninstall\`.
+`;
+
+const SCHEMA = {
+  skills: "string",
+  adapter: "string",
+  target: "string",
+  "dry-run": "boolean",
+  yes: "boolean",
+  help: "boolean",
+};
+const ALIASES = { h: "help" };
+
+function splitList(value) {
+  return value ? value.split(",").map((s) => s.trim()).filter(Boolean) : null;
+}
+
+/** Adapter-owned roots (everything except the shared base). */
+function ownedRoots(adapter) {
+  return (ADAPTER_LAYOUT[adapter]?.skillsRoots ?? []).filter((r) => r !== SHARED_BASE_ROOT);
+}
+
+/**
+ * Build the removal plan for one skill: which marker-owned directories to delete
+ * outright, and how the shared base marker is reference-count-updated.
+ *
+ * @returns {Promise<{ skill: string, deletions: string[], baseUpdate: object | null, installed: boolean }>}
+ */
+async function planSkill(scopeRoot, skill, removeAdapters) {
+  const deletions = [];
+  let installed = false;
+
+  // Adapter-owned dirs (e.g. .claude/skills/<name>) — delete when ours.
+  for (const adapter of removeAdapters) {
+    for (const root of ownedRoots(adapter)) {
+      const dir = join(scopeRoot, root, skill);
+      if (existsSync(dir) && (await readDirMarker(dir))) {
+        deletions.push(dir);
+        installed = true;
+      }
+    }
+  }
+
+  // Shared base — reference count.
+  let baseUpdate = null;
+  const baseDir = join(scopeRoot, SHARED_BASE_ROOT, skill);
+  const baseMarker = await readDirMarker(baseDir);
+  if (baseMarker) {
+    installed = true;
+    const current = baseMarker.adapters ?? [];
+    const left = current.filter((a) => !removeAdapters.includes(a));
+    if (left.length === 0) {
+      deletions.push(baseDir);
+      baseUpdate = { dir: baseDir, action: "delete" };
+    } else if (left.length !== current.length) {
+      baseUpdate = {
+        dir: baseDir,
+        action: "rewrite",
+        adapters: left,
+        version: baseMarker.bundleVersion,
+      };
+    }
+  }
+
+  return { skill, deletions: [...new Set(deletions)], baseUpdate, installed };
+}
+
+/**
+ * @param {string[]} argv args past the `remove` subcommand keyword
+ * @param {{ isTTY?: boolean }} [opts]
+ * @returns {Promise<number>} exit code
+ */
+export async function runRemove(argv, opts = {}) {
+  let parsed;
+  try {
+    parsed = parseFlags(argv, SCHEMA, ALIASES);
+  } catch (err) {
+    process.stderr.write(`error: ${err.message}\n\n${HELP}`);
+    return 1;
+  }
+  if (parsed.values.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  if (parsed.rejected.length > 0) {
+    process.stderr.write(`error: unknown argument(s): ${parsed.rejected.join(", ")}\n\n${HELP}`);
+    return 1;
+  }
+  const skills = splitList(parsed.values.skills);
+  if (!skills || skills.length === 0) {
+    process.stderr.write(`error: --skills is required\n\n${HELP}`);
+    return 1;
+  }
+
+  let removeAdapters = SUPPORTED_ADAPTERS;
+  if (parsed.values.adapter) {
+    removeAdapters = splitList(parsed.values.adapter);
+    for (const a of removeAdapters) {
+      if (!SUPPORTED_ADAPTERS.includes(a)) {
+        process.stderr.write(
+          `error: unknown adapter '${a}'${didYouMean(a, SUPPORTED_ADAPTERS)}\n`,
+        );
+        return 1;
+      }
+    }
+  }
+
+  await findPackageRoot(); // validates we are running from the package
+  const scopeRoot = parsed.values.target ?? process.env.OZZYLABS_SKILLS_HOME ?? homedir();
+  const isTTY = opts.isTTY ?? Boolean(process.stdin.isTTY);
+
+  const plans = [];
+  for (const skill of skills) plans.push(await planSkill(scopeRoot, skill, removeAdapters));
+
+  const actionable = plans.filter((p) => p.installed);
+  if (actionable.length === 0) {
+    process.stdout.write("Nothing to remove (no matching installed skills).\n");
+    return 0;
+  }
+
+  // Preview.
+  const lines = ["The following will be removed:"];
+  for (const p of actionable) {
+    for (const d of p.deletions) lines.push(`  delete  ${d}`);
+    if (p.baseUpdate?.action === "rewrite") {
+      lines.push(`  keep    ${p.baseUpdate.dir}  (still needed by: ${p.baseUpdate.adapters.join(", ")})`);
+    }
+  }
+  process.stdout.write(`${lines.join("\n")}\n`);
+
+  if (parsed.values["dry-run"]) {
+    process.stdout.write(`${JSON.stringify({ scope: parsed.values.target ? "project" : "user", plans: actionable }, null, 2)}\n`);
+    return 0;
+  }
+
+  if (!parsed.values.yes) {
+    if (!isTTY) {
+      process.stderr.write("error: refusing to remove non-interactively — pass --yes.\n");
+      return 1;
+    }
+    const ok = await confirm("Proceed?", false);
+    if (!ok) {
+      process.stdout.write("Aborted.\n");
+      return 0;
+    }
+  }
+
+  // Execute.
+  for (const p of actionable) {
+    for (const d of p.deletions) await rm(d, { recursive: true, force: true });
+    if (p.baseUpdate?.action === "rewrite") {
+      await writeDirMarker(p.baseUpdate.dir, {
+        bundleVersion: p.baseUpdate.version,
+        adapters: p.baseUpdate.adapters,
+      });
+    }
+  }
+  process.stdout.write(
+    `${JSON.stringify({ removed: actionable.map((p) => p.skill) }, null, 2)}\n`,
+  );
+  return 0;
+}
+
+export { HELP };

--- a/bin/skills.mjs
+++ b/bin/skills.mjs
@@ -16,6 +16,7 @@
 import { runAdd } from "./lib/add.mjs";
 import { didYouMean } from "./lib/detect.mjs";
 import { runList } from "./lib/list.mjs";
+import { runRemove } from "./lib/remove.mjs";
 
 const VERBS = ["add", "update", "list", "remove", "fork", "diff"];
 const VERB_ALIASES = { install: "add", uninstall: "remove" };
@@ -27,7 +28,7 @@ Verbs:
              project scope. Alias: install.
   update     Update installed skills, preserving local edits. (coming — #151)
   list       Show the catalog and what is installed.
-  remove     Uninstall skills. Alias: uninstall. (coming — #151)
+  remove     Uninstall skills (confirmation required). Alias: uninstall.
   fork       Copy a skill to a user-owned name. (coming — #151)
   diff       Show a skill's diff against upstream. (coming — #151)
 
@@ -65,6 +66,9 @@ async function main(argv) {
   }
   if (verb === "list") {
     return await runList(rest);
+  }
+  if (verb === "remove") {
+    return await runRemove(rest);
   }
   if (VERBS.includes(verb)) {
     return notYetImplemented(verb);

--- a/tests/cli-e2e.test.mjs
+++ b/tests/cli-e2e.test.mjs
@@ -215,3 +215,70 @@ test("e2e: add refuses to overwrite an unmarked (foreign) skill dir without --fo
     await rm(home, { recursive: true, force: true });
   }
 });
+
+test("e2e: remove uninstalls a skill (base deleted, marker gone)", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    runCli(["add", "--adapter=codex-cli", "--skills=drive", "--force"], { home });
+    const base = join(home, ".agents", "skills", "drive");
+    assert.ok(existsSync(base));
+    const r = runCli(["remove", "--skills=drive", "--yes"], { home });
+    assert.equal(r.status, 0, `remove failed: ${r.stderr}`);
+    assert.ok(!existsSync(base), "base dir removed");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: remove --adapter reference-counts the shared base", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    runCli(["add", "--adapter=codex-cli", "--skills=drive", "--force"], { home });
+    runCli(["add", "--adapter=claude-code", "--skills=drive", "--force"], { home });
+    const base = join(home, ".agents", "skills", "drive");
+    const wrapper = join(home, ".claude", "skills", "drive");
+
+    // Remove just codex — base stays (claude still needs it), wrapper untouched.
+    runCli(["remove", "--skills=drive", "--adapter=codex-cli", "--yes"], { home });
+    assert.ok(existsSync(base), "base kept while claude-code still needs it");
+    assert.ok(existsSync(wrapper), "claude wrapper untouched");
+    const marker = JSON.parse(readFileSync(join(base, ".ozzylabs-skills.json"), "utf8"));
+    assert.deepEqual(marker.adapters, ["claude-code"]);
+
+    // Remove claude — last reference gone, base + wrapper deleted.
+    runCli(["remove", "--skills=drive", "--adapter=claude-code", "--yes"], { home });
+    assert.ok(!existsSync(base), "base removed after last adapter");
+    assert.ok(!existsSync(wrapper), "claude wrapper removed");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: remove refuses without --yes in a non-TTY session", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    runCli(["add", "--adapter=codex-cli", "--skills=drive", "--force"], { home });
+    const r = runCli(["remove", "--skills=drive"], { home });
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /--yes/);
+    assert.ok(existsSync(join(home, ".agents", "skills", "drive")), "not removed");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: remove never touches an unmarked (foreign) skill dir", async () => {
+  const { mkdirSync, writeFileSync } = await import("node:fs");
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    const foreign = join(home, ".agents", "skills", "drive");
+    mkdirSync(foreign, { recursive: true });
+    writeFileSync(join(foreign, "SKILL.md"), "mine\n");
+    const r = runCli(["remove", "--skills=drive", "--yes"], { home });
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /Nothing to remove/);
+    assert.ok(existsSync(join(foreign, "SKILL.md")), "foreign dir untouched");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
**[#151](https://github.com/ozzy-labs/skills/issues/151) の PR5**。`skills remove`（alias `uninstall`）を実装。マーカー付きのみ対象・共有 base を **参照カウント**（`--adapter` で 1 つ外す→最後の adapter が消えたら base 削除）・**foreign dir は不可侵**・破壊操作は**確認必須**（TTY プロンプト or 非対話は `--yes`）。e2e: uninstall / 参照カウント keep&delete / 非TTYの--yes必須 / foreign 不可侵。全 292 テスト green。次は PR6（`update`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)