### PR TITLE
feat(cli): implement `update` with editable protection (#151 PR6)

### DIFF
--- a/bin/lib/install-markers.mjs
+++ b/bin/lib/install-markers.mjs
@@ -10,7 +10,7 @@ import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { ADAPTER_LAYOUT } from "./install.mjs";
-import { readDirMarker, withAdapterAdded, writeDirMarker } from "./marker.mjs";
+import { computeDirHash, readDirMarker, withAdapterAdded, writeDirMarker } from "./marker.mjs";
 
 // The cross-tool base root is shared by every adapter; its marker carries the
 // adapter reference count. Other roots (e.g. `.claude/skills`) are adapter-owned.
@@ -61,11 +61,15 @@ export async function findCollisions({ home, adapter, skills }) {
 export async function writeMarkers({ home, adapter, skills, bundleVersion }) {
   for (const { dir, root } of skillDirs(home, adapter, skills)) {
     if (!existsSync(dir)) continue;
+    // originalHash baselines the as-installed content so `update` can detect a
+    // user's local edits. Markers are excluded from the hash, so order vs. write
+    // does not matter.
+    const originalHash = await computeDirHash(dir);
     if (root === SHARED_BASE_ROOT) {
-      const existing = await readDirMarker(dir);
-      await writeDirMarker(dir, withAdapterAdded(existing, adapter, bundleVersion));
+      const merged = withAdapterAdded(await readDirMarker(dir), adapter, bundleVersion);
+      await writeDirMarker(dir, { ...merged, extra: { originalHash } });
     } else {
-      await writeDirMarker(dir, { bundleVersion, adapters: [adapter] });
+      await writeDirMarker(dir, { bundleVersion, adapters: [adapter], extra: { originalHash } });
     }
   }
 }

--- a/bin/lib/installed.mjs
+++ b/bin/lib/installed.mjs
@@ -1,0 +1,45 @@
+// Read installed-skill state from per-item provenance markers (shared by `list`
+// and `update`). No central registry — the markers under each scope root are the
+// source of truth.
+
+import { existsSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { readDirMarker } from "./marker.mjs";
+
+// Roots scanned under a scope root. `.agents/skills` is the shared base
+// (ref-counted across adapters); `.claude/skills` carries claude-code-only
+// skills (e.g. usage-guard, which has no base).
+export const SCAN_ROOTS = [".agents/skills", ".claude/skills"];
+
+async function subdirs(dir) {
+  if (!existsSync(dir)) return [];
+  return (await readdir(dir, { withFileTypes: true }))
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name);
+}
+
+/**
+ * @param {string} scopeRoot
+ * @returns {Promise<Map<string, { version: string, adapters: Set<string>, dirs: string[] }>>}
+ */
+export async function readInstalled(scopeRoot) {
+  const installed = new Map();
+  for (const root of SCAN_ROOTS) {
+    for (const name of await subdirs(join(scopeRoot, root))) {
+      const dir = join(scopeRoot, root, name);
+      const marker = await readDirMarker(dir);
+      if (!marker) continue; // unmarked dir → not ours
+      const entry = installed.get(name) ?? {
+        version: marker.bundleVersion,
+        adapters: new Set(),
+        dirs: [],
+      };
+      for (const a of marker.adapters ?? []) entry.adapters.add(a);
+      entry.version = marker.bundleVersion ?? entry.version;
+      entry.dirs.push(dir);
+      installed.set(name, entry);
+    }
+  }
+  return installed;
+}

--- a/bin/lib/list.mjs
+++ b/bin/lib/list.mjs
@@ -11,8 +11,8 @@ import { readdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { parseFlags } from "./args.mjs";
+import { readInstalled } from "./installed.mjs";
 import { findPackageRoot } from "./install.mjs";
-import { readDirMarker } from "./marker.mjs";
 
 const HELP = `npx @ozzylabs/skills list [options]
 
@@ -27,39 +27,14 @@ Options:
 const SCHEMA = { target: "string", json: "boolean", help: "boolean" };
 const ALIASES = { h: "help" };
 
-// Roots scanned for installed skills, relative to the scope root. The base is
-// shared across adapters; `.claude/skills` carries claude-code-only skills.
-const SCAN_ROOTS = [".agents/skills", ".claude/skills"];
-
-async function subdirs(dir) {
-  if (!existsSync(dir)) return [];
-  const entries = await readdir(dir, { withFileTypes: true });
-  return entries.filter((e) => e.isDirectory()).map((e) => e.name);
-}
-
-/**
- * Read the installed state under a scope root from provenance markers.
- * @returns {Promise<Map<string, { version: string, adapters: Set<string> }>>}
- */
-async function readInstalled(scopeRoot) {
-  const installed = new Map();
-  for (const root of SCAN_ROOTS) {
-    for (const name of await subdirs(join(scopeRoot, root))) {
-      const marker = await readDirMarker(join(scopeRoot, root, name));
-      if (!marker) continue; // unmarked dir → not ours, skip
-      const entry = installed.get(name) ?? { version: marker.bundleVersion, adapters: new Set() };
-      for (const a of marker.adapters ?? []) entry.adapters.add(a);
-      entry.version = marker.bundleVersion ?? entry.version;
-      installed.set(name, entry);
-    }
-  }
-  return installed;
-}
-
 /** The full skill catalog the package ships (claude-code dist has every public skill). */
 async function readCatalog(packageRoot) {
-  const names = await subdirs(join(packageRoot, "dist", "claude-code", ".claude", "skills"));
-  return names.sort();
+  const dir = join(packageRoot, "dist", "claude-code", ".claude", "skills");
+  if (!existsSync(dir)) return [];
+  return (await readdir(dir, { withFileTypes: true }))
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
 }
 
 /**

--- a/bin/lib/marker.mjs
+++ b/bin/lib/marker.mjs
@@ -13,9 +13,10 @@
 // `scripts/build.mjs` excludes `*ozzylabs-skills.json` from the shipped payload
 // (`isMarkerFile` is the shared predicate) so a marker can never leak into dist.
 
-import { readFile, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
 
 export const MARKER_NAME = ".ozzylabs-skills.json";
 export const MARKER_SCHEMA = 1;
@@ -97,6 +98,38 @@ export async function writeMarker(markerPath, fields) {
 /** Write the marker into a skill directory. */
 export function writeDirMarker(dir, fields) {
   return writeMarker(markerPathForDir(dir), fields);
+}
+
+/**
+ * Content hash of a materialized skill directory — every file under `dir`
+ * EXCEPT provenance markers, combined deterministically. Used as the
+ * `originalHash` baseline so `update` can detect a user's local edits (a hash
+ * mismatch means the skill was modified and must not be clobbered).
+ *
+ * @param {string} dir
+ * @returns {Promise<string>} `sha256:<hex>`
+ */
+export async function computeDirHash(dir) {
+  const files = [];
+  async function walk(d) {
+    for (const entry of (await readdir(d, { withFileTypes: true })).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    )) {
+      const full = join(d, entry.name);
+      if (entry.isDirectory()) await walk(full);
+      else if (entry.isFile() && !isMarkerFile(entry.name)) files.push(full);
+    }
+  }
+  await walk(dir);
+  files.sort();
+  const hash = createHash("sha256");
+  for (const file of files) {
+    hash.update(relative(dir, file).split("\\").join("/"));
+    hash.update("\0");
+    hash.update(await readFile(file));
+    hash.update("\0");
+  }
+  return `sha256:${hash.digest("hex")}`;
 }
 
 /**

--- a/bin/lib/update.mjs
+++ b/bin/lib/update.mjs
@@ -1,0 +1,119 @@
+// `skills update` — update installed skills, preserving local edits
+// (ozzy-labs/skills#151 PR6). Editable-skill protection: each installed skill
+// dir was baselined with an `originalHash` at install time. On update we re-hash
+// the on-disk content; an UNEDITED skill is re-materialized from the current
+// bundle, while an EDITED skill is NOT clobbered — it is reported and the user
+// resolves it with `--take-theirs` (adopt upstream) or `--keep-mine` (skip).
+// (3-way `--merge` lands in PR7.) Edit detection is user-scope only; project
+// scope relies on git diff.
+
+import { homedir } from "node:os";
+import { parseFlags } from "./args.mjs";
+import { readInstalled } from "./installed.mjs";
+import { executeInstall, findPackageRoot, planInstall } from "./install.mjs";
+import { getBundleVersion, writeMarkers } from "./install-markers.mjs";
+import { computeDirHash, readDirMarker } from "./marker.mjs";
+
+const HELP = `npx @ozzylabs/skills update [<skill>...] [options]
+
+Update installed skills to the current bundle, preserving your local edits.
+With no skill names, updates everything installed.
+
+Options:
+  --take-theirs    For edited skills, adopt the upstream version (discard edits).
+  --keep-mine      For edited skills, keep your version (skip the update).
+  --dry-run        Print the plan as JSON and exit.
+  -h, --help       Show this help.
+
+Edited skills are never overwritten unless --take-theirs is given.
+`;
+
+const SCHEMA = {
+  "take-theirs": "boolean",
+  "keep-mine": "boolean",
+  "dry-run": "boolean",
+  help: "boolean",
+};
+const ALIASES = { h: "help" };
+
+/** True when any of a skill's installed directories differs from its baseline. */
+async function isEdited(dirs) {
+  for (const dir of dirs) {
+    const marker = await readDirMarker(dir);
+    if (!marker?.originalHash) continue; // no baseline → can't tell, treat as clean
+    if ((await computeDirHash(dir)) !== marker.originalHash) return true;
+  }
+  return false;
+}
+
+/**
+ * @param {string[]} argv args past the `update` subcommand keyword
+ * @returns {Promise<number>} exit code
+ */
+export async function runUpdate(argv) {
+  let parsed;
+  try {
+    parsed = parseFlags(argv, SCHEMA, ALIASES);
+  } catch (err) {
+    process.stderr.write(`error: ${err.message}\n\n${HELP}`);
+    return 1;
+  }
+  if (parsed.values.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  const unknownFlags = parsed.rejected.filter((a) => a.startsWith("-"));
+  if (unknownFlags.length > 0) {
+    process.stderr.write(`error: unknown argument(s): ${unknownFlags.join(", ")}\n\n${HELP}`);
+    return 1;
+  }
+  const requested = parsed.rejected.filter((a) => !a.startsWith("-"));
+  const takeTheirs = Boolean(parsed.values["take-theirs"]);
+  const keepMine = Boolean(parsed.values["keep-mine"]);
+  const dryRun = Boolean(parsed.values["dry-run"]);
+
+  const packageRoot = await findPackageRoot();
+  const home = process.env.OZZYLABS_SKILLS_HOME ?? homedir();
+  const installed = await readInstalled(home);
+
+  const targets = requested.length > 0 ? requested : [...installed.keys()];
+  const updated = [];
+  const modified = [];
+  const skipped = [];
+
+  for (const skill of targets) {
+    const entry = installed.get(skill);
+    if (!entry) {
+      process.stderr.write(`warning: '${skill}' is not installed — skipping.\n`);
+      continue;
+    }
+    const edited = await isEdited(entry.dirs);
+    if (edited && !takeTheirs) {
+      if (keepMine) skipped.push(skill);
+      else modified.push(skill);
+      continue;
+    }
+    if (!dryRun) {
+      const bundleVersion = await getBundleVersion(packageRoot);
+      for (const adapter of entry.adapters) {
+        const plan = await planInstall({ packageRoot, home, adapter, skillsFilter: [skill] });
+        await executeInstall(plan, { upgrade: true, force: true });
+        await writeMarkers({ home, adapter, skills: [skill], bundleVersion });
+      }
+    }
+    updated.push(skill);
+  }
+
+  if (modified.length > 0) {
+    process.stderr.write(
+      `\nmodified locally (not updated): ${modified.join(", ")}\n` +
+        `  resolve with: skills update ${modified.join(" ")} --take-theirs | --keep-mine\n`,
+    );
+  }
+  process.stdout.write(
+    `${JSON.stringify({ updated, modified, skipped, dryRun }, null, 2)}\n`,
+  );
+  return modified.length > 0 && !dryRun ? 1 : 0;
+}
+
+export { HELP };

--- a/bin/skills.mjs
+++ b/bin/skills.mjs
@@ -17,6 +17,7 @@ import { runAdd } from "./lib/add.mjs";
 import { didYouMean } from "./lib/detect.mjs";
 import { runList } from "./lib/list.mjs";
 import { runRemove } from "./lib/remove.mjs";
+import { runUpdate } from "./lib/update.mjs";
 
 const VERBS = ["add", "update", "list", "remove", "fork", "diff"];
 const VERB_ALIASES = { install: "add", uninstall: "remove" };
@@ -26,7 +27,7 @@ const TOP_LEVEL_HELP = `npx @ozzylabs/skills <verb> [options]
 Verbs:
   add        Add skills to a scope. User scope by default; --target <repo> for
              project scope. Alias: install.
-  update     Update installed skills, preserving local edits. (coming — #151)
+  update     Update installed skills, preserving local edits.
   list       Show the catalog and what is installed.
   remove     Uninstall skills (confirmation required). Alias: uninstall.
   fork       Copy a skill to a user-owned name. (coming — #151)
@@ -63,6 +64,9 @@ async function main(argv) {
 
   if (verb === "add") {
     return await runAdd(rest);
+  }
+  if (verb === "update") {
+    return await runUpdate(rest);
   }
   if (verb === "list") {
     return await runList(rest);

--- a/tests/cli-e2e.test.mjs
+++ b/tests/cli-e2e.test.mjs
@@ -119,7 +119,7 @@ test("e2e: unknown verb suggests a correction", () => {
 });
 
 test("e2e: not-yet-implemented verbs exit non-zero with the #151 pointer", () => {
-  const result = runCli(["update"]);
+  const result = runCli(["fork", "drive", "my-drive"]);
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /#151/);
 });
@@ -278,6 +278,61 @@ test("e2e: remove never touches an unmarked (foreign) skill dir", async () => {
     assert.equal(r.status, 0);
     assert.match(r.stdout, /Nothing to remove/);
     assert.ok(existsSync(join(foreign, "SKILL.md")), "foreign dir untouched");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: update refreshes an unedited installed skill", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    runCli(["add", "--adapter=codex-cli", "--skills=drive", "--force"], { home });
+    const r = runCli(["update", "drive"], { home });
+    assert.equal(r.status, 0, `update failed: ${r.stderr}`);
+    const out = JSON.parse(r.stdout);
+    assert.deepEqual(out.updated, ["drive"]);
+    assert.deepEqual(out.modified, []);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: update does NOT clobber a locally edited skill (reports modified)", async () => {
+  const { writeFileSync } = await import("node:fs");
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    runCli(["add", "--adapter=codex-cli", "--skills=drive", "--force"], { home });
+    const skillMd = join(home, ".agents", "skills", "drive", "SKILL.md");
+    writeFileSync(skillMd, "my local edit\n");
+
+    const r = runCli(["update", "drive"], { home });
+    assert.notEqual(r.status, 0, "modified skill makes update exit non-zero");
+    assert.match(r.stderr, /modified locally|--take-theirs|--keep-mine/);
+    assert.equal(readFileSync(skillMd, "utf8"), "my local edit\n", "edit preserved");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: update --take-theirs overwrites a local edit; --keep-mine preserves it", async () => {
+  const { writeFileSync } = await import("node:fs");
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    runCli(["add", "--adapter=codex-cli", "--skills=drive", "--force"], { home });
+    const skillMd = join(home, ".agents", "skills", "drive", "SKILL.md");
+
+    // keep-mine: edit preserved
+    writeFileSync(skillMd, "mine\n");
+    const keep = runCli(["update", "drive", "--keep-mine"], { home });
+    assert.equal(keep.status, 0, keep.stderr);
+    assert.deepEqual(JSON.parse(keep.stdout).skipped, ["drive"]);
+    assert.equal(readFileSync(skillMd, "utf8"), "mine\n");
+
+    // take-theirs: upstream restored
+    const take = runCli(["update", "drive", "--take-theirs"], { home });
+    assert.equal(take.status, 0, take.stderr);
+    assert.deepEqual(JSON.parse(take.stdout).updated, ["drive"]);
+    assert.notEqual(readFileSync(skillMd, "utf8"), "mine\n");
   } finally {
     await rm(home, { recursive: true, force: true });
   }


### PR DESCRIPTION
**[#151](https://github.com/ozzy-labs/skills/issues/151) の PR6**。`skills update` を実装し editable-skill を保護。

- マーカーに **`originalHash`**（as-installed のコンテンツ hash・マーカー除外）を add 時に記録＝編集検出の baseline。
- update は各 skill の dir を再 hash: **未編集→再 materialize＋再マーク / 編集済み→clobber せず "modified locally" 報告（非ゼロ終了）**し `--take-theirs`（上流採用）/ `--keep-mine`（維持）で解決。3-way `--merge` は PR7。
- 共有 `readInstalled`（`bin/lib/installed.mjs`）を切り出し、`list` も再利用。
- e2e: 未編集更新 / 編集済みの no-clobber＋報告 / --take-theirs 上書き / --keep-mine 維持。

全 295 テスト green / lint clean。次は PR7（merge 3-way / fork / diff / prune）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)