### PR TITLE
feat(cli): fork, diff, update --prune (#151 PR7)

### DIFF
--- a/bin/lib/diff.mjs
+++ b/bin/lib/diff.mjs
@@ -1,0 +1,89 @@
+// `skills diff <skill>` — show a skill's local edits vs the current upstream
+// (ozzy-labs/skills#151 PR7). The pristine version is re-materialized into a
+// temp HOME (identical bytes to a clean install, since refs are rewritten to the
+// literal `~/` form either way), then each non-marker file is compared. Output
+// is a unified diff per changed file.
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import { readInstalled } from "./installed.mjs";
+import { executeInstall, findPackageRoot, planInstall } from "./install.mjs";
+import { isMarkerFile } from "./marker.mjs";
+
+const HELP = `npx @ozzylabs/skills diff <skill>
+
+Show how an installed skill differs from the current upstream version
+(i.e. your local edits). No changes are made.
+`;
+
+async function walkRel(root) {
+  const out = [];
+  async function go(dir) {
+    if (!existsSync(dir)) return;
+    for (const e of await readdir(dir, { withFileTypes: true })) {
+      const full = join(dir, e.name);
+      if (e.isDirectory()) await go(full);
+      else if (e.isFile() && !isMarkerFile(e.name)) out.push(relative(root, full));
+    }
+  }
+  await go(root);
+  return out.sort();
+}
+
+export async function runDiff(argv) {
+  if (argv.includes("-h") || argv.includes("--help")) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  const [skill, ...extra] = argv.filter((a) => !a.startsWith("-"));
+  if (!skill || extra.length > 0) {
+    process.stderr.write(`error: usage: skills diff <skill>\n\n${HELP}`);
+    return 1;
+  }
+
+  const packageRoot = await findPackageRoot();
+  const home = process.env.OZZYLABS_SKILLS_HOME ?? homedir();
+  const installed = await readInstalled(home);
+  const entry = installed.get(skill);
+  if (!entry) {
+    process.stderr.write(`error: '${skill}' is not installed.\n`);
+    return 1;
+  }
+
+  const tmp = await mkdtemp(join(tmpdir(), "skills-diff-"));
+  let changed = 0;
+  try {
+    for (const adapter of entry.adapters) {
+      const plan = await planInstall({ packageRoot, home: tmp, adapter, skillsFilter: [skill] });
+      await executeInstall(plan, { upgrade: true, force: true });
+    }
+    for (const installedDir of entry.dirs) {
+      const rel = relative(home, installedDir);
+      const pristineDir = join(tmp, rel);
+      const files = new Set([...(await walkRel(pristineDir)), ...(await walkRel(installedDir))]);
+      for (const f of [...files].sort()) {
+        const a = join(pristineDir, f);
+        const b = join(installedDir, f);
+        const res = spawnSync(
+          "git",
+          ["diff", "--no-index", existsSync(a) ? a : "/dev/null", existsSync(b) ? b : "/dev/null"],
+          { encoding: "utf8" },
+        );
+        if (res.stdout) {
+          process.stdout.write(`${res.stdout}\n`);
+          changed += 1;
+        }
+      }
+    }
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+
+  if (changed === 0) process.stdout.write(`'${skill}' matches upstream (no local edits).\n`);
+  return 0;
+}
+
+export { HELP };

--- a/bin/lib/fork.mjs
+++ b/bin/lib/fork.mjs
@@ -1,0 +1,73 @@
+// `skills fork <skill> <new-name>` — copy an installed skill to a user-owned
+// name the CLI does not manage (ozzy-labs/skills#151 PR7). The original stays
+// pristine and upgradeable; the fork carries NO provenance marker, so update /
+// remove never touch it, and the user can edit it freely. The copied SKILL.md's
+// `name:` is rewritten to the new name so it loads under that name.
+
+import { cp, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { readInstalled } from "./installed.mjs";
+import { findPackageRoot } from "./install.mjs";
+import { MARKER_NAME } from "./marker.mjs";
+
+const HELP = `npx @ozzylabs/skills fork <skill> <new-name>
+
+Copy an installed skill to a user-owned, unmanaged name. The original stays
+managed (upgradeable); the fork is yours to edit and is never touched by
+update/remove.
+`;
+
+const NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+export async function runFork(argv) {
+  if (argv.includes("-h") || argv.includes("--help")) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  const [skill, newName, ...extra] = argv.filter((a) => !a.startsWith("-"));
+  if (!skill || !newName || extra.length > 0) {
+    process.stderr.write(`error: usage: skills fork <skill> <new-name>\n\n${HELP}`);
+    return 1;
+  }
+  if (!NAME_RE.test(newName)) {
+    process.stderr.write(`error: invalid skill name '${newName}' (use lowercase letters, digits, hyphens)\n`);
+    return 1;
+  }
+
+  await findPackageRoot();
+  const home = process.env.OZZYLABS_SKILLS_HOME ?? homedir();
+  const installed = await readInstalled(home);
+  const entry = installed.get(skill);
+  if (!entry) {
+    process.stderr.write(`error: '${skill}' is not installed — nothing to fork.\n`);
+    return 1;
+  }
+
+  const created = [];
+  for (const srcDir of entry.dirs) {
+    const destDir = join(dirname(srcDir), newName);
+    if (existsSync(destDir)) {
+      process.stderr.write(`error: '${destDir}' already exists — pick another name.\n`);
+      return 1;
+    }
+    await cp(srcDir, destDir, { recursive: true });
+    // A fork is user-owned: strip the provenance marker so the CLI won't manage it.
+    await rm(join(destDir, MARKER_NAME), { force: true });
+    // Rewrite the skill name so it loads under the new name.
+    const skillMd = join(destDir, "SKILL.md");
+    if (existsSync(skillMd)) {
+      const text = await readFile(skillMd, "utf8");
+      await writeFile(skillMd, text.replace(/^name:\s*.*$/m, `name: ${newName}`));
+    }
+    created.push(destDir);
+  }
+
+  process.stdout.write(
+    `${JSON.stringify({ forked: skill, into: newName, dirs: created.map((d) => basename(dirname(d)) + "/" + newName) }, null, 2)}\n`,
+  );
+  return 0;
+}
+
+export { HELP };

--- a/bin/lib/update.mjs
+++ b/bin/lib/update.mjs
@@ -7,12 +7,24 @@
 // (3-way `--merge` lands in PR7.) Edit detection is user-scope only; project
 // scope relies on git diff.
 
+import { existsSync } from "node:fs";
+import { readdir, rm } from "node:fs/promises";
 import { homedir } from "node:os";
+import { join } from "node:path";
 import { parseFlags } from "./args.mjs";
 import { readInstalled } from "./installed.mjs";
 import { executeInstall, findPackageRoot, planInstall } from "./install.mjs";
 import { getBundleVersion, writeMarkers } from "./install-markers.mjs";
 import { computeDirHash, readDirMarker } from "./marker.mjs";
+
+/** Skill names the current bundle ships (claude-code dist has every public skill). */
+async function readCatalog(packageRoot) {
+  const dir = join(packageRoot, "dist", "claude-code", ".claude", "skills");
+  if (!existsSync(dir)) return [];
+  return (await readdir(dir, { withFileTypes: true }))
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name);
+}
 
 const HELP = `npx @ozzylabs/skills update [<skill>...] [options]
 
@@ -22,6 +34,7 @@ With no skill names, updates everything installed.
 Options:
   --take-theirs    For edited skills, adopt the upstream version (discard edits).
   --keep-mine      For edited skills, keep your version (skip the update).
+  --prune          Also remove installed skills no longer in the bundle.
   --dry-run        Print the plan as JSON and exit.
   -h, --help       Show this help.
 
@@ -31,6 +44,7 @@ Edited skills are never overwritten unless --take-theirs is given.
 const SCHEMA = {
   "take-theirs": "boolean",
   "keep-mine": "boolean",
+  prune: "boolean",
   "dry-run": "boolean",
   help: "boolean",
 };
@@ -75,6 +89,7 @@ export async function runUpdate(argv) {
   const packageRoot = await findPackageRoot();
   const home = process.env.OZZYLABS_SKILLS_HOME ?? homedir();
   const installed = await readInstalled(home);
+  const catalog = new Set(await readCatalog(packageRoot));
 
   const targets = requested.length > 0 ? requested : [...installed.keys()];
   const updated = [];
@@ -87,6 +102,9 @@ export async function runUpdate(argv) {
       process.stderr.write(`warning: '${skill}' is not installed — skipping.\n`);
       continue;
     }
+    // Orphans (installed but no longer in the bundle) can't be re-materialized;
+    // they are left for --prune.
+    if (!catalog.has(skill)) continue;
     const edited = await isEdited(entry.dirs);
     if (edited && !takeTheirs) {
       if (keepMine) skipped.push(skill);
@@ -104,6 +122,18 @@ export async function runUpdate(argv) {
     updated.push(skill);
   }
 
+  // --prune: remove our installed skills no longer present in the bundle.
+  const pruned = [];
+  if (parsed.values.prune) {
+    for (const [name, entry] of installed) {
+      if (catalog.has(name)) continue;
+      pruned.push(name);
+      if (!dryRun) {
+        for (const dir of entry.dirs) await rm(dir, { recursive: true, force: true });
+      }
+    }
+  }
+
   if (modified.length > 0) {
     process.stderr.write(
       `\nmodified locally (not updated): ${modified.join(", ")}\n` +
@@ -111,7 +141,7 @@ export async function runUpdate(argv) {
     );
   }
   process.stdout.write(
-    `${JSON.stringify({ updated, modified, skipped, dryRun }, null, 2)}\n`,
+    `${JSON.stringify({ updated, modified, skipped, pruned, dryRun }, null, 2)}\n`,
   );
   return modified.length > 0 && !dryRun ? 1 : 0;
 }

--- a/bin/skills.mjs
+++ b/bin/skills.mjs
@@ -15,6 +15,8 @@
 
 import { runAdd } from "./lib/add.mjs";
 import { didYouMean } from "./lib/detect.mjs";
+import { runDiff } from "./lib/diff.mjs";
+import { runFork } from "./lib/fork.mjs";
 import { runList } from "./lib/list.mjs";
 import { runRemove } from "./lib/remove.mjs";
 import { runUpdate } from "./lib/update.mjs";
@@ -30,26 +32,11 @@ Verbs:
   update     Update installed skills, preserving local edits.
   list       Show the catalog and what is installed.
   remove     Uninstall skills (confirmation required). Alias: uninstall.
-  fork       Copy a skill to a user-owned name. (coming — #151)
-  diff       Show a skill's diff against upstream. (coming — #151)
+  fork       Copy a skill to a user-owned name.
+  diff       Show a skill's diff against upstream.
 
 Run 'npx @ozzylabs/skills <verb> --help' for verb-specific options.
 `;
-
-/**
- * Placeholder for verbs whose implementation lands in a later #151 PR. Exits
- * non-zero so callers/scripts don't silently treat a no-op as success.
- *
- * @param {string} verb
- * @returns {number}
- */
-function notYetImplemented(verb) {
-  process.stderr.write(
-    `'${verb}' is not implemented yet — tracked in ozzy-labs/skills#151. ` +
-      `For now use 'add' (alias: install).\n`,
-  );
-  return 1;
-}
 
 async function main(argv) {
   const raw = argv[0];
@@ -74,8 +61,11 @@ async function main(argv) {
   if (verb === "remove") {
     return await runRemove(rest);
   }
-  if (VERBS.includes(verb)) {
-    return notYetImplemented(verb);
+  if (verb === "fork") {
+    return await runFork(rest);
+  }
+  if (verb === "diff") {
+    return await runDiff(rest);
   }
 
   process.stderr.write(

--- a/tests/cli-e2e.test.mjs
+++ b/tests/cli-e2e.test.mjs
@@ -118,12 +118,6 @@ test("e2e: unknown verb suggests a correction", () => {
   assert.match(result.stderr, /did you mean 'install'\?/);
 });
 
-test("e2e: not-yet-implemented verbs exit non-zero with the #151 pointer", () => {
-  const result = runCli(["fork", "drive", "my-drive"]);
-  assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /#151/);
-});
-
 test("e2e: list --json shows installed skills + the available catalog", async () => {
   const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
   try {
@@ -333,6 +327,74 @@ test("e2e: update --take-theirs overwrites a local edit; --keep-mine preserves i
     assert.equal(take.status, 0, take.stderr);
     assert.deepEqual(JSON.parse(take.stdout).updated, ["drive"]);
     assert.notEqual(readFileSync(skillMd, "utf8"), "mine\n");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: fork copies an installed skill to a user-owned name (no marker)", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    runCli(["add", "--adapter=codex-cli", "--skills=drive", "--force"], { home });
+    const r = runCli(["fork", "drive", "my-drive"], { home });
+    assert.equal(r.status, 0, `fork failed: ${r.stderr}`);
+    const forkDir = join(home, ".agents", "skills", "my-drive");
+    assert.ok(existsSync(join(forkDir, "SKILL.md")), "fork SKILL.md exists");
+    assert.ok(!existsSync(join(forkDir, ".ozzylabs-skills.json")), "fork is unmanaged (no marker)");
+    assert.match(
+      readFileSync(join(forkDir, "SKILL.md"), "utf8"),
+      /^name: my-drive$/m,
+      "name rewritten",
+    );
+    // The original stays managed.
+    assert.ok(existsSync(join(home, ".agents", "skills", "drive", ".ozzylabs-skills.json")));
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: diff shows local edits, and reports clean when unedited", async () => {
+  const { writeFileSync } = await import("node:fs");
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    runCli(["add", "--adapter=codex-cli", "--skills=drive", "--force"], { home });
+    const clean = runCli(["diff", "drive"], { home });
+    assert.equal(clean.status, 0, clean.stderr);
+    assert.match(clean.stdout, /matches upstream/);
+
+    writeFileSync(join(home, ".agents", "skills", "drive", "SKILL.md"), "edited\n");
+    const dirty = runCli(["diff", "drive"], { home });
+    assert.equal(dirty.status, 0, dirty.stderr);
+    assert.match(dirty.stdout, /edited/);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: update --prune removes installed skills no longer in the bundle", async () => {
+  const { mkdirSync, writeFileSync } = await import("node:fs");
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    runCli(["add", "--adapter=codex-cli", "--skills=drive", "--force"], { home });
+    // Simulate a managed-but-removed-from-bundle skill.
+    const orphanDir = join(home, ".agents", "skills", "legacy-skill");
+    mkdirSync(orphanDir, { recursive: true });
+    writeFileSync(join(orphanDir, "SKILL.md"), "---\nname: legacy-skill\ndescription: x\n---\n");
+    writeFileSync(
+      join(orphanDir, ".ozzylabs-skills.json"),
+      JSON.stringify({
+        schema: 1,
+        source: "@ozzylabs/skills",
+        bundleVersion: "1.0.0",
+        adapters: ["codex-cli"],
+      }),
+    );
+
+    const r = runCli(["update", "--prune"], { home });
+    const out = JSON.parse(r.stdout);
+    assert.ok(out.pruned.includes("legacy-skill"), "orphan pruned");
+    assert.ok(!existsSync(orphanDir), "orphan dir removed");
+    assert.ok(existsSync(join(home, ".agents", "skills", "drive")), "catalog skill kept");
   } finally {
     await rm(home, { recursive: true, force: true });
   }


### PR DESCRIPTION
**[#151](https://github.com/ozzy-labs/skills/issues/151) の PR7**。高度化機能。

- **`fork <skill> <new-name>`**: installed skill をユーザー所有の管理外名へ複製（マーカーなし・`name:` 書換）。原本は managed のまま、fork は自由編集・update/remove 不可侵。
- **`diff <skill>`**: 現上流を temp に再 materialize しファイル別 unified diff（＝ローカル編集）を表示、無編集なら clean 報告。
- **`update --prune`**: bundle catalog から消えた installed skill（自分の物）を削除。update は再 install 時に orphan をスキップ。
- 全 verb 実装完了 → 未実装 stub を撤去。
- e2e: fork / diff（clean&dirty）/ prune。

### ⚠️ deferred: `update --merge`（3-way）
hash-only マーカーは `originalHash` を持つが**原本コンテンツを保持しない**ため、merge base を再構成できない。原本コンテンツ保持 or 旧 bundle version pin が必要な follow-up（#151 で追跡）。

全 297 テスト green / lint clean。残りは PR8（docs）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)