### PR TITLE
feat(cli): 3-way `update --merge` (#151 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Supported adapters: `claude-code`, `codex-cli`, `gemini-cli`, `copilot`. On an *
 | --- | --- |
 | `add` (alias `install`) | Add skills to a scope. Refuses to overwrite an unmarked (foreign) skill dir without `--force`. |
 | `list` | Show the catalog with installed status. `--json`, `--target`. |
-| `update [<skill>…]` | Re-materialize installed skills, **preserving local edits**: an edited skill is not clobbered — resolve with `--take-theirs` / `--keep-mine`. `--prune` removes skills no longer in the bundle. |
+| `update [<skill>…]` | Re-materialize installed skills, **preserving local edits**: an edited skill is not clobbered — resolve with `--take-theirs` / `--keep-mine` / `--merge` (3-way). `--prune` removes skills no longer in the bundle. |
 | `remove` (alias `uninstall`) | Uninstall skills. Confirmation required (TTY prompt or `--yes`). `--skills` required. |
 | `fork <skill> <new-name>` | Copy an installed skill to a user-owned, unmanaged name (free to edit; never touched by update/remove). |
 | `diff <skill>` | Show a skill's local edits vs the current upstream. |
@@ -69,7 +69,7 @@ Supported adapters: `claude-code`, `codex-cli`, `gemini-cli`, `copilot`. On an *
 
 Installed skills are **editable** — edit them in place under their own name. The CLI tracks what it installed with **per-item provenance markers** (`.ozzylabs-skills.json` co-located in each skill dir; no central registry). The shared `.agents/skills/<name>` base is **reference-counted** across adapters (removing one adapter keeps the base while another needs it). `update` baselines each skill's content hash so it can detect — and refuse to clobber — your local edits.
 
-Project scope (`--target`) writes the committed payload (`.claude/skills/` wrappers + canonical `.agents/skills/` + `.claude/agents/`) with repo-root-relative refs preserved. The legacy `sync-project` and `migrate` subcommands have been removed — use `add --target <repo>`. (3-way `update --merge` is tracked as a follow-up in [#151](https://github.com/ozzy-labs/skills/issues/151).)
+Project scope (`--target`) writes the committed payload (`.claude/skills/` wrappers + canonical `.agents/skills/` + `.claude/agents/`) with repo-root-relative refs preserved. The legacy `sync-project` and `migrate` subcommands have been removed — use `add --target <repo>`. For edited skills, `update --merge` does a 3-way merge (base = the install-time snapshot, mine = your edits, theirs = current upstream); conflicts are left with standard `<<<<<<<` markers.
 
 ## Consumer setup
 

--- a/bin/lib/install-markers.mjs
+++ b/bin/lib/install-markers.mjs
@@ -11,6 +11,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { ADAPTER_LAYOUT } from "./install.mjs";
 import { computeDirHash, readDirMarker, withAdapterAdded, writeDirMarker } from "./marker.mjs";
+import { savePristine } from "./pristine.mjs";
 
 // The cross-tool base root is shared by every adapter; its marker carries the
 // adapter reference count. Other roots (e.g. `.claude/skills`) are adapter-owned.
@@ -71,6 +72,8 @@ export async function writeMarkers({ home, adapter, skills, bundleVersion }) {
     } else {
       await writeDirMarker(dir, { bundleVersion, adapters: [adapter], extra: { originalHash } });
     }
+    // Snapshot the clean content as the merge base for `update --merge`.
+    await savePristine(home, dir);
   }
 }
 

--- a/bin/lib/merge.mjs
+++ b/bin/lib/merge.mjs
@@ -1,0 +1,93 @@
+// 3-way merge for `update --merge` (#151 follow-up). For an edited skill:
+//   base   = the pristine snapshot taken at install/last-merge (merge base)
+//   mine   = the current on-disk content (the user's edits)
+//   theirs = the current upstream, re-materialized into a temp HOME
+// Each file is merged with `git merge-file`; conflicts are left with standard
+// markers. Afterwards the baseline is advanced to `theirs` (marker hash +
+// pristine), so the skill stays correctly flagged as edited vs the new upstream.
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { cp, mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, relative } from "node:path";
+import { executeInstall, planInstall } from "./install.mjs";
+import { computeDirHash, isMarkerFile, readDirMarker, writeDirMarker } from "./marker.mjs";
+import { hasPristine, pristinePath, savePristineFrom } from "./pristine.mjs";
+
+async function nonMarkerFiles(root) {
+  const out = [];
+  async function go(dir) {
+    if (!existsSync(dir)) return;
+    for (const e of await readdir(dir, { withFileTypes: true })) {
+      const full = join(dir, e.name);
+      if (e.isDirectory()) await go(full);
+      else if (e.isFile() && !isMarkerFile(e.name)) out.push(relative(root, full));
+    }
+  }
+  await go(root);
+  return out;
+}
+
+/**
+ * @returns {Promise<{ skill: string, status: "merged"|"merged-with-conflicts"|"no-base", conflicts: number }>}
+ */
+export async function mergeSkill({ home, packageRoot, skill, entry, bundleVersion }) {
+  // Need a base for every dir; without it, fall back (caller suggests --take-theirs/--keep-mine).
+  if (entry.dirs.some((dir) => !hasPristine(home, dir))) {
+    return { skill, status: "no-base", conflicts: 0 };
+  }
+
+  const theirsHome = await mkdtemp(join(tmpdir(), "skills-merge-"));
+  let conflicts = 0;
+  try {
+    for (const adapter of entry.adapters) {
+      const plan = await planInstall({ packageRoot, home: theirsHome, adapter, skillsFilter: [skill] });
+      await executeInstall(plan, { upgrade: true, force: true });
+    }
+
+    for (const dir of entry.dirs) {
+      const rel = relative(home, dir);
+      const theirsDir = join(theirsHome, rel);
+      const baseDir = pristinePath(home, dir);
+      const files = new Set([
+        ...(await nonMarkerFiles(baseDir)),
+        ...(await nonMarkerFiles(dir)),
+        ...(await nonMarkerFiles(theirsDir)),
+      ]);
+      for (const f of files) {
+        const mine = join(dir, f);
+        const base = join(baseDir, f);
+        const theirs = join(theirsDir, f);
+        if (existsSync(mine) && existsSync(base) && existsSync(theirs)) {
+          // -p prints the merge to stdout; exit status = conflict count.
+          const r = spawnSync("git", ["merge-file", "-p", mine, base, theirs], { encoding: "utf8" });
+          await writeFile(mine, r.stdout);
+          if (r.status > 0) conflicts += r.status;
+        } else if (existsSync(theirs) && !existsSync(mine) && !existsSync(base)) {
+          // New upstream file — add it.
+          await mkdir(dirname(mine), { recursive: true });
+          await cp(theirs, mine);
+        }
+        // Otherwise keep mine (user-added, or upstream-deleted) — conservative.
+      }
+    }
+
+    // Advance the baseline to the upstream we merged against.
+    for (const dir of entry.dirs) {
+      const theirsDir = join(theirsHome, relative(home, dir));
+      const existing = await readDirMarker(dir);
+      const originalHash = await computeDirHash(theirsDir);
+      await writeDirMarker(dir, {
+        adapters: existing?.adapters,
+        bundleVersion,
+        extra: { originalHash },
+      });
+      await savePristineFrom(home, dir, theirsDir);
+    }
+  } finally {
+    await rm(theirsHome, { recursive: true, force: true });
+  }
+
+  return { skill, status: conflicts > 0 ? "merged-with-conflicts" : "merged", conflicts };
+}

--- a/bin/lib/pristine.mjs
+++ b/bin/lib/pristine.mjs
@@ -1,0 +1,57 @@
+// Pristine content store — the merge base for `update --merge` (#151 follow-up).
+//
+// The per-item marker records an `originalHash` (cheap edit detection) but NOT
+// the original CONTENT, so a 3-way merge has no base to reconstruct. This store
+// snapshots the as-installed content of each skill directory at install/update
+// time, keyed by the installed dir's absolute path, under the scope's
+// `.cache/@ozzylabs-skills/pristine/`. It is a rebuildable cache (cleared → merge
+// gracefully degrades to --take-theirs/--keep-mine), never a provenance source.
+
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { cp, mkdir, rm } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { isMarkerFile } from "./marker.mjs";
+
+function keyFor(dir) {
+  return createHash("sha256").update(dir).digest("hex").slice(0, 16);
+}
+
+/** Cache path holding the pristine snapshot of an installed skill directory. */
+export function pristinePath(home, dir) {
+  return join(home, ".cache", "@ozzylabs-skills", "pristine", keyFor(dir));
+}
+
+export function hasPristine(home, dir) {
+  return existsSync(pristinePath(home, dir));
+}
+
+/**
+ * Snapshot the as-installed content of `dir` (markers excluded) into the cache,
+ * overwriting any previous snapshot. Called after a successful install/update so
+ * the base always reflects the last clean state.
+ */
+export async function savePristine(home, dir) {
+  return savePristineFrom(home, dir, dir);
+}
+
+/**
+ * Snapshot `sourceDir`'s content (markers excluded) as the pristine base for the
+ * installed directory `dir`. After `update --merge`, the new base is the upstream
+ * we merged against, so we snapshot the temp "theirs" tree rather than the
+ * (now-merged) on-disk one.
+ */
+export async function savePristineFrom(home, dir, sourceDir) {
+  const dest = pristinePath(home, dir);
+  await rm(dest, { recursive: true, force: true });
+  await mkdir(dirname(dest), { recursive: true });
+  await cp(sourceDir, dest, {
+    recursive: true,
+    filter: (src) => !isMarkerFile(basename(src)),
+  });
+}
+
+/** Remove a skill directory's pristine snapshot (used when the skill is removed). */
+export async function dropPristine(home, dir) {
+  await rm(pristinePath(home, dir), { recursive: true, force: true });
+}

--- a/bin/lib/update.mjs
+++ b/bin/lib/update.mjs
@@ -16,6 +16,7 @@ import { readInstalled } from "./installed.mjs";
 import { executeInstall, findPackageRoot, planInstall } from "./install.mjs";
 import { getBundleVersion, writeMarkers } from "./install-markers.mjs";
 import { computeDirHash, readDirMarker } from "./marker.mjs";
+import { mergeSkill } from "./merge.mjs";
 
 /** Skill names the current bundle ships (claude-code dist has every public skill). */
 async function readCatalog(packageRoot) {
@@ -34,6 +35,8 @@ With no skill names, updates everything installed.
 Options:
   --take-theirs    For edited skills, adopt the upstream version (discard edits).
   --keep-mine      For edited skills, keep your version (skip the update).
+  --merge          For edited skills, 3-way merge upstream changes into your
+                   edits (conflicts left with standard markers).
   --prune          Also remove installed skills no longer in the bundle.
   --dry-run        Print the plan as JSON and exit.
   -h, --help       Show this help.
@@ -44,6 +47,7 @@ Edited skills are never overwritten unless --take-theirs is given.
 const SCHEMA = {
   "take-theirs": "boolean",
   "keep-mine": "boolean",
+  merge: "boolean",
   prune: "boolean",
   "dry-run": "boolean",
   help: "boolean",
@@ -84,17 +88,20 @@ export async function runUpdate(argv) {
   const requested = parsed.rejected.filter((a) => !a.startsWith("-"));
   const takeTheirs = Boolean(parsed.values["take-theirs"]);
   const keepMine = Boolean(parsed.values["keep-mine"]);
+  const doMerge = Boolean(parsed.values.merge);
   const dryRun = Boolean(parsed.values["dry-run"]);
 
   const packageRoot = await findPackageRoot();
   const home = process.env.OZZYLABS_SKILLS_HOME ?? homedir();
   const installed = await readInstalled(home);
   const catalog = new Set(await readCatalog(packageRoot));
+  const bundleVersion = await getBundleVersion(packageRoot);
 
   const targets = requested.length > 0 ? requested : [...installed.keys()];
   const updated = [];
   const modified = [];
   const skipped = [];
+  const merged = [];
 
   for (const skill of targets) {
     const entry = installed.get(skill);
@@ -107,12 +114,20 @@ export async function runUpdate(argv) {
     if (!catalog.has(skill)) continue;
     const edited = await isEdited(entry.dirs);
     if (edited && !takeTheirs) {
+      // --merge: 3-way merge upstream changes into the user's edits.
+      if (doMerge) {
+        if (dryRun) {
+          merged.push({ skill, status: "would-merge" });
+        } else {
+          merged.push(await mergeSkill({ home, packageRoot, skill, entry, bundleVersion }));
+        }
+        continue;
+      }
       if (keepMine) skipped.push(skill);
       else modified.push(skill);
       continue;
     }
     if (!dryRun) {
-      const bundleVersion = await getBundleVersion(packageRoot);
       for (const adapter of entry.adapters) {
         const plan = await planInstall({ packageRoot, home, adapter, skillsFilter: [skill] });
         await executeInstall(plan, { upgrade: true, force: true });
@@ -137,13 +152,27 @@ export async function runUpdate(argv) {
   if (modified.length > 0) {
     process.stderr.write(
       `\nmodified locally (not updated): ${modified.join(", ")}\n` +
-        `  resolve with: skills update ${modified.join(" ")} --take-theirs | --keep-mine\n`,
+        `  resolve with: skills update ${modified.join(" ")} --take-theirs | --keep-mine | --merge\n`,
+    );
+  }
+  const conflicted = merged.filter((m) => m.status === "merged-with-conflicts");
+  const noBase = merged.filter((m) => m.status === "no-base");
+  if (conflicted.length > 0) {
+    process.stderr.write(
+      `\nmerged with conflicts (resolve the <<<<<<< markers): ${conflicted.map((m) => m.skill).join(", ")}\n`,
+    );
+  }
+  if (noBase.length > 0) {
+    process.stderr.write(
+      `\nno merge base available (cache cleared) for: ${noBase.map((m) => m.skill).join(", ")}\n` +
+        `  resolve with: --take-theirs | --keep-mine\n`,
     );
   }
   process.stdout.write(
-    `${JSON.stringify({ updated, modified, skipped, pruned, dryRun }, null, 2)}\n`,
+    `${JSON.stringify({ updated, modified, skipped, merged, pruned, dryRun }, null, 2)}\n`,
   );
-  return modified.length > 0 && !dryRun ? 1 : 0;
+  const needsAttention = modified.length + conflicted.length + noBase.length;
+  return needsAttention > 0 && !dryRun ? 1 : 0;
 }
 
 export { HELP };

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -56,7 +56,7 @@ npx @ozzylabs/skills add --target=./my-repo
 
 対応 adapter: `claude-code` / `codex-cli` / `gemini-cli` / `copilot`。**対話実行では `--adapter` は `$HOME` 配下の CLI 検出から既定**、非対話（CI）では必須。installed skill は **editable** で、CLI は per-item 来歴マーカー（`.ozzylabs-skills.json`）で管理対象を追跡（共有 `.agents/skills/<name>` base は参照カウント）。`update` は content hash で**ローカル編集を検出し clobber しない**（`--take-theirs` / `--keep-mine` で解決）。
 
-旧 `sync-project` / `migrate` subcommand は撤去済み（project scope は `add --target`、3-way `update --merge` は [#151](https://github.com/ozzy-labs/skills/issues/151) で追跡）。
+旧 `sync-project` / `migrate` subcommand は撤去済み（project scope は `add --target`）。編集済み skill には `update --merge` で 3-way マージ（base=install 時スナップショット / mine=編集 / theirs=現上流。conflict は `<<<<<<<` マーカーで残す）。
 
 ## Consumer セットアップ
 

--- a/tests/cli-e2e.test.mjs
+++ b/tests/cli-e2e.test.mjs
@@ -399,3 +399,41 @@ test("e2e: update --prune removes installed skills no longer in the bundle", asy
     await rm(home, { recursive: true, force: true });
   }
 });
+
+test("e2e: update --merge keeps local edits and re-baselines (upstream unchanged)", async () => {
+  const { appendFileSync } = await import("node:fs");
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    runCli(["add", "--adapter=codex-cli", "--skills=drive", "--force"], { home });
+    const skillMd = join(home, ".agents", "skills", "drive", "SKILL.md");
+    appendFileSync(skillMd, "\nMY CUSTOM LINE\n");
+
+    const r = runCli(["update", "drive", "--merge"], { home });
+    const out = JSON.parse(r.stdout);
+    const m = out.merged.find((x) => x.skill === "drive");
+    assert.equal(m.status, "merged", `expected clean merge, got ${m?.status}`);
+    assert.match(readFileSync(skillMd, "utf8"), /MY CUSTOM LINE/, "local edit preserved");
+    assert.doesNotMatch(readFileSync(skillMd, "utf8"), /<<<<<<</, "no conflict markers");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: update --merge degrades to a fallback when the merge base (cache) is gone", async () => {
+  const { writeFileSync } = await import("node:fs");
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    runCli(["add", "--adapter=codex-cli", "--skills=drive", "--force"], { home });
+    writeFileSync(join(home, ".agents", "skills", "drive", "SKILL.md"), "edited\n");
+    // Wipe the pristine cache → no merge base.
+    await rm(join(home, ".cache"), { recursive: true, force: true });
+
+    const r = runCli(["update", "drive", "--merge"], { home });
+    assert.notEqual(r.status, 0);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.merged.find((x) => x.skill === "drive")?.status, "no-base");
+    assert.match(r.stderr, /no merge base|--take-theirs/);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
**[#151](https://github.com/ozzy-labs/skills/issues/151) の follow-up**。deferred だった 3-way `update --merge` を実装。

## 解決した設計制約
hash-only マーカーは編集検出はできるが **merge base（原本コンテンツ）を持たない**ため 3-way 不能だった。→ **install/update 時に as-installed コンテンツを pristine キャッシュに保存**（`<scope>/.cache/@ozzylabs-skills/pristine/`、dir パス key、再構築可能）。

## 実装
- `merge.mjs`: 現上流を temp に再 materialize（theirs）→ `git merge-file -p mine base theirs` をファイル別に実行（base=pristine）。新規上流ファイルは追加、conflict は `<<<<<<<` マーカー。マージ後は baseline（marker hash + pristine）を theirs に前進。
- `update --merge`: 編集済み skill を skip/clobber でなく 3-way マージ。**base 喪失（cache クリア）時は `--take-theirs/--keep-mine` へ graceful fallback**、conflict / no-base は非ゼロ終了。
- e2e: 編集保持＋re-baseline / no-base degrade。README/AGENTS/ja 更新。

全 299 テスト green / lint・markdownlint clean。これで **#151 は 3-way merge 含め完全実装**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)