### PR TITLE
chore(cli): remove dead install glue; drop pristine cache on remove

### DIFF
--- a/bin/lib/args.mjs
+++ b/bin/lib/args.mjs
@@ -66,31 +66,3 @@ export function parseFlags(argv, schema, aliases = {}) {
 
   return { values, rejected };
 }
-
-/**
- * Detect `--target`, `--from`, `--to`, etc. — flags that the sub-issue B
- * acceptance criteria explicitly forbid. Throwing here keeps the error message
- * close to the user input so the help text stays the source of truth.
- *
- * @param {string[]} argv
- */
-export function assertNoForbiddenFlags(argv) {
-  const forbidden = new Set([
-    "--target",
-    "--target-dir",
-    "--target=",
-    "--from",
-    "--to",
-    "--project",
-  ]);
-  for (const arg of argv) {
-    // Allow `--target-something-else` to slip through; we only block exact
-    // matches and the `--target=...` form.
-    const head = arg.split("=")[0];
-    if (forbidden.has(arg) || forbidden.has(head) || forbidden.has(`${head}=`)) {
-      throw new Error(
-        `flag ${arg.split("=")[0]} is not supported by 'install' — it writes to the user-scoped skills directory only. For project-scope delivery into a repo (Claude mobile / web), use 'npx @ozzylabs/skills sync-project --target <repo>'.`,
-      );
-    }
-  }
-}

--- a/bin/lib/install.mjs
+++ b/bin/lib/install.mjs
@@ -1,58 +1,18 @@
-// `npx @ozzylabs/skills install` implementation.
-//
-// The installer copies canonical skill payloads from the package's `dist/`
-// directory into the user-scoped skills directory (always under HOME — never
-// project-scoped). Adapter layouts mirror what the build pipeline writes
-// under `dist/{adapter-id}/`:
+// User-scope install primitives (planInstall / executeInstall) used by
+// `skills add`. Copies canonical skill payloads from the package's
+// `dist/{adapter-id}/` into the user-scoped skills directory under HOME:
 //
 //   claude-code → ~/.claude/skills/{name}/SKILL.md  (+ canonical ~/.agents base)
 //   codex-cli   → ~/.agents/skills/{name}/SKILL.md  (+ extras + AGENTS.md.snippet)
 //   gemini-cli  → ~/.agents/skills/{name}/SKILL.md  (+ ~/.gemini/settings.json + snippet)
 //   copilot     → ~/.agents/skills/{name}/SKILL.md  (+ copilot-instructions snippet)
-//
-// `--dry-run` reports the plan as JSON on stdout without touching the disk.
 
 import { existsSync } from "node:fs";
 import { copyFile, mkdir, readdir } from "node:fs/promises";
-import { homedir } from "node:os";
 import { dirname, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
-import { assertNoForbiddenFlags, parseFlags } from "./args.mjs";
-
-const HELP = `npx @ozzylabs/skills install [options]
-
-Install canonical OzzyLabs skills into the user-scoped skills directory.
-
-Options:
-  --skills=<list>      Comma-separated skill names (default: install all).
-  --adapter=<list>     Comma-separated adapter ids: claude-code (default),
-                       codex-cli, gemini-cli, copilot. Pass several to install
-                       multiple agents at once (e.g. claude-code,codex-cli).
-  --dry-run            Print the install plan as JSON and exit. No files are
-                       written.
-  --upgrade            Overwrite skills that are already installed.
-  --force              Skip the interactive confirmation prompt (non-TTY
-                       sessions skip the prompt automatically).
-  -h, --help           Show this help.
-
-Note: @ozzylabs/skills installs into the user-scoped skills directory only —
-i.e. under \$HOME. Project-scoped install paths (e.g. \`--target\`) are not
-supported and never will be. Use the legacy \`/sync-consumers\` flow if you
-need per-repo skill mirrors.
-`;
 
 const SUPPORTED_ADAPTERS = ["claude-code", "codex-cli", "gemini-cli", "copilot"];
-
-const SCHEMA = {
-  skills: "string",
-  adapter: "string",
-  "dry-run": "boolean",
-  upgrade: "boolean",
-  force: "boolean",
-  help: "boolean",
-};
-
-const ALIASES = { h: "help" };
 
 // Per-adapter description of how to walk the dist tree and map it onto
 // the user HOME directory. Each adapter declares:
@@ -328,111 +288,5 @@ export async function executeInstall(plan, options) {
   };
 }
 
-/**
- * Run the `install` subcommand from CLI argv. Returns a process exit code.
- *
- * @param {string[]} argv The args after the `install` subcommand keyword.
- * @returns {Promise<number>}
- */
-export async function runInstall(argv) {
-  try {
-    assertNoForbiddenFlags(argv);
-  } catch (err) {
-    process.stderr.write(`error: ${err.message}\n\n${HELP}`);
-    return 1;
-  }
 
-  let parsed;
-  try {
-    parsed = parseFlags(argv, SCHEMA, ALIASES);
-  } catch (err) {
-    process.stderr.write(`error: ${err.message}\n\n${HELP}`);
-    return 1;
-  }
-
-  if (parsed.values.help) {
-    process.stdout.write(HELP);
-    return 0;
-  }
-  if (parsed.rejected.length > 0) {
-    process.stderr.write(`error: unknown argument(s): ${parsed.rejected.join(", ")}\n\n${HELP}`);
-    return 1;
-  }
-
-  // `--adapter` accepts a comma-separated list so a single run can install
-  // multiple agents (e.g. `--adapter=claude-code,codex-cli`), mirroring the
-  // `--skills` syntax. Defaults to claude-code.
-  const adapters = (parsed.values.adapter ?? "claude-code")
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
-  const skillsFilter = parsed.values.skills
-    ? parsed.values.skills.split(",").map((s) => s.trim()).filter(Boolean)
-    : null;
-  const dryRun = Boolean(parsed.values["dry-run"]);
-  const upgrade = Boolean(parsed.values.upgrade);
-  const force = Boolean(parsed.values.force);
-
-  const packageRoot = await findPackageRoot();
-  const home = process.env.OZZYLABS_SKILLS_HOME ?? homedir();
-
-  const plans = [];
-  for (const adapter of adapters) {
-    try {
-      plans.push(await planInstall({ packageRoot, home, adapter, skillsFilter }));
-    } catch (err) {
-      process.stderr.write(`error: ${err.message}\n`);
-      return 1;
-    }
-  }
-
-  if (dryRun) {
-    const summaries = await Promise.all(plans.map((plan) => summarizePlan(plan, home)));
-    const out = summaries.length === 1 ? summaries[0] : summaries;
-    process.stdout.write(`${JSON.stringify(out, null, 2)}\n`);
-    return 0;
-  }
-
-  const summaries = [];
-  for (const plan of plans) {
-    const result = await executeInstall(plan, { upgrade, force });
-    summaries.push({
-      target_dir: plan.target_dir,
-      adapter: plan.adapter,
-      installed: result.installed,
-      upgraded: result.upgraded,
-      skipped: result.skipped,
-    });
-  }
-  const out = summaries.length === 1 ? summaries[0] : summaries;
-  process.stdout.write(`${JSON.stringify(out, null, 2)}\n`);
-  return 0;
-}
-
-/**
- * Compute a dry-run summary that mirrors `executeInstall`'s result shape so
- * downstream tooling can rely on the same JSON contract.
- *
- * @param {Awaited<ReturnType<typeof planInstall>>} plan
- * @param {string} home
- */
-async function summarizePlan(plan, _home) {
-  const installed = new Set();
-  const upgraded = new Set();
-  const skipped = new Set();
-  for (const file of plan.files) {
-    if (!file.skill) continue;
-    if (existsSync(file.dest)) upgraded.add(file.skill);
-    else installed.add(file.skill);
-  }
-  return {
-    target_dir: plan.target_dir,
-    adapter: plan.adapter,
-    installed: [...installed].sort(),
-    upgraded: [...upgraded].sort(),
-    skipped: [...skipped].sort(),
-    files: plan.files.map((f) => ({ source: f.source, dest: f.dest, skill: f.skill })),
-  };
-}
-
-export { SUPPORTED_ADAPTERS, ADAPTER_LAYOUT, HELP };
+export { SUPPORTED_ADAPTERS, ADAPTER_LAYOUT };

--- a/bin/lib/remove.mjs
+++ b/bin/lib/remove.mjs
@@ -15,6 +15,7 @@ import { parseFlags } from "./args.mjs";
 import { didYouMean } from "./detect.mjs";
 import { ADAPTER_LAYOUT, findPackageRoot, SUPPORTED_ADAPTERS } from "./install.mjs";
 import { readDirMarker, writeDirMarker } from "./marker.mjs";
+import { dropPristine } from "./pristine.mjs";
 import { confirm } from "./prompt.mjs";
 
 const SHARED_BASE_ROOT = ".agents/skills";
@@ -180,7 +181,11 @@ export async function runRemove(argv, opts = {}) {
 
   // Execute.
   for (const p of actionable) {
-    for (const d of p.deletions) await rm(d, { recursive: true, force: true });
+    for (const d of p.deletions) {
+      await rm(d, { recursive: true, force: true });
+      // Drop the merge-base snapshot for a fully removed skill dir.
+      await dropPristine(scopeRoot, d);
+    }
     if (p.baseUpdate?.action === "rewrite") {
       await writeDirMarker(p.baseUpdate.dir, {
         bundleVersion: p.baseUpdate.version,

--- a/tests/cli-e2e.test.mjs
+++ b/tests/cli-e2e.test.mjs
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
+import { pristinePath } from "../bin/lib/pristine.mjs";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const BIN = join(ROOT, "bin", "skills.mjs");
@@ -433,6 +434,19 @@ test("e2e: update --merge degrades to a fallback when the merge base (cache) is 
     const out = JSON.parse(r.stdout);
     assert.equal(out.merged.find((x) => x.skill === "drive")?.status, "no-base");
     assert.match(r.stderr, /no merge base|--take-theirs/);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: remove drops the pristine merge-base cache", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-e2e-"));
+  try {
+    runCli(["add", "--adapter=codex-cli", "--skills=drive", "--force"], { home });
+    const baseDir = join(home, ".agents", "skills", "drive");
+    assert.ok(existsSync(pristinePath(home, baseDir)), "pristine saved on add");
+    runCli(["remove", "--skills=drive", "--yes"], { home });
+    assert.ok(!existsSync(pristinePath(home, baseDir)), "pristine dropped on remove");
   } finally {
     await rm(home, { recursive: true, force: true });
   }

--- a/tests/cli-install.test.mjs
+++ b/tests/cli-install.test.mjs
@@ -1,8 +1,7 @@
-// Unit tests for `npx @ozzylabs/skills install`.
+// Unit tests for the user-scope install primitives.
 //
 // These exercise the pure planner (`planInstall`) plus argument parsing
-// (`runInstall` via stdout capture). Filesystem-touching scenarios live in
-// `cli-e2e.test.mjs`.
+// (`parseFlags`). Filesystem-touching scenarios live in `cli-e2e.test.mjs`.
 
 import assert from "node:assert/strict";
 import { mkdtemp, rm } from "node:fs/promises";
@@ -10,7 +9,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
-import { assertNoForbiddenFlags, parseFlags } from "../bin/lib/args.mjs";
+import { parseFlags } from "../bin/lib/args.mjs";
 import { planInstall, SUPPORTED_ADAPTERS } from "../bin/lib/install.mjs";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
@@ -153,13 +152,6 @@ test("parseFlags routes -h to --help via the aliases table", () => {
 test("parseFlags surfaces unknown flags in the rejected array", () => {
   const { rejected } = parseFlags(["--bogus"], { skills: "string" });
   assert.deepEqual(rejected, ["--bogus"]);
-});
-
-test("assertNoForbiddenFlags blocks --target= and --target value", () => {
-  assert.throws(() => assertNoForbiddenFlags(["--target=/tmp"]), /not supported/);
-  assert.throws(() => assertNoForbiddenFlags(["--target", "/tmp"]), /not supported/);
-  assert.throws(() => assertNoForbiddenFlags(["--from=foo"]), /not supported/);
-  assert.throws(() => assertNoForbiddenFlags(["--to=foo"]), /not supported/);
 });
 
 test("planInstall with --skills filter includes only the named skill files", async () => {


### PR DESCRIPTION
#151 後の loose end 2 件を掃除。

1. **dead code 除去**: dispatcher が `bin/skills.mjs` に移った後に残った install-CLI glue（`bin/lib/install.mjs` の `runInstall`/`summarizePlan`/`HELP`/`SCHEMA`/`ALIASES` → 純粋な plan/execute lib に）と、`add --target` で契約が逆転した `bin/lib/args.mjs` の `assertNoForbiddenFlags`。obsolete テスト・未使用 import も削除。
2. **`remove` が pristine キャッシュを破棄**（`dropPristine`）— orphan cache を残さない。

live コマンドの挙動変化なし。299 テスト green / lint clean。