### PR TITLE
feat(drive): surface idempotent resume command in failure reports

### DIFF
--- a/.agents/skills/drive/SKILL.claude-code.md
+++ b/.agents/skills/drive/SKILL.claude-code.md
@@ -30,7 +30,7 @@ usage-guard の取り扱い:
 - **既定で有効（opt-out）**。明示的に `--no-usage-guard` を付けたときのみ checkpoint を挟まない素の drive を実行する。
 - `--no-usage-guard` 未指定なら、後述「usage-guard 配線（既定 ON・`--no-usage-guard` で無効化）」の checkpoint で usage-guard エンジンを呼び、Usage Limit 超過時は枠回復まで待機してから自己再入する。
 - `--usage-guard` は後方互換の **deprecated no-op エイリアス**として受理する（既定 ON のため明示は不要・挙動は既定と同一）。継続コマンドには強制付与しない。
-- 解析時に**元の引数列を保存**する（継続コマンド `/drive <元の引数>` の組み立てに使う）。`--no-usage-guard` がユーザー指定されていた場合のみ保存対象に含めて継続コマンドにも引き継ぐ。`--usage-guard` は no-op エイリアスなので保存・付与しない。
+- 解析時に**元の引数列を保存**する（継続コマンド `/drive <元の引数>` と、失敗時レポートの再開行 `再開: /drive <元の引数>` — canonical の Phase 5 / Phase Final-6、`failed` / `merge-ready` 残置 / `skipped` があるときのみ — の組み立てに使う）。`--no-usage-guard` がユーザー指定されていた場合のみ保存対象に含めて継続コマンドにも引き継ぐ。`--usage-guard` は no-op エイリアスなので保存・付与しない。
 
 ### 自律実行
 

--- a/.agents/skills/drive/SKILL.md
+++ b/.agents/skills/drive/SKILL.md
@@ -48,6 +48,14 @@ Issue または指示を受け取り、実装 → ship → セルフレビュー
   - 超過時は枠リセットまで待機してから継続コマンド `/drive <元の引数>` を自己再入する（drive 冪等 resume で続行）。`--no-usage-guard` がユーザー指定されていた場合のみ継続コマンドにも引き継ぐ（`--usage-guard` を強制付与しない）。
   - usage-guard skill / `usage-check.mjs` が未インストールの環境でもエラーで drive を止めない。skill 不在を検出したら 1 行警告を出し、そのまま通常進行する（fail-open 扱い）。
 
+### 引数復元（再開コマンド）
+
+解析時に**元の引数列を保存**する。失敗時レポートの再開行（単一モード Phase 5 / オーケストレーション Phase Final-6）と usage-guard の継続コマンドは、この保存済み引数から `/drive <元の引数>` を組み立てる。復元規約は usage-guard の継続コマンド規約と同一:
+
+- 元の引数をそのまま再掲する。drive の冪等 resume（既存 PR / ブランチ / merged 済み PR の検出）が続きから再開する
+- `--no-usage-guard` はユーザー指定されていた場合のみ引き継ぐ
+- `--usage-guard` は deprecated no-op エイリアスのため保存・付与しない（強制付与もしない）
+
 ### モード分岐
 
 - target が 1 件かつ依存記法なし → **単一モード**
@@ -130,7 +138,10 @@ drive 完了:
             総計 Critical: 0, Warning: 0, Info: N
             by_axis: correctness:C0W0I0 security:C0W0I0 ...
   状態:     <merged | merge-ready | auto-merge enabled | failed>
+  再開:     /drive <元の引数>
 ```
+
+`再開:` 行は状態が `failed` または `merge-ready` のとき**必ず**出力する（発見可能性のため。resume が効くことを SKILL.md を読まずに知れるようにする）。引数は「引数復元（再開コマンド）」の規約に従って復元し、`再開: /drive <元の引数>` の 1 行で示す。再実行すると冪等 resume が既存 PR / ブランチを検出し、Phase 3 から続きを再開する。状態が `merged` / `auto-merge enabled` で完結した場合は表示しない。
 
 ## オーケストレーションモード
 
@@ -370,9 +381,13 @@ drive 完了 (4/5 merged, 1 skipped):
   総レビュー反復:    5 回
   cross-cutting:    2 gaps resolved (folded into PR #100, #102)
   cleanup:          3/5 removed (2 preserved: 1 failed, 1 skipped)
+
+再開: /drive <元の引数>
 ```
 
 `cross-cutting:` 行は Phase Final-3 で reconciliation により解消した gap 数と畳み込み先 PR を `<N> gaps resolved (folded into ...)` 形式で表示する。専用 reconciliation PR を作成・マージした場合はそれも merged リストの 1 行として現れ、`folded into` にその PR 番号を含める。gap が 0 件なら `cross-cutting: none`。fail-soft で残った gap があれば `<N> resolved, <M> unresolved (warning)` とし、warning ブロックに未解決分と手動対応の推奨を出す。
+
+`再開:` 行は `failed` / `merge-ready` 残置 / `skipped` が 1 件以上あるとき、集計ブロック直後に `再開: /drive <元の引数>` の 1 行を**必ず**出力する（「引数復元（再開コマンド）」の規約に従う）。再実行すると冪等 resume が merged 済み PR / 既存 PR を検出して完了済み target をスキップし、残りの target から続行する。全 target が merged で完結した場合は表示しない。
 
 ## 失敗 semantics
 
@@ -383,6 +398,8 @@ drive 完了 (4/5 merged, 1 skipped):
 | implement / ship 中断（テスト失敗等） | failed | skipped |
 | reconciliation の畳み込み失敗 | fail-soft（gap を warning 残置） | 影響なし（PR 自体は merge-ready） |
 | 独立 task の失敗 | 他並列 task に影響させない | - |
+
+いずれの失敗・残置も再開手段は共通で、レポート末尾の `再開: /drive <元の引数>` を再実行すればよい（Phase 5 / Phase Final-6 参照）。冪等 resume が既存 PR / ブランチ / merged 済み PR を検出し、完了済み target をスキップして続きから再開する。
 
 ## 注意事項
 

--- a/.claude/skills/drive/SKILL.md
+++ b/.claude/skills/drive/SKILL.md
@@ -31,7 +31,7 @@ usage-guard の取り扱い:
 - **既定で有効（opt-out）**。明示的に `--no-usage-guard` を付けたときのみ checkpoint を挟まない素の drive を実行する。
 - `--no-usage-guard` 未指定なら、後述「usage-guard 配線（既定 ON・`--no-usage-guard` で無効化）」の checkpoint で usage-guard エンジンを呼び、Usage Limit 超過時は枠回復まで待機してから自己再入する。
 - `--usage-guard` は後方互換の **deprecated no-op エイリアス**として受理する（既定 ON のため明示は不要・挙動は既定と同一）。継続コマンドには強制付与しない。
-- 解析時に**元の引数列を保存**する（継続コマンド `/drive <元の引数>` の組み立てに使う）。`--no-usage-guard` がユーザー指定されていた場合のみ保存対象に含めて継続コマンドにも引き継ぐ。`--usage-guard` は no-op エイリアスなので保存・付与しない。
+- 解析時に**元の引数列を保存**する（継続コマンド `/drive <元の引数>` と、失敗時レポートの再開行 `再開: /drive <元の引数>` — canonical の Phase 5 / Phase Final-6、`failed` / `merge-ready` 残置 / `skipped` があるときのみ — の組み立てに使う）。`--no-usage-guard` がユーザー指定されていた場合のみ保存対象に含めて継続コマンドにも引き継ぐ。`--usage-guard` は no-op エイリアスなので保存・付与しない。
 
 ### 自律実行
 

--- a/dist/claude-code-project/.agents/skills/drive/SKILL.md
+++ b/dist/claude-code-project/.agents/skills/drive/SKILL.md
@@ -48,6 +48,14 @@ Issue または指示を受け取り、実装 → ship → セルフレビュー
   - 超過時は枠リセットまで待機してから継続コマンド `/drive <元の引数>` を自己再入する（drive 冪等 resume で続行）。`--no-usage-guard` がユーザー指定されていた場合のみ継続コマンドにも引き継ぐ（`--usage-guard` を強制付与しない）。
   - usage-guard skill / `usage-check.mjs` が未インストールの環境でもエラーで drive を止めない。skill 不在を検出したら 1 行警告を出し、そのまま通常進行する（fail-open 扱い）。
 
+### 引数復元（再開コマンド）
+
+解析時に**元の引数列を保存**する。失敗時レポートの再開行（単一モード Phase 5 / オーケストレーション Phase Final-6）と usage-guard の継続コマンドは、この保存済み引数から `/drive <元の引数>` を組み立てる。復元規約は usage-guard の継続コマンド規約と同一:
+
+- 元の引数をそのまま再掲する。drive の冪等 resume（既存 PR / ブランチ / merged 済み PR の検出）が続きから再開する
+- `--no-usage-guard` はユーザー指定されていた場合のみ引き継ぐ
+- `--usage-guard` は deprecated no-op エイリアスのため保存・付与しない（強制付与もしない）
+
 ### モード分岐
 
 - target が 1 件かつ依存記法なし → **単一モード**
@@ -130,7 +138,10 @@ drive 完了:
             総計 Critical: 0, Warning: 0, Info: N
             by_axis: correctness:C0W0I0 security:C0W0I0 ...
   状態:     <merged | merge-ready | auto-merge enabled | failed>
+  再開:     /drive <元の引数>
 ```
+
+`再開:` 行は状態が `failed` または `merge-ready` のとき**必ず**出力する（発見可能性のため。resume が効くことを SKILL.md を読まずに知れるようにする）。引数は「引数復元（再開コマンド）」の規約に従って復元し、`再開: /drive <元の引数>` の 1 行で示す。再実行すると冪等 resume が既存 PR / ブランチを検出し、Phase 3 から続きを再開する。状態が `merged` / `auto-merge enabled` で完結した場合は表示しない。
 
 ## オーケストレーションモード
 
@@ -370,9 +381,13 @@ drive 完了 (4/5 merged, 1 skipped):
   総レビュー反復:    5 回
   cross-cutting:    2 gaps resolved (folded into PR #100, #102)
   cleanup:          3/5 removed (2 preserved: 1 failed, 1 skipped)
+
+再開: /drive <元の引数>
 ```
 
 `cross-cutting:` 行は Phase Final-3 で reconciliation により解消した gap 数と畳み込み先 PR を `<N> gaps resolved (folded into ...)` 形式で表示する。専用 reconciliation PR を作成・マージした場合はそれも merged リストの 1 行として現れ、`folded into` にその PR 番号を含める。gap が 0 件なら `cross-cutting: none`。fail-soft で残った gap があれば `<N> resolved, <M> unresolved (warning)` とし、warning ブロックに未解決分と手動対応の推奨を出す。
+
+`再開:` 行は `failed` / `merge-ready` 残置 / `skipped` が 1 件以上あるとき、集計ブロック直後に `再開: /drive <元の引数>` の 1 行を**必ず**出力する（「引数復元（再開コマンド）」の規約に従う）。再実行すると冪等 resume が merged 済み PR / 既存 PR を検出して完了済み target をスキップし、残りの target から続行する。全 target が merged で完結した場合は表示しない。
 
 ## 失敗 semantics
 
@@ -383,6 +398,8 @@ drive 完了 (4/5 merged, 1 skipped):
 | implement / ship 中断（テスト失敗等） | failed | skipped |
 | reconciliation の畳み込み失敗 | fail-soft（gap を warning 残置） | 影響なし（PR 自体は merge-ready） |
 | 独立 task の失敗 | 他並列 task に影響させない | - |
+
+いずれの失敗・残置も再開手段は共通で、レポート末尾の `再開: /drive <元の引数>` を再実行すればよい（Phase 5 / Phase Final-6 参照）。冪等 resume が既存 PR / ブランチ / merged 済み PR を検出し、完了済み target をスキップして続きから再開する。
 
 ## 注意事項
 

--- a/dist/claude-code-project/.claude/skills/drive/SKILL.md
+++ b/dist/claude-code-project/.claude/skills/drive/SKILL.md
@@ -31,7 +31,7 @@ usage-guard の取り扱い:
 - **既定で有効（opt-out）**。明示的に `--no-usage-guard` を付けたときのみ checkpoint を挟まない素の drive を実行する。
 - `--no-usage-guard` 未指定なら、後述「usage-guard 配線（既定 ON・`--no-usage-guard` で無効化）」の checkpoint で usage-guard エンジンを呼び、Usage Limit 超過時は枠回復まで待機してから自己再入する。
 - `--usage-guard` は後方互換の **deprecated no-op エイリアス**として受理する（既定 ON のため明示は不要・挙動は既定と同一）。継続コマンドには強制付与しない。
-- 解析時に**元の引数列を保存**する（継続コマンド `/drive <元の引数>` の組み立てに使う）。`--no-usage-guard` がユーザー指定されていた場合のみ保存対象に含めて継続コマンドにも引き継ぐ。`--usage-guard` は no-op エイリアスなので保存・付与しない。
+- 解析時に**元の引数列を保存**する（継続コマンド `/drive <元の引数>` と、失敗時レポートの再開行 `再開: /drive <元の引数>` — canonical の Phase 5 / Phase Final-6、`failed` / `merge-ready` 残置 / `skipped` があるときのみ — の組み立てに使う）。`--no-usage-guard` がユーザー指定されていた場合のみ保存対象に含めて継続コマンドにも引き継ぐ。`--usage-guard` は no-op エイリアスなので保存・付与しない。
 
 ### 自律実行
 

--- a/dist/claude-code/.agents/skills/drive/SKILL.md
+++ b/dist/claude-code/.agents/skills/drive/SKILL.md
@@ -48,6 +48,14 @@ Issue または指示を受け取り、実装 → ship → セルフレビュー
   - 超過時は枠リセットまで待機してから継続コマンド `/drive <元の引数>` を自己再入する（drive 冪等 resume で続行）。`--no-usage-guard` がユーザー指定されていた場合のみ継続コマンドにも引き継ぐ（`--usage-guard` を強制付与しない）。
   - usage-guard skill / `usage-check.mjs` が未インストールの環境でもエラーで drive を止めない。skill 不在を検出したら 1 行警告を出し、そのまま通常進行する（fail-open 扱い）。
 
+### 引数復元（再開コマンド）
+
+解析時に**元の引数列を保存**する。失敗時レポートの再開行（単一モード Phase 5 / オーケストレーション Phase Final-6）と usage-guard の継続コマンドは、この保存済み引数から `/drive <元の引数>` を組み立てる。復元規約は usage-guard の継続コマンド規約と同一:
+
+- 元の引数をそのまま再掲する。drive の冪等 resume（既存 PR / ブランチ / merged 済み PR の検出）が続きから再開する
+- `--no-usage-guard` はユーザー指定されていた場合のみ引き継ぐ
+- `--usage-guard` は deprecated no-op エイリアスのため保存・付与しない（強制付与もしない）
+
 ### モード分岐
 
 - target が 1 件かつ依存記法なし → **単一モード**
@@ -130,7 +138,10 @@ drive 完了:
             総計 Critical: 0, Warning: 0, Info: N
             by_axis: correctness:C0W0I0 security:C0W0I0 ...
   状態:     <merged | merge-ready | auto-merge enabled | failed>
+  再開:     /drive <元の引数>
 ```
+
+`再開:` 行は状態が `failed` または `merge-ready` のとき**必ず**出力する（発見可能性のため。resume が効くことを SKILL.md を読まずに知れるようにする）。引数は「引数復元（再開コマンド）」の規約に従って復元し、`再開: /drive <元の引数>` の 1 行で示す。再実行すると冪等 resume が既存 PR / ブランチを検出し、Phase 3 から続きを再開する。状態が `merged` / `auto-merge enabled` で完結した場合は表示しない。
 
 ## オーケストレーションモード
 
@@ -370,9 +381,13 @@ drive 完了 (4/5 merged, 1 skipped):
   総レビュー反復:    5 回
   cross-cutting:    2 gaps resolved (folded into PR #100, #102)
   cleanup:          3/5 removed (2 preserved: 1 failed, 1 skipped)
+
+再開: /drive <元の引数>
 ```
 
 `cross-cutting:` 行は Phase Final-3 で reconciliation により解消した gap 数と畳み込み先 PR を `<N> gaps resolved (folded into ...)` 形式で表示する。専用 reconciliation PR を作成・マージした場合はそれも merged リストの 1 行として現れ、`folded into` にその PR 番号を含める。gap が 0 件なら `cross-cutting: none`。fail-soft で残った gap があれば `<N> resolved, <M> unresolved (warning)` とし、warning ブロックに未解決分と手動対応の推奨を出す。
+
+`再開:` 行は `failed` / `merge-ready` 残置 / `skipped` が 1 件以上あるとき、集計ブロック直後に `再開: /drive <元の引数>` の 1 行を**必ず**出力する（「引数復元（再開コマンド）」の規約に従う）。再実行すると冪等 resume が merged 済み PR / 既存 PR を検出して完了済み target をスキップし、残りの target から続行する。全 target が merged で完結した場合は表示しない。
 
 ## 失敗 semantics
 
@@ -383,6 +398,8 @@ drive 完了 (4/5 merged, 1 skipped):
 | implement / ship 中断（テスト失敗等） | failed | skipped |
 | reconciliation の畳み込み失敗 | fail-soft（gap を warning 残置） | 影響なし（PR 自体は merge-ready） |
 | 独立 task の失敗 | 他並列 task に影響させない | - |
+
+いずれの失敗・残置も再開手段は共通で、レポート末尾の `再開: /drive <元の引数>` を再実行すればよい（Phase 5 / Phase Final-6 参照）。冪等 resume が既存 PR / ブランチ / merged 済み PR を検出し、完了済み target をスキップして続きから再開する。
 
 ## 注意事項
 

--- a/dist/claude-code/.claude/skills/drive/SKILL.md
+++ b/dist/claude-code/.claude/skills/drive/SKILL.md
@@ -31,7 +31,7 @@ usage-guard の取り扱い:
 - **既定で有効（opt-out）**。明示的に `--no-usage-guard` を付けたときのみ checkpoint を挟まない素の drive を実行する。
 - `--no-usage-guard` 未指定なら、後述「usage-guard 配線（既定 ON・`--no-usage-guard` で無効化）」の checkpoint で usage-guard エンジンを呼び、Usage Limit 超過時は枠回復まで待機してから自己再入する。
 - `--usage-guard` は後方互換の **deprecated no-op エイリアス**として受理する（既定 ON のため明示は不要・挙動は既定と同一）。継続コマンドには強制付与しない。
-- 解析時に**元の引数列を保存**する（継続コマンド `/drive <元の引数>` の組み立てに使う）。`--no-usage-guard` がユーザー指定されていた場合のみ保存対象に含めて継続コマンドにも引き継ぐ。`--usage-guard` は no-op エイリアスなので保存・付与しない。
+- 解析時に**元の引数列を保存**する（継続コマンド `/drive <元の引数>` と、失敗時レポートの再開行 `再開: /drive <元の引数>` — canonical の Phase 5 / Phase Final-6、`failed` / `merge-ready` 残置 / `skipped` があるときのみ — の組み立てに使う）。`--no-usage-guard` がユーザー指定されていた場合のみ保存対象に含めて継続コマンドにも引き継ぐ。`--usage-guard` は no-op エイリアスなので保存・付与しない。
 
 ### 自律実行
 

--- a/dist/codex-cli/.agents/skills/drive/SKILL.md
+++ b/dist/codex-cli/.agents/skills/drive/SKILL.md
@@ -48,6 +48,14 @@ Issue または指示を受け取り、実装 → ship → セルフレビュー
   - 超過時は枠リセットまで待機してから継続コマンド `/drive <元の引数>` を自己再入する（drive 冪等 resume で続行）。`--no-usage-guard` がユーザー指定されていた場合のみ継続コマンドにも引き継ぐ（`--usage-guard` を強制付与しない）。
   - usage-guard skill / `usage-check.mjs` が未インストールの環境でもエラーで drive を止めない。skill 不在を検出したら 1 行警告を出し、そのまま通常進行する（fail-open 扱い）。
 
+### 引数復元（再開コマンド）
+
+解析時に**元の引数列を保存**する。失敗時レポートの再開行（単一モード Phase 5 / オーケストレーション Phase Final-6）と usage-guard の継続コマンドは、この保存済み引数から `/drive <元の引数>` を組み立てる。復元規約は usage-guard の継続コマンド規約と同一:
+
+- 元の引数をそのまま再掲する。drive の冪等 resume（既存 PR / ブランチ / merged 済み PR の検出）が続きから再開する
+- `--no-usage-guard` はユーザー指定されていた場合のみ引き継ぐ
+- `--usage-guard` は deprecated no-op エイリアスのため保存・付与しない（強制付与もしない）
+
 ### モード分岐
 
 - target が 1 件かつ依存記法なし → **単一モード**
@@ -130,7 +138,10 @@ drive 完了:
             総計 Critical: 0, Warning: 0, Info: N
             by_axis: correctness:C0W0I0 security:C0W0I0 ...
   状態:     <merged | merge-ready | auto-merge enabled | failed>
+  再開:     /drive <元の引数>
 ```
+
+`再開:` 行は状態が `failed` または `merge-ready` のとき**必ず**出力する（発見可能性のため。resume が効くことを SKILL.md を読まずに知れるようにする）。引数は「引数復元（再開コマンド）」の規約に従って復元し、`再開: /drive <元の引数>` の 1 行で示す。再実行すると冪等 resume が既存 PR / ブランチを検出し、Phase 3 から続きを再開する。状態が `merged` / `auto-merge enabled` で完結した場合は表示しない。
 
 ## オーケストレーションモード
 
@@ -370,9 +381,13 @@ drive 完了 (4/5 merged, 1 skipped):
   総レビュー反復:    5 回
   cross-cutting:    2 gaps resolved (folded into PR #100, #102)
   cleanup:          3/5 removed (2 preserved: 1 failed, 1 skipped)
+
+再開: /drive <元の引数>
 ```
 
 `cross-cutting:` 行は Phase Final-3 で reconciliation により解消した gap 数と畳み込み先 PR を `<N> gaps resolved (folded into ...)` 形式で表示する。専用 reconciliation PR を作成・マージした場合はそれも merged リストの 1 行として現れ、`folded into` にその PR 番号を含める。gap が 0 件なら `cross-cutting: none`。fail-soft で残った gap があれば `<N> resolved, <M> unresolved (warning)` とし、warning ブロックに未解決分と手動対応の推奨を出す。
+
+`再開:` 行は `failed` / `merge-ready` 残置 / `skipped` が 1 件以上あるとき、集計ブロック直後に `再開: /drive <元の引数>` の 1 行を**必ず**出力する（「引数復元（再開コマンド）」の規約に従う）。再実行すると冪等 resume が merged 済み PR / 既存 PR を検出して完了済み target をスキップし、残りの target から続行する。全 target が merged で完結した場合は表示しない。
 
 ## 失敗 semantics
 
@@ -383,6 +398,8 @@ drive 完了 (4/5 merged, 1 skipped):
 | implement / ship 中断（テスト失敗等） | failed | skipped |
 | reconciliation の畳み込み失敗 | fail-soft（gap を warning 残置） | 影響なし（PR 自体は merge-ready） |
 | 独立 task の失敗 | 他並列 task に影響させない | - |
+
+いずれの失敗・残置も再開手段は共通で、レポート末尾の `再開: /drive <元の引数>` を再実行すればよい（Phase 5 / Phase Final-6 参照）。冪等 resume が既存 PR / ブランチ / merged 済み PR を検出し、完了済み target をスキップして続きから再開する。
 
 ## 注意事項
 

--- a/dist/copilot/.agents/skills/drive/SKILL.md
+++ b/dist/copilot/.agents/skills/drive/SKILL.md
@@ -48,6 +48,14 @@ Issue または指示を受け取り、実装 → ship → セルフレビュー
   - 超過時は枠リセットまで待機してから継続コマンド `/drive <元の引数>` を自己再入する（drive 冪等 resume で続行）。`--no-usage-guard` がユーザー指定されていた場合のみ継続コマンドにも引き継ぐ（`--usage-guard` を強制付与しない）。
   - usage-guard skill / `usage-check.mjs` が未インストールの環境でもエラーで drive を止めない。skill 不在を検出したら 1 行警告を出し、そのまま通常進行する（fail-open 扱い）。
 
+### 引数復元（再開コマンド）
+
+解析時に**元の引数列を保存**する。失敗時レポートの再開行（単一モード Phase 5 / オーケストレーション Phase Final-6）と usage-guard の継続コマンドは、この保存済み引数から `/drive <元の引数>` を組み立てる。復元規約は usage-guard の継続コマンド規約と同一:
+
+- 元の引数をそのまま再掲する。drive の冪等 resume（既存 PR / ブランチ / merged 済み PR の検出）が続きから再開する
+- `--no-usage-guard` はユーザー指定されていた場合のみ引き継ぐ
+- `--usage-guard` は deprecated no-op エイリアスのため保存・付与しない（強制付与もしない）
+
 ### モード分岐
 
 - target が 1 件かつ依存記法なし → **単一モード**
@@ -130,7 +138,10 @@ drive 完了:
             総計 Critical: 0, Warning: 0, Info: N
             by_axis: correctness:C0W0I0 security:C0W0I0 ...
   状態:     <merged | merge-ready | auto-merge enabled | failed>
+  再開:     /drive <元の引数>
 ```
+
+`再開:` 行は状態が `failed` または `merge-ready` のとき**必ず**出力する（発見可能性のため。resume が効くことを SKILL.md を読まずに知れるようにする）。引数は「引数復元（再開コマンド）」の規約に従って復元し、`再開: /drive <元の引数>` の 1 行で示す。再実行すると冪等 resume が既存 PR / ブランチを検出し、Phase 3 から続きを再開する。状態が `merged` / `auto-merge enabled` で完結した場合は表示しない。
 
 ## オーケストレーションモード
 
@@ -370,9 +381,13 @@ drive 完了 (4/5 merged, 1 skipped):
   総レビュー反復:    5 回
   cross-cutting:    2 gaps resolved (folded into PR #100, #102)
   cleanup:          3/5 removed (2 preserved: 1 failed, 1 skipped)
+
+再開: /drive <元の引数>
 ```
 
 `cross-cutting:` 行は Phase Final-3 で reconciliation により解消した gap 数と畳み込み先 PR を `<N> gaps resolved (folded into ...)` 形式で表示する。専用 reconciliation PR を作成・マージした場合はそれも merged リストの 1 行として現れ、`folded into` にその PR 番号を含める。gap が 0 件なら `cross-cutting: none`。fail-soft で残った gap があれば `<N> resolved, <M> unresolved (warning)` とし、warning ブロックに未解決分と手動対応の推奨を出す。
+
+`再開:` 行は `failed` / `merge-ready` 残置 / `skipped` が 1 件以上あるとき、集計ブロック直後に `再開: /drive <元の引数>` の 1 行を**必ず**出力する（「引数復元（再開コマンド）」の規約に従う）。再実行すると冪等 resume が merged 済み PR / 既存 PR を検出して完了済み target をスキップし、残りの target から続行する。全 target が merged で完結した場合は表示しない。
 
 ## 失敗 semantics
 
@@ -383,6 +398,8 @@ drive 完了 (4/5 merged, 1 skipped):
 | implement / ship 中断（テスト失敗等） | failed | skipped |
 | reconciliation の畳み込み失敗 | fail-soft（gap を warning 残置） | 影響なし（PR 自体は merge-ready） |
 | 独立 task の失敗 | 他並列 task に影響させない | - |
+
+いずれの失敗・残置も再開手段は共通で、レポート末尾の `再開: /drive <元の引数>` を再実行すればよい（Phase 5 / Phase Final-6 参照）。冪等 resume が既存 PR / ブランチ / merged 済み PR を検出し、完了済み target をスキップして続きから再開する。
 
 ## 注意事項
 

--- a/dist/gemini-cli/.agents/skills/drive/SKILL.md
+++ b/dist/gemini-cli/.agents/skills/drive/SKILL.md
@@ -48,6 +48,14 @@ Issue または指示を受け取り、実装 → ship → セルフレビュー
   - 超過時は枠リセットまで待機してから継続コマンド `/drive <元の引数>` を自己再入する（drive 冪等 resume で続行）。`--no-usage-guard` がユーザー指定されていた場合のみ継続コマンドにも引き継ぐ（`--usage-guard` を強制付与しない）。
   - usage-guard skill / `usage-check.mjs` が未インストールの環境でもエラーで drive を止めない。skill 不在を検出したら 1 行警告を出し、そのまま通常進行する（fail-open 扱い）。
 
+### 引数復元（再開コマンド）
+
+解析時に**元の引数列を保存**する。失敗時レポートの再開行（単一モード Phase 5 / オーケストレーション Phase Final-6）と usage-guard の継続コマンドは、この保存済み引数から `/drive <元の引数>` を組み立てる。復元規約は usage-guard の継続コマンド規約と同一:
+
+- 元の引数をそのまま再掲する。drive の冪等 resume（既存 PR / ブランチ / merged 済み PR の検出）が続きから再開する
+- `--no-usage-guard` はユーザー指定されていた場合のみ引き継ぐ
+- `--usage-guard` は deprecated no-op エイリアスのため保存・付与しない（強制付与もしない）
+
 ### モード分岐
 
 - target が 1 件かつ依存記法なし → **単一モード**
@@ -130,7 +138,10 @@ drive 完了:
             総計 Critical: 0, Warning: 0, Info: N
             by_axis: correctness:C0W0I0 security:C0W0I0 ...
   状態:     <merged | merge-ready | auto-merge enabled | failed>
+  再開:     /drive <元の引数>
 ```
+
+`再開:` 行は状態が `failed` または `merge-ready` のとき**必ず**出力する（発見可能性のため。resume が効くことを SKILL.md を読まずに知れるようにする）。引数は「引数復元（再開コマンド）」の規約に従って復元し、`再開: /drive <元の引数>` の 1 行で示す。再実行すると冪等 resume が既存 PR / ブランチを検出し、Phase 3 から続きを再開する。状態が `merged` / `auto-merge enabled` で完結した場合は表示しない。
 
 ## オーケストレーションモード
 
@@ -370,9 +381,13 @@ drive 完了 (4/5 merged, 1 skipped):
   総レビュー反復:    5 回
   cross-cutting:    2 gaps resolved (folded into PR #100, #102)
   cleanup:          3/5 removed (2 preserved: 1 failed, 1 skipped)
+
+再開: /drive <元の引数>
 ```
 
 `cross-cutting:` 行は Phase Final-3 で reconciliation により解消した gap 数と畳み込み先 PR を `<N> gaps resolved (folded into ...)` 形式で表示する。専用 reconciliation PR を作成・マージした場合はそれも merged リストの 1 行として現れ、`folded into` にその PR 番号を含める。gap が 0 件なら `cross-cutting: none`。fail-soft で残った gap があれば `<N> resolved, <M> unresolved (warning)` とし、warning ブロックに未解決分と手動対応の推奨を出す。
+
+`再開:` 行は `failed` / `merge-ready` 残置 / `skipped` が 1 件以上あるとき、集計ブロック直後に `再開: /drive <元の引数>` の 1 行を**必ず**出力する（「引数復元（再開コマンド）」の規約に従う）。再実行すると冪等 resume が merged 済み PR / 既存 PR を検出して完了済み target をスキップし、残りの target から続行する。全 target が merged で完結した場合は表示しない。
 
 ## 失敗 semantics
 
@@ -383,6 +398,8 @@ drive 完了 (4/5 merged, 1 skipped):
 | implement / ship 中断（テスト失敗等） | failed | skipped |
 | reconciliation の畳み込み失敗 | fail-soft（gap を warning 残置） | 影響なし（PR 自体は merge-ready） |
 | 独立 task の失敗 | 他並列 task に影響させない | - |
+
+いずれの失敗・残置も再開手段は共通で、レポート末尾の `再開: /drive <元の引数>` を再実行すればよい（Phase 5 / Phase Final-6 参照）。冪等 resume が既存 PR / ブランチ / merged 済み PR を検出し、完了済み target をスキップして続きから再開する。
 
 ## 注意事項
 

--- a/tests/drive-resume.test.mjs
+++ b/tests/drive-resume.test.mjs
@@ -1,0 +1,176 @@
+// drive idempotent-resume hint in failure reports (issue #168).
+//
+// drive already resumes idempotently (existing PR / branch detection resumes
+// from Phase 3; merged-PR detection lets orchestration continue with the
+// remaining targets), but failure reports never surfaced HOW to resume —
+// users had to read SKILL.md to discover it. #168 adds a mandatory
+// `再開: /drive <元の引数>` line to the single-mode Phase 5 report and the
+// orchestration Phase Final-6 aggregate report whenever a run ends with
+// `failed` / `merge-ready` leftovers / `skipped`, and documents the
+// argument-restoration convention (same rule as the usage-guard continuation
+// command: carry `--no-usage-guard` only when user-specified, never force
+// `--usage-guard`) in the input-parsing section.
+//
+// These are simple string-contains assertions over (a) the canonical
+// SKILL.md (section-anchored so the line lives in the right report), and
+// (b) the built claude-code output (companion emitted via ClaudeCodeAdapter).
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { ClaudeCodeAdapter } from "../scripts/adapters/claude-code.mjs";
+import { assertRequiredFields, parseSkillDocument } from "../scripts/lib/frontmatter.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SRC = join(ROOT, ".agents", "skills");
+
+const RESUME_LINE = "再開: /drive <元の引数>";
+
+async function loadCanonicalRaw() {
+  return readFile(join(SRC, "drive", "SKILL.md"), "utf8");
+}
+
+/** Slice raw between two unique markers (endMarker exclusive) and assert both anchor. */
+function section(raw, startMarker, endMarker) {
+  const start = raw.indexOf(startMarker);
+  assert.ok(start >= 0, `section start marker not found: ${startMarker}`);
+  const end = raw.indexOf(endMarker, start);
+  assert.ok(end > start, `section end marker not found after start: ${endMarker}`);
+  return raw.slice(start, end);
+}
+
+// --- canonical SKILL.md: input parsing carries the restoration convention ---
+
+test("canonical drive SKILL.md: input-parsing section documents the argument-restoration convention", async () => {
+  const raw = await loadCanonicalRaw();
+  const parsing = section(raw, "## 入力解析", "## 単一モード");
+  assert.ok(
+    parsing.includes("### 引数復元（再開コマンド）"),
+    "input parsing must carry a dedicated argument-restoration subsection",
+  );
+  // same rule as the usage-guard continuation command
+  assert.ok(
+    parsing.includes("継続コマンド規約と同一"),
+    "restoration convention must be declared identical to the usage-guard continuation-command rule",
+  );
+  // carry --no-usage-guard only when the user specified it
+  assert.ok(
+    parsing.includes("`--no-usage-guard` はユーザー指定されていた場合のみ引き継ぐ"),
+    "must carry --no-usage-guard only when user-specified",
+  );
+  // never force / persist the deprecated no-op alias
+  assert.ok(
+    parsing.includes("`--usage-guard` は deprecated no-op エイリアスのため保存・付与しない"),
+    "must never save/force the deprecated --usage-guard alias",
+  );
+});
+
+// --- canonical SKILL.md: Phase 5 single-mode report --------------------------
+
+test("canonical drive SKILL.md: Phase 5 report template carries the resume line", async () => {
+  const raw = await loadCanonicalRaw();
+  const phase5 = section(raw, "### Phase 5: 完了報告", "## オーケストレーションモード");
+  // template line (aligned) + prose rule both present
+  assert.ok(
+    phase5.includes("再開:     /drive <元の引数>"),
+    "Phase 5 report template must include the resume line",
+  );
+  assert.ok(phase5.includes(RESUME_LINE), "Phase 5 prose must spell the exact resume command");
+  // gated on failed / merge-ready — and mandatory there
+  assert.ok(
+    /`failed` または `merge-ready` のとき\*\*必ず\*\*出力する/.test(phase5),
+    "resume line must be mandatory for failed / merge-ready outcomes",
+  );
+  // suppressed when the run completed (merged / auto-merge enabled)
+  assert.ok(
+    phase5.includes("`merged` / `auto-merge enabled` で完結した場合は表示しない"),
+    "resume line must be suppressed when the single-mode run completed",
+  );
+});
+
+// --- canonical SKILL.md: Phase Final-6 aggregate report -----------------------
+
+test("canonical drive SKILL.md: Phase Final-6 aggregate report carries the resume line", async () => {
+  const raw = await loadCanonicalRaw();
+  const final6 = section(raw, "#### Phase Final-6: 集約レポート", "## 失敗 semantics");
+  // the example template shows the line after the 集計 block
+  assert.ok(final6.includes(RESUME_LINE), "Final-6 template/prose must include the resume line");
+  // gated on failed / merge-ready leftovers / skipped — and mandatory there
+  assert.ok(
+    final6.includes("`failed` / `merge-ready` 残置 / `skipped` が 1 件以上あるとき"),
+    "resume line triggers on failed / merge-ready leftovers / skipped",
+  );
+  assert.ok(
+    final6.includes("**必ず**出力する"),
+    "resume line must be mandatory in Final-6 when leftovers exist",
+  );
+  // suppressed when every target merged
+  assert.ok(
+    final6.includes("全 target が merged で完結した場合は表示しない"),
+    "resume line must be suppressed when all targets merged",
+  );
+  // idempotent-resume semantics: merged PRs are detected and skipped
+  assert.ok(
+    final6.includes("merged 済み PR") && final6.includes("続行"),
+    "documents that idempotent resume skips already-merged targets and continues",
+  );
+});
+
+// --- canonical SKILL.md: 失敗 semantics notes the resume path -----------------
+
+test("canonical drive SKILL.md: failure-semantics section notes the shared resume path", async () => {
+  const raw = await loadCanonicalRaw();
+  const semantics = section(raw, "## 失敗 semantics", "## 注意事項");
+  assert.ok(
+    semantics.includes(RESUME_LINE),
+    "failure semantics must point at the report resume line",
+  );
+  assert.ok(
+    semantics.includes("冪等 resume"),
+    "failure semantics must name the idempotent resume mechanism",
+  );
+});
+
+// --- built claude-code output (companion emitted via the adapter) ------------
+
+test("built claude-code drive output emits the failure-report resume line wiring", async () => {
+  const file = join(SRC, "drive", "SKILL.md");
+  const raw = await readFile(file, "utf8");
+  const label = ".agents/skills/drive/SKILL.md";
+  const { frontmatter, body } = parseSkillDocument(raw, label);
+  assertRequiredFields(frontmatter, ["name", "description"], label);
+  const companionFile = join(SRC, "drive", "SKILL.claude-code.md");
+  const companionRaw = await readFile(companionFile, "utf8");
+  const companion = parseSkillDocument(companionRaw, ".agents/skills/drive/SKILL.claude-code.md");
+  const drive = {
+    name: frontmatter.name,
+    description: frontmatter.description,
+    frontmatter,
+    body,
+    raw,
+    claudeCodeCompanion: companion,
+  };
+  const out = await new ClaudeCodeAdapter().generate([drive]);
+  const driveOut = out.find((o) => o.relativePath === ".claude/skills/drive/SKILL.md");
+  assert.ok(driveOut, "claude-code adapter emits .claude/skills/drive/SKILL.md");
+  // the emitted overlay reuses the saved original-argument list for the resume line
+  assert.ok(
+    driveOut.content.includes(RESUME_LINE),
+    "built output must carry the resume-line command",
+  );
+  assert.ok(
+    driveOut.content.includes("Phase 5") && driveOut.content.includes("Final-6"),
+    "built output must point the resume line at the Phase 5 / Final-6 reports",
+  );
+  // restoration convention preserved in the built output
+  assert.ok(
+    driveOut.content.includes("`--no-usage-guard` がユーザー指定されていた場合のみ"),
+    "built output must keep the --no-usage-guard carry-only-when-user-specified rule",
+  );
+  assert.ok(
+    !driveOut.content.includes("/drive --usage-guard"),
+    "built output must not force --usage-guard in any restored command",
+  );
+});


### PR DESCRIPTION
## Summary

drive は冪等 resume を実装済み（既存 PR / ブランチ検出で Phase 3 から再開、merged 済み PR 検出でオーケストレーションの残りを続行）だが、失敗時レポートに「どう再開するか」が出力されず発見可能性がなかった。本 PR でレポート末尾に再開コマンド行を必ず出すよう SKILL.md を改訂する。

## Changes

- **`.agents/skills/drive/SKILL.md`**（SSOT）
  - 「入力解析」に `### 引数復元（再開コマンド）` を新設: 元の引数をそのまま再掲、usage-guard 継続コマンド規約と同一（`--no-usage-guard` はユーザー指定時のみ引き継ぐ / `--usage-guard` は deprecated no-op のため保存・付与しない）
  - Phase 5 完了報告テンプレートに `再開:     /drive <元の引数>` 行を追加。状態が `failed` / `merge-ready` のとき必ず出力、`merged` / `auto-merge enabled` で完結した場合は表示しない
  - Phase Final-6 集約レポートに同再開行を追加。`failed` / `merge-ready` 残置 / `skipped` が 1 件以上あるとき集計ブロック直後に必ず出力、全 target merged なら表示しない
  - 「失敗 semantics」表の直後に共通再開手段の注記を追加
- **`.agents/skills/drive/SKILL.claude-code.md`**（overlay）: 保存済み引数列の用途に失敗時レポート再開行（Phase 5 / Final-6）を追記（built claude-code 出力にも emit される）
- **`dist/` / `.claude/skills/`**: `pnpm build` で再生成（手編集なし）
- **`tests/drive-resume.test.mjs`**（新設）: doc-content assertion
  - Phase 5 / Final-6 の両セクションに `再開: /drive` が存在（section-anchored）
  - 引数復元規約（`--no-usage-guard` のみ引き継ぐ）が入力解析節に存在
  - 「全 target merged のとき表示しない」条件の文書化
  - built claude-code 出力（`ClaudeCodeAdapter` 経由）にも同記述が emit される

## Test plan

- [x] `pnpm build`（dist / dogfood mirror 再生成、diff 込みでコミット）
- [x] `pnpm test` 343 pass（新規 5 test 含む）
- [x] `pnpm run lint`（biome）green
- [x] `markdownlint-cli2` 変更 10 .md ファイル 0 error

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)