### PR TITLE
feat(cli): hooks add/remove to wire usage-guard/observability hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,33 @@ Supported adapters: `claude-code`, `codex-cli`, `gemini-cli`, `copilot`. On an *
 | `remove` (alias `uninstall`) | Uninstall skills. Confirmation required (TTY prompt or `--yes`). `--skills` required. |
 | `fork <skill> <new-name>` | Copy an installed skill to a user-owned, unmanaged name (free to edit; never touched by update/remove). |
 | `diff <skill>` | Show a skill's local edits vs the current upstream. |
+| `hooks <add\|remove> <name>` | Wire/unwire an optional Claude Code hook (`usage-guard`, `observability`) into your local settings. Resolves the script's absolute path, previews a diff, confirms (`--yes` non-interactively). |
 
 ### State & editable skills
 
 Installed skills are **editable** — edit them in place under their own name. The CLI tracks what it installed with **per-item provenance markers** (`.ozzylabs-skills.json` co-located in each skill dir; no central registry). The shared `.agents/skills/<name>` base is **reference-counted** across adapters (removing one adapter keeps the base while another needs it). `update` baselines each skill's content hash so it can detect — and refuse to clobber — your local edits.
 
 Project scope (`--target`) writes the committed payload (`.claude/skills/` wrappers + canonical `.agents/skills/` + `.claude/agents/`) with repo-root-relative refs preserved. The legacy `sync-project` and `migrate` subcommands have been removed — use `add --target <repo>`. For edited skills, `update --merge` does a 3-way merge (base = the install-time snapshot, mine = your edits, theirs = current upstream); conflicts are left with standard `<<<<<<<` markers.
+
+### Hook wiring
+
+Two skills ship an optional Claude Code hook as an extra file: usage-guard's PreToolUse ceiling (`usage-guard-hook.mjs`) and skill-observability's SessionEnd capture (`obs-derive.mjs`). Enabling one means adding a hook entry whose `command` is the **absolute** path to that script — and that path differs between a user-scope install (`~/.claude/skills/…`) and dogfooding inside this repo (`<repo>/.claude/skills/…`). `hooks add` resolves it for you:
+
+```bash
+# Wire usage-guard's PreToolUse ceiling into ~/.claude/settings.local.json
+npx @ozzylabs/skills hooks add usage-guard
+
+# Wire skill-observability's SessionEnd capture; --scope=user targets settings.json
+npx @ozzylabs/skills hooks add observability --scope=user
+
+# Preview the settings diff without writing anything
+npx @ozzylabs/skills hooks add usage-guard --dry-run
+
+# Remove only the entry this CLI wrote (other hooks stay untouched)
+npx @ozzylabs/skills hooks remove usage-guard
+```
+
+`hooks add` resolves the script from the installed skill dir (run `add --skills=usage-guard` first if it is missing), previews the settings diff, and asks before writing (`--yes` is required on non-interactive / CI runs). It edits `settings.local.json` by default (`--scope=user` for `settings.json`), is idempotent (a re-add is a no-op), only ever touches the entries it owns, and refuses to overwrite an unparseable settings file. The repo still ships no settings/hooks — this only writes your local settings on request.
 
 ## Consumer setup
 

--- a/bin/lib/hooks.mjs
+++ b/bin/lib/hooks.mjs
@@ -1,0 +1,393 @@
+// `skills hooks add|remove` — wire the optional Claude Code hooks that ship as
+// extra files inside a skill directory (ozzy-labs/skills#174 PR 1).
+//
+// Two hooks are opt-in today and require a hand-written absolute path in
+// settings: usage-guard's PreToolUse ceiling (`usage-guard-hook.mjs`) and
+// skill-observability's SessionEnd capture (`obs-derive.mjs`). This verb resolves
+// the script's absolute path from the installed skill directory and read-modify-
+// writes it into `~/.claude/settings.local.json` (or `settings.json` with
+// `--scope=user`), so the user never hand-copies a path. It only ever touches the
+// entries it owns (identified by the script filename in the `command`), preserves
+// every other entry byte-for-byte, and refuses to overwrite a settings file it
+// cannot parse. The repo still ships no settings/hooks — the CLI just writes local
+// settings on explicit user consent (same dry-run / diff / confirm UX as `remove`).
+
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { parseFlags } from "./args.mjs";
+import { didYouMean } from "./detect.mjs";
+import { findPackageRoot } from "./install.mjs";
+import { readInstalled } from "./installed.mjs";
+import { confirm } from "./prompt.mjs";
+
+// The hook definition table. `skill` is the installed skill directory name that
+// carries `script`; `event` + `matcher` describe the Claude Code settings entry.
+// SessionEnd entries carry no matcher (matcher: null → omitted from the entry).
+export const HOOK_DEFS = {
+  "usage-guard": {
+    skill: "usage-guard",
+    event: "PreToolUse",
+    matcher: "*",
+    script: "usage-guard-hook.mjs",
+  },
+  observability: {
+    skill: "skill-observability",
+    event: "SessionEnd",
+    matcher: null,
+    script: "obs-derive.mjs",
+  },
+};
+
+const HOOK_NAMES = Object.keys(HOOK_DEFS);
+
+const HELP = `npx @ozzylabs/skills hooks <add|remove> <${HOOK_NAMES.join("|")}> [options]
+
+Wire (or unwire) an optional Claude Code hook shipped with a skill. The hook
+script's absolute path is resolved from the installed skill dir and written into
+your local Claude settings. Only entries this CLI owns are ever modified.
+
+Hooks:
+  usage-guard     PreToolUse ceiling (usage-guard-hook.mjs, matcher "*").
+  observability   SessionEnd capture (obs-derive.mjs).
+
+Options:
+  --scope=<user|local>  Settings file to edit: 'local' → settings.local.json
+                        (default), 'user' → settings.json.
+  --dry-run             Print the diff + JSON plan and exit. Writes nothing.
+  --yes                 Skip the confirmation prompt (required non-interactively).
+  -h, --help            Show this help.
+`;
+
+const SCHEMA = {
+  scope: "string",
+  "dry-run": "boolean",
+  yes: "boolean",
+  help: "boolean",
+};
+const ALIASES = { h: "help" };
+
+/** The absolute command string written into settings for a resolved script. */
+export function buildCommand(scriptPath) {
+  return `node ${scriptPath}`;
+}
+
+/** True when a settings `command` string invokes our hook script (by filename). */
+function commandReferencesScript(command, scriptName) {
+  return typeof command === "string" && command.includes(scriptName);
+}
+
+/**
+ * Resolve the absolute path of a hook's script from the first scope root that has
+ * the owning skill installed. Two layouts are honored:
+ *   1. marker-verified installs (user-scope `add`) — the skill dir carries a
+ *      provenance marker, so `readInstalled` finds it.
+ *   2. build-output layout (dogfooding inside skills/commons, or a project-scope
+ *      `--target` payload) — `<root>/.claude/skills/<skill>/<script>` exists but
+ *      carries no marker; accepted as a direct fallback.
+ * Returns null when no root has the script (caller surfaces an install hint).
+ *
+ * @param {string[]} scopeRoots
+ * @param {{ skill: string, script: string }} def
+ * @returns {Promise<string | null>}
+ */
+export async function resolveScriptPath(scopeRoots, def) {
+  for (const root of scopeRoots) {
+    // (1) marker-verified install.
+    const installed = await readInstalled(root);
+    const entry = installed.get(def.skill);
+    if (entry) {
+      for (const dir of entry.dirs) {
+        const scriptPath = join(dir, def.script);
+        if (existsSync(scriptPath)) return scriptPath;
+      }
+    }
+    // (2) build-output layout fallback (no marker).
+    const direct = join(root, ".claude", "skills", def.skill, def.script);
+    if (existsSync(direct)) return direct;
+  }
+  return null;
+}
+
+/**
+ * Pure: return a new settings object with the hook entry added, plus whether it
+ * changed. Idempotent — if the event bucket already has an entry invoking our
+ * script (any path / env prefix), nothing is added.
+ *
+ * @param {object} settings
+ * @param {{ event: string, matcher: string | null, script: string }} def
+ * @param {string} command
+ * @returns {{ settings: object, changed: boolean }}
+ */
+export function addHookEntry(settings, def, command) {
+  const next = structuredClone(settings);
+  if (!next.hooks || typeof next.hooks !== "object" || Array.isArray(next.hooks)) {
+    next.hooks = {};
+  }
+  if (!Array.isArray(next.hooks[def.event])) next.hooks[def.event] = [];
+  const bucket = next.hooks[def.event];
+
+  for (const group of bucket) {
+    if (!group || !Array.isArray(group.hooks)) continue;
+    for (const h of group.hooks) {
+      if (commandReferencesScript(h?.command, def.script)) {
+        return { settings, changed: false }; // already wired — idempotent skip
+      }
+    }
+  }
+
+  const hookEntry = { type: "command", command };
+  const entry = def.matcher
+    ? { matcher: def.matcher, hooks: [hookEntry] }
+    : { hooks: [hookEntry] };
+  bucket.push(entry);
+  return { settings: next, changed: true };
+}
+
+/**
+ * Pure: return a new settings object with only OUR hook entries removed (matched
+ * by the script filename in the `command`). Groups we empty are dropped; every
+ * other group — including pre-existing empty ones and other hooks in a shared
+ * group — is preserved untouched.
+ *
+ * @param {object} settings
+ * @param {{ event: string, script: string }} def
+ * @returns {{ settings: object, changed: boolean }}
+ */
+export function removeHookEntry(settings, def) {
+  const bucket = settings?.hooks?.[def.event];
+  if (!Array.isArray(bucket)) return { settings, changed: false };
+
+  const next = structuredClone(settings);
+  let changed = false;
+  const kept = [];
+  for (const group of next.hooks[def.event]) {
+    if (!group || !Array.isArray(group.hooks)) {
+      kept.push(group);
+      continue;
+    }
+    const before = group.hooks.length;
+    const remaining = group.hooks.filter((h) => !commandReferencesScript(h?.command, def.script));
+    if (remaining.length === before) {
+      kept.push(group); // untouched — preserve exactly
+      continue;
+    }
+    changed = true;
+    if (remaining.length > 0) kept.push({ ...group, hooks: remaining });
+    // else: we emptied this group → drop it
+  }
+
+  if (!changed) return { settings, changed: false };
+  if (kept.length === 0) {
+    delete next.hooks[def.event];
+    if (Object.keys(next.hooks).length === 0) delete next.hooks;
+  } else {
+    next.hooks[def.event] = kept;
+  }
+  return { settings: next, changed: true };
+}
+
+/**
+ * Minimal LCS line diff. Returns `+`/`-`/`  ` prefixed lines (the caller filters
+ * to changed lines for display). Dependency-free — settings files are small.
+ *
+ * @param {string} before
+ * @param {string} after
+ * @returns {string[]}
+ */
+export function diffLines(before, after) {
+  const a = before.length ? before.split("\n") : [];
+  const b = after.length ? after.split("\n") : [];
+  const m = a.length;
+  const n = b.length;
+  const dp = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+  const out = [];
+  let i = 0;
+  let j = 0;
+  while (i < m && j < n) {
+    if (a[i] === b[j]) {
+      out.push(`  ${a[i]}`);
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      out.push(`- ${a[i]}`);
+      i++;
+    } else {
+      out.push(`+ ${b[j]}`);
+      j++;
+    }
+  }
+  while (i < m) out.push(`- ${a[i++]}`);
+  while (j < n) out.push(`+ ${b[j++]}`);
+  return out;
+}
+
+/** Read + validate the settings file. Returns { settings } or { error }. */
+async function readSettings(settingsFile) {
+  if (!existsSync(settingsFile)) return { settings: {} };
+  let raw;
+  try {
+    raw = await readFile(settingsFile, "utf8");
+  } catch (err) {
+    return { error: `cannot read ${settingsFile}: ${err.message}` };
+  }
+  if (raw.trim().length === 0) return { settings: {} };
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {
+      error: `${settingsFile} is not valid JSON — refusing to overwrite. Fix it by hand and retry.`,
+    };
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { error: `${settingsFile} does not contain a JSON object — refusing to overwrite.` };
+  }
+  return { settings: parsed };
+}
+
+/**
+ * @param {string[]} argv args past the `hooks` subcommand keyword
+ * @param {{ isTTY?: boolean, scopeRoots?: string[] }} [opts] `scopeRoots` overrides
+ *   the resolution roots (tests inject an empty root to exercise the not-installed
+ *   path, which the dogfood build-output fallback would otherwise always resolve).
+ * @returns {Promise<number>} exit code
+ */
+export async function runHooks(argv, opts = {}) {
+  let parsed;
+  try {
+    parsed = parseFlags(argv, SCHEMA, ALIASES);
+  } catch (err) {
+    process.stderr.write(`error: ${err.message}\n\n${HELP}`);
+    return 1;
+  }
+  if (parsed.values.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+
+  const positionals = parsed.rejected.filter((a) => !a.startsWith("-"));
+  const unknownFlags = parsed.rejected.filter((a) => a.startsWith("-"));
+  if (unknownFlags.length > 0) {
+    process.stderr.write(`error: unknown argument(s): ${unknownFlags.join(", ")}\n\n${HELP}`);
+    return 1;
+  }
+
+  const [action, name] = positionals;
+  if (action !== "add" && action !== "remove") {
+    process.stderr.write(
+      `error: expected 'add' or 'remove'${action ? ` (got '${action}')` : ""}\n\n${HELP}`,
+    );
+    return 1;
+  }
+  if (!name) {
+    process.stderr.write(`error: hooks ${action} requires a hook name (${HOOK_NAMES.join(" | ")})\n`);
+    return 1;
+  }
+  const def = HOOK_DEFS[name];
+  if (!def) {
+    process.stderr.write(
+      `error: unknown hook '${name}'${didYouMean(name, HOOK_NAMES)} (choose from: ${HOOK_NAMES.join(", ")})\n`,
+    );
+    return 1;
+  }
+
+  const scope = parsed.values.scope ?? "local";
+  if (scope !== "user" && scope !== "local") {
+    process.stderr.write(`error: --scope must be 'user' or 'local' (got '${scope}')\n`);
+    return 1;
+  }
+
+  const base = process.env.OZZYLABS_SKILLS_HOME ?? homedir();
+  const claudeDir = join(base, ".claude");
+  const settingsFile = join(claudeDir, scope === "user" ? "settings.json" : "settings.local.json");
+
+  const read = await readSettings(settingsFile);
+  if (read.error) {
+    process.stderr.write(`error: ${read.error}\n`);
+    return 1;
+  }
+  const currentSettings = read.settings;
+
+  let command = null;
+  let result;
+  if (action === "add") {
+    let scopeRoots = opts.scopeRoots;
+    if (!scopeRoots) {
+      const packageRoot = await findPackageRoot().catch(() => null);
+      scopeRoots = packageRoot ? [base, packageRoot] : [base];
+    }
+    const scriptPath = await resolveScriptPath(scopeRoots, def);
+    if (!scriptPath) {
+      process.stderr.write(
+        `error: '${def.skill}' is not installed — run \`npx @ozzylabs/skills add --skills=${def.skill}\` first.\n`,
+      );
+      return 1;
+    }
+    command = buildCommand(scriptPath);
+    result = addHookEntry(currentSettings, def, command);
+  } else {
+    result = removeHookEntry(currentSettings, def);
+  }
+
+  if (!result.changed) {
+    process.stdout.write(
+      action === "add"
+        ? `Hook '${name}' (${def.event}) is already wired in ${settingsFile}. Nothing to do.\n`
+        : `Hook '${name}' (${def.event}) is not present in ${settingsFile}. Nothing to do.\n`,
+    );
+    return 0;
+  }
+
+  const beforeStr = JSON.stringify(currentSettings, null, 2);
+  const afterStr = JSON.stringify(result.settings, null, 2);
+  const diff = diffLines(beforeStr, afterStr)
+    .filter((l) => l.startsWith("+") || l.startsWith("-"))
+    .join("\n");
+
+  const header =
+    action === "add"
+      ? `hooks add ${name} → ${settingsFile}\n  + ${def.event}${def.matcher ? ` (matcher: ${def.matcher})` : ""}: ${command}`
+      : `hooks remove ${name} → ${settingsFile}\n  - ${def.event} entries referencing ${def.script}`;
+  process.stdout.write(`${header}\n\nDiff:\n${diff}\n`);
+
+  const summary = {
+    action,
+    name,
+    event: def.event,
+    settings_file: settingsFile,
+    ...(command ? { command } : {}),
+    changed: true,
+  };
+
+  if (parsed.values["dry-run"]) {
+    process.stdout.write(`${JSON.stringify({ ...summary, dry_run: true }, null, 2)}\n`);
+    return 0;
+  }
+
+  const isTTY = opts.isTTY ?? Boolean(process.stdin.isTTY);
+  if (!parsed.values.yes) {
+    if (!isTTY) {
+      process.stderr.write("error: refusing to modify settings non-interactively — pass --yes.\n");
+      return 1;
+    }
+    const ok = await confirm("Proceed?", false);
+    if (!ok) {
+      process.stdout.write("Aborted.\n");
+      return 0;
+    }
+  }
+
+  await mkdir(claudeDir, { recursive: true });
+  await writeFile(settingsFile, `${afterStr}\n`);
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  return 0;
+}
+
+export { HELP };

--- a/bin/skills.mjs
+++ b/bin/skills.mjs
@@ -8,6 +8,7 @@
 //   remove  Uninstall skills (with confirmation).
 //   fork    Copy a skill to a user-owned, unmanaged name.
 //   diff    Show a skill's local diff against upstream.
+//   hooks   Wire/unwire optional Claude Code hooks shipped with a skill (#174).
 //
 // `install`/`uninstall` are accepted as aliases for `add`/`remove`. Scope is
 // expressed by `--target` (absent = user, present = project repo). See #151 for
@@ -17,11 +18,12 @@ import { runAdd } from "./lib/add.mjs";
 import { didYouMean } from "./lib/detect.mjs";
 import { runDiff } from "./lib/diff.mjs";
 import { runFork } from "./lib/fork.mjs";
+import { runHooks } from "./lib/hooks.mjs";
 import { runList } from "./lib/list.mjs";
 import { runRemove } from "./lib/remove.mjs";
 import { runUpdate } from "./lib/update.mjs";
 
-const VERBS = ["add", "update", "list", "remove", "fork", "diff"];
+const VERBS = ["add", "update", "list", "remove", "fork", "diff", "hooks"];
 const VERB_ALIASES = { install: "add", uninstall: "remove" };
 
 const TOP_LEVEL_HELP = `npx @ozzylabs/skills <verb> [options]
@@ -34,6 +36,8 @@ Verbs:
   remove     Uninstall skills (confirmation required). Alias: uninstall.
   fork       Copy a skill to a user-owned name.
   diff       Show a skill's diff against upstream.
+  hooks      Wire/unwire an optional Claude Code hook shipped with a skill
+             (usage-guard, observability) into your local settings.
 
 Run 'npx @ozzylabs/skills <verb> --help' for verb-specific options.
 `;
@@ -66,6 +70,9 @@ async function main(argv) {
   }
   if (verb === "diff") {
     return await runDiff(rest);
+  }
+  if (verb === "hooks") {
+    return await runHooks(rest);
   }
 
   process.stderr.write(

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -81,6 +81,26 @@ npx @ozzylabs/skills add --target=./my-repo
 
 旧 `sync-project` / `migrate` subcommand は撤去済み（project scope は `add --target`）。編集済み skill には `update --merge` で 3-way マージ（base=install 時スナップショット / mine=編集 / theirs=現上流。conflict は `<<<<<<<` マーカーで残す）。
 
+### Hook 配線
+
+2 つの skill は Claude Code hook を extra file として同梱する: usage-guard の PreToolUse ceiling（`usage-guard-hook.mjs`）と skill-observability の SessionEnd capture（`obs-derive.mjs`）。有効化には hook エントリの `command` に **絶対パス**を書く必要があり、そのパスは user-scope install（`~/.claude/skills/…`）と本リポでの dogfood（`<repo>/.claude/skills/…`）で異なる。`hooks add` がこのパスを自動解決する:
+
+```bash
+# usage-guard の PreToolUse ceiling を ~/.claude/settings.local.json に配線
+npx @ozzylabs/skills hooks add usage-guard
+
+# skill-observability の SessionEnd capture を配線（--scope=user で settings.json）
+npx @ozzylabs/skills hooks add observability --scope=user
+
+# 書き込まずに settings の diff を確認（非対話/CI では適用に --yes 必須）
+npx @ozzylabs/skills hooks add usage-guard --dry-run
+
+# CLI が書いたエントリのみ削除（他の hook はそのまま）
+npx @ozzylabs/skills hooks remove usage-guard
+```
+
+install 済み skill dir から script を解決し（無ければ先に `add --skills=usage-guard`）、settings の diff を提示してから確認する（非対話では `--yes` 必須）。既定は `settings.local.json`（`--scope=user` で `settings.json`）を編集し、再 add は冪等 no-op、自分が書いたエントリのみ操作し、壊れた JSON settings は上書きしない。リポは依然 settings/hooks を配信せず、要求時にローカル settings を書くだけ。
+
 ## Consumer セットアップ
 
 skills を **user skills** として 1 コマンドで install する:

--- a/tests/cli-hooks.test.mjs
+++ b/tests/cli-hooks.test.mjs
@@ -1,0 +1,392 @@
+// Tests for `skills hooks add|remove` (ozzy-labs/skills#174 PR 1).
+//
+// Split like the rest of the CLI suite: the pure settings transforms + path
+// resolution are unit-tested directly, and the end-to-end wiring runs the actual
+// `bin/skills.mjs` entry point as a child process against a temporary HOME (via
+// OZZYLABS_SKILLS_HOME), mirroring `cli-install.test.mjs` / `cli-e2e.test.mjs`.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  addHookEntry,
+  buildCommand,
+  HOOK_DEFS,
+  removeHookEntry,
+  resolveScriptPath,
+  runHooks,
+} from "../bin/lib/hooks.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const BIN = join(ROOT, "bin", "skills.mjs");
+
+const UG = HOOK_DEFS["usage-guard"];
+const OBS = HOOK_DEFS.observability;
+
+function runCli(args, options = {}) {
+  return spawnSync("node", [BIN, ...args], {
+    cwd: options.cwd ?? ROOT,
+    env: { ...process.env, ...(options.home ? { OZZYLABS_SKILLS_HOME: options.home } : {}) },
+    encoding: "utf8",
+  });
+}
+
+/** Materialize a build-output-style skill dir (no provenance marker). */
+function seedBuildOutput(root, skill, script) {
+  const dir = join(root, ".claude", "skills", skill);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, script), "// hook\n");
+  return join(dir, script);
+}
+
+/** Materialize a marker-verified (user-scope install style) skill dir. */
+function seedInstalled(root, skill, script) {
+  const p = seedBuildOutput(root, skill, script);
+  writeFileSync(
+    join(dirname(p), ".ozzylabs-skills.json"),
+    JSON.stringify({
+      schema: 1,
+      source: "@ozzylabs/skills",
+      bundleVersion: "1.0.0",
+      adapters: ["claude-code"],
+    }),
+  );
+  return p;
+}
+
+// ── pure transforms ─────────────────────────────────────────────────────────
+
+test("buildCommand prefixes the absolute script path with node", () => {
+  assert.equal(buildCommand("/abs/usage-guard-hook.mjs"), "node /abs/usage-guard-hook.mjs");
+});
+
+test("addHookEntry seeds hooks.PreToolUse with a matcher on empty settings", () => {
+  const { settings, changed } = addHookEntry({}, UG, "node /x/usage-guard-hook.mjs");
+  assert.equal(changed, true);
+  assert.deepEqual(settings.hooks.PreToolUse, [
+    { matcher: "*", hooks: [{ type: "command", command: "node /x/usage-guard-hook.mjs" }] },
+  ]);
+});
+
+test("addHookEntry omits matcher for SessionEnd (observability)", () => {
+  const { settings } = addHookEntry({}, OBS, "node /x/obs-derive.mjs");
+  const entry = settings.hooks.SessionEnd[0];
+  assert.ok(!("matcher" in entry), "SessionEnd entry must not carry a matcher");
+  assert.deepEqual(entry.hooks, [{ type: "command", command: "node /x/obs-derive.mjs" }]);
+});
+
+test("addHookEntry appends to an existing PreToolUse array and preserves foreign entries", () => {
+  const existing = {
+    hooks: {
+      PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "bash ./other.sh" }] }],
+    },
+  };
+  const { settings, changed } = addHookEntry(existing, UG, "node /x/usage-guard-hook.mjs");
+  assert.equal(changed, true);
+  assert.equal(settings.hooks.PreToolUse.length, 2);
+  assert.equal(settings.hooks.PreToolUse[0].hooks[0].command, "bash ./other.sh");
+  assert.equal(existing.hooks.PreToolUse.length, 1, "input settings must not be mutated");
+});
+
+test("addHookEntry is idempotent — a second add (even with a different path) is a no-op", () => {
+  const first = addHookEntry({}, UG, "node /a/usage-guard-hook.mjs");
+  const second = addHookEntry(first.settings, UG, "node /b/usage-guard-hook.mjs");
+  assert.equal(second.changed, false);
+  assert.strictEqual(second.settings, first.settings, "unchanged object returned as-is");
+});
+
+test("removeHookEntry deletes only our entry, keeping foreign hooks and other events", () => {
+  const settings = {
+    hooks: {
+      PreToolUse: [
+        { matcher: "Bash", hooks: [{ type: "command", command: "bash ./other.sh" }] },
+        { matcher: "*", hooks: [{ type: "command", command: "node /x/usage-guard-hook.mjs" }] },
+      ],
+      PostToolUse: [{ hooks: [{ type: "command", command: "node /x/audit.mjs" }] }],
+    },
+  };
+  const { settings: out, changed } = removeHookEntry(settings, UG);
+  assert.equal(changed, true);
+  assert.equal(out.hooks.PreToolUse.length, 1, "our emptied group is dropped");
+  assert.equal(out.hooks.PreToolUse[0].hooks[0].command, "bash ./other.sh");
+  assert.deepEqual(out.hooks.PostToolUse, settings.hooks.PostToolUse, "other events untouched");
+});
+
+test("removeHookEntry keeps a shared group but strips our command from it", () => {
+  const settings = {
+    hooks: {
+      PreToolUse: [
+        {
+          matcher: "*",
+          hooks: [
+            { type: "command", command: "node /x/usage-guard-hook.mjs" },
+            { type: "command", command: "node /x/keep-me.mjs" },
+          ],
+        },
+      ],
+    },
+  };
+  const { settings: out, changed } = removeHookEntry(settings, UG);
+  assert.equal(changed, true);
+  assert.deepEqual(out.hooks.PreToolUse[0].hooks, [
+    { type: "command", command: "node /x/keep-me.mjs" },
+  ]);
+});
+
+test("removeHookEntry on absent hook is a no-op", () => {
+  const settings = { hooks: { PreToolUse: [] } };
+  const { changed } = removeHookEntry(settings, UG);
+  assert.equal(changed, false);
+});
+
+// ── path resolution ─────────────────────────────────────────────────────────
+
+test("resolveScriptPath resolves a marker-verified (user-scope) install", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skills-hooks-"));
+  try {
+    const expected = seedInstalled(root, "usage-guard", "usage-guard-hook.mjs");
+    assert.equal(await resolveScriptPath([root], UG), expected);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("resolveScriptPath resolves a dogfood build-output dir with no marker", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skills-hooks-"));
+  try {
+    const expected = seedBuildOutput(root, "skill-observability", "obs-derive.mjs");
+    assert.equal(await resolveScriptPath([root], OBS), expected);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("resolveScriptPath returns null when the skill is not installed anywhere", async () => {
+  const root = await mkdtemp(join(tmpdir(), "skills-hooks-"));
+  try {
+    assert.equal(await resolveScriptPath([root], UG), null);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// ── not-installed error (in-process, injected empty scope root) ──────────────
+
+test("runHooks add errors with an install hint when the skill is not installed", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-hooks-"));
+  const empty = await mkdtemp(join(tmpdir(), "skills-empty-"));
+  const prevHome = process.env.OZZYLABS_SKILLS_HOME;
+  const captured = { out: "", err: "" };
+  const so = process.stdout.write.bind(process.stdout);
+  const se = process.stderr.write.bind(process.stderr);
+  process.stdout.write = (s) => {
+    captured.out += s;
+    return true;
+  };
+  process.stderr.write = (s) => {
+    captured.err += s;
+    return true;
+  };
+  try {
+    process.env.OZZYLABS_SKILLS_HOME = home;
+    const code = await runHooks(["add", "usage-guard", "--yes"], {
+      isTTY: false,
+      scopeRoots: [empty],
+    });
+    assert.equal(code, 1);
+    assert.match(captured.err, /not installed/);
+    assert.match(captured.err, /add --skills=usage-guard/);
+  } finally {
+    process.stdout.write = so;
+    process.stderr.write = se;
+    if (prevHome === undefined) delete process.env.OZZYLABS_SKILLS_HOME;
+    else process.env.OZZYLABS_SKILLS_HOME = prevHome;
+    await rm(home, { recursive: true, force: true });
+    await rm(empty, { recursive: true, force: true });
+  }
+});
+
+// ── end-to-end (child process) ───────────────────────────────────────────────
+
+test("e2e: hooks add refuses to write non-interactively without --yes", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-hooks-e2e-"));
+  try {
+    runCli(["add", "--adapter=claude-code", "--skills=usage-guard", "--force"], { home });
+    const r = runCli(["hooks", "add", "usage-guard"], { home });
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /--yes/);
+    assert.ok(
+      !existsSync(join(home, ".claude", "settings.local.json")),
+      "nothing written without confirmation",
+    );
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: hooks remove refuses to write non-interactively without --yes", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-hooks-e2e-"));
+  try {
+    runCli(["add", "--adapter=claude-code", "--skills=usage-guard", "--force"], { home });
+    runCli(["hooks", "add", "usage-guard", "--yes"], { home });
+    const r = runCli(["hooks", "remove", "usage-guard"], { home });
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /--yes/);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: hooks add usage-guard wires an absolute path into settings.local.json", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-hooks-e2e-"));
+  try {
+    const add = runCli(["add", "--adapter=claude-code", "--skills=usage-guard", "--force"], {
+      home,
+    });
+    assert.equal(add.status, 0, `install failed: ${add.stderr}`);
+
+    const r = runCli(["hooks", "add", "usage-guard", "--yes"], { home });
+    assert.equal(r.status, 0, `hooks add failed: ${r.stderr}`);
+
+    const settingsFile = join(home, ".claude", "settings.local.json");
+    const settings = JSON.parse(readFileSync(settingsFile, "utf8"));
+    const entry = settings.hooks.PreToolUse[0];
+    assert.equal(entry.matcher, "*");
+    const expected = join(home, ".claude", "skills", "usage-guard", "usage-guard-hook.mjs");
+    assert.equal(entry.hooks[0].command, `node ${expected}`);
+    assert.ok(entry.hooks[0].command.includes(home), "command is an absolute path under HOME");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: hooks add observability wires a SessionEnd entry (no matcher)", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-hooks-e2e-"));
+  try {
+    runCli(["add", "--adapter=claude-code", "--skills=skill-observability", "--force"], { home });
+    const r = runCli(["hooks", "add", "observability", "--yes"], { home });
+    assert.equal(r.status, 0, `hooks add failed: ${r.stderr}`);
+    const settings = JSON.parse(readFileSync(join(home, ".claude", "settings.local.json"), "utf8"));
+    const entry = settings.hooks.SessionEnd[0];
+    assert.ok(!("matcher" in entry), "SessionEnd carries no matcher");
+    assert.match(entry.hooks[0].command, /obs-derive\.mjs$/);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: a second hooks add is an idempotent no-op", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-hooks-e2e-"));
+  try {
+    runCli(["add", "--adapter=claude-code", "--skills=usage-guard", "--force"], { home });
+    runCli(["hooks", "add", "usage-guard", "--yes"], { home });
+    const settingsFile = join(home, ".claude", "settings.local.json");
+    const before = readFileSync(settingsFile, "utf8");
+
+    const r = runCli(["hooks", "add", "usage-guard", "--yes"], { home });
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /already wired|Nothing to do/i);
+    assert.equal(readFileSync(settingsFile, "utf8"), before, "settings unchanged on repeat add");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: hooks add refuses to overwrite an unparseable settings file", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-hooks-e2e-"));
+  try {
+    runCli(["add", "--adapter=claude-code", "--skills=usage-guard", "--force"], { home });
+    const settingsFile = join(home, ".claude", "settings.local.json");
+    mkdirSync(dirname(settingsFile), { recursive: true });
+    writeFileSync(settingsFile, "{ not valid json ");
+
+    const r = runCli(["hooks", "add", "usage-guard", "--yes"], { home });
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /not valid JSON/);
+    assert.equal(readFileSync(settingsFile, "utf8"), "{ not valid json ", "corrupt file untouched");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: --scope=user writes settings.json instead of settings.local.json", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-hooks-e2e-"));
+  try {
+    runCli(["add", "--adapter=claude-code", "--skills=usage-guard", "--force"], { home });
+    const r = runCli(["hooks", "add", "usage-guard", "--scope=user", "--yes"], { home });
+    assert.equal(r.status, 0, r.stderr);
+    assert.ok(existsSync(join(home, ".claude", "settings.json")), "settings.json written");
+    assert.ok(
+      !existsSync(join(home, ".claude", "settings.local.json")),
+      "settings.local.json not touched under --scope=user",
+    );
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: hooks remove deletes only our entry, preserving foreign hooks", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-hooks-e2e-"));
+  try {
+    runCli(["add", "--adapter=claude-code", "--skills=usage-guard", "--force"], { home });
+    runCli(["hooks", "add", "usage-guard", "--yes"], { home });
+
+    // Inject a foreign PreToolUse entry the CLI must not touch.
+    const settingsFile = join(home, ".claude", "settings.local.json");
+    const settings = JSON.parse(readFileSync(settingsFile, "utf8"));
+    settings.hooks.PreToolUse.unshift({
+      matcher: "Bash",
+      hooks: [{ type: "command", command: "bash ./guard.sh" }],
+    });
+    writeFileSync(settingsFile, `${JSON.stringify(settings, null, 2)}\n`);
+
+    const r = runCli(["hooks", "remove", "usage-guard", "--yes"], { home });
+    assert.equal(r.status, 0, `remove failed: ${r.stderr}`);
+    const after = JSON.parse(readFileSync(settingsFile, "utf8"));
+    assert.equal(after.hooks.PreToolUse.length, 1, "only our entry removed");
+    assert.equal(after.hooks.PreToolUse[0].hooks[0].command, "bash ./guard.sh");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: hooks remove on an unwired hook is a no-op (exit 0)", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-hooks-e2e-"));
+  try {
+    runCli(["add", "--adapter=claude-code", "--skills=usage-guard", "--force"], { home });
+    const r = runCli(["hooks", "remove", "usage-guard", "--yes"], { home });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /not present|Nothing to do/i);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: hooks --dry-run prints a plan and writes nothing", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-hooks-e2e-"));
+  try {
+    runCli(["add", "--adapter=claude-code", "--skills=usage-guard", "--force"], { home });
+    const r = runCli(["hooks", "add", "usage-guard", "--dry-run"], { home });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /"dry_run": true/);
+    assert.ok(!existsSync(join(home, ".claude", "settings.local.json")), "dry-run wrote nothing");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: an unknown hook name is rejected with a suggestion", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-hooks-e2e-"));
+  try {
+    const r = runCli(["hooks", "add", "usage-gaurd", "--yes"], { home });
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /unknown hook 'usage-gaurd'/);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What

Adds a `hooks` CLI verb (`hooks add` / `hooks remove`) that wires the optional Claude Code hooks shipped as extra files inside a skill directory, so enabling them no longer means hand-copying an absolute path into settings.

Hook definition table:

| Name | Skill dir | Event | Matcher | Script |
| --- | --- | --- | --- | --- |
| `usage-guard` | `usage-guard` | `PreToolUse` | `*` | `usage-guard-hook.mjs` |
| `observability` | `skill-observability` | `SessionEnd` | — | `obs-derive.mjs` |

## How

- **Path resolution** (`resolveScriptPath`): resolves the script's absolute path from the installed skill dir — marker-verified user-scope installs (`~/.claude/skills/…`, via `readInstalled`) and dogfood/project build-output layout (`<repo>/.claude/skills/…`, no marker) are both honored. Missing → errors with an `add --skills=<skill>` hint.
- **Settings write**: read-modify-writes `~/.claude/settings.local.json` (default) or `settings.json` (`--scope=user`). Existing structure is preserved; a re-add is an idempotent no-op; a settings file that does not parse is never overwritten (errors instead).
- **Remove**: deletes only the entries this CLI owns (identified by the script filename in `command`); other entries, other hook events, and shared groups are left intact.
- **UX**: previews a settings diff and confirms before writing (`--yes` required on non-interactive / CI runs), mirroring `remove`'s dry-run/diff/confirm flow (`prompt.mjs` reused). `--dry-run` prints the diff + JSON plan and writes nothing.
- The repo still ships **no** settings/hooks (nothing added to the build payload); the CLI only writes local settings on explicit consent.

## Tests

`tests/cli-hooks.test.mjs` (tmp-HOME fixture pattern from `cli-install.test.mjs` / `cli-e2e.test.mjs`): empty-settings add, append to an existing hooks array, idempotent skip, non-destructive error on corrupt JSON, path resolution (user-scope marker + dogfood build-output + not-installed → null and install-hint error), remove touches only our entry, and `--yes` required non-interactively. Plus `--scope=user`, SessionEnd-has-no-matcher, `--dry-run`, and unknown-hook suggestion.

`pnpm build` (no dist change), `pnpm test` (508 pass), and `pnpm run lint` are green. README CLI verbs table gains a `hooks` row + a "Hook wiring" section; `docs/README.ja.md` is synced. Skill set unchanged (catalog tests green).

Refs #174 (PR 1/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015n4J4RWvHAsXNf5pDVypFg
