### PR TITLE
feat(policy): policy-hook.mjs PreToolUse enforcement (R3)

### DIFF
--- a/.agents/skills/policy/SKILL.md
+++ b/.agents/skills/policy/SKILL.md
@@ -96,12 +96,62 @@ fail-safe の作法:
 - **parse 不能なファイル** → そのファイルを無視し `degraded: true`。もう一方のファイル + 既定で解決する（危険クラスの既定は元々 `ask`）。
 - あらゆる失敗で throw せず exit 0。`&&` で連結した caller を壊さない。
 
+## PreToolUse enforcement hook（Claude Code / `policy-hook.mjs`）
+
+prose 層（各 skill の「自アクションを分類して policy を引く」）はあくまで **依頼**であり、モデルが無視・迂回し得る。`policy-hook.mjs`（sibling・`usage-guard-hook.mjs` と同型の PreToolUse hook）は**実行エンジン側の gate 強制**で、これを物理的に塞ぐ。全 tool 呼び出し前（subagent 内含む）に発火し、**特定の不可逆コマンド**を検出したときだけ policy を引いて deny/allow を決める。
+
+| 検出コマンド | 引く action（class） | ゼロコンフィグ既定 gate | hook の挙動 |
+| --- | --- | --- | --- |
+| `gh pr merge …` | `merge`（`irreversible`） | `ask` | deny（exit 2） |
+| `gh release create …` | `release-create`（`irreversible`） | `ask` | deny |
+| `git push --force` / `-f` / `--force-with-lease` | `force-push`（`irreversible`） | `ask` | deny |
+| `npm` / `pnpm` / `yarn publish` | `publish`（`irreversible`） | `ask` | deny |
+
+- **gate → 判定:** 解決した gate が `ask` なら deny（exit 2 + 理由を stderr）、`proceed` / `batch-confirm` なら allow。hook が hard-block するのは `ask` のみ（batch 確認は caller / prose 層の責務）。
+- **narrow gating（全 tool deny 事故の防止）:** policy を引くのは**上表の不可逆コマンドにマッチした時だけ**。それ以外（読取・編集・safe な git/gh/npm・非 Bash tool）は素通し。matcher にバグがあっても「危険コマンドを取りこぼす」方向にしか倒れず、全 tool を deny してセッションを wedge させることはない。
+- **一過性で hard-stop させない（`usage-guard-hook.mjs` から踏襲）:**
+  - **(a) file kill-switch:** `~/.claude/policy-guard/DISABLE` があれば冒頭で即 no-op allow。`!` シェルから `touch` すれば設定編集不要・セッション内で即解除できる。
+  - **(b) policy 読取不能・パース不能 → allow + stderr 警告:** `policy-read.mjs` が `degraded` を返す／resolver が throw する等で **gate を信頼できないとき**は deny せず allow する。gate 対象コマンドの検出はできても gate 値を信頼できないなら通す。**resumable prose-layer checkpoint（drive / health / lessons-triage）が同じ `policy-read.mjs`（fail-safe に `ask`）を引く一次ゲート**であり、hook は二次的な網なので broken policy でセッションを止めない側に倒す。
+  - **(c) proceed 上書き（`--merge` 相当）:** すでに gate を解決し自律を委任された caller（例 `drive --merge` は prose で merge を `proceed` に上書き）は `POLICY_GUARD_PROCEED=<action>[,<action>…]`（`all` / `*` も可）を export する。hook はその action を再ゲートせず allow する。これで正当な opt-in マージが強制網に阻まれない。
+- **subagent:** payload の `agent_id` を deny メッセージに `[origin: subagent <id>]` として付す（走行中 worker の mid-unit ceiling として機能）。
+
+### 配線（本 PR では自動配線しない）
+
+hook スクリプトは全 adapter payload に同梱されるが、**settings への配線は本 PR の scope 外**。将来 `hooks add policy`（[#174](https://github.com/ozzy-labs/skills/issues/174) の hooks CLI に追加予定。現状 `usage-guard` / `observability` のみ対応）が担う。それまでは手動で `~/.claude/settings.local.json` に 1 エントリ追加する（settings は mid-session reload されるため再起動不要）:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /home/<you>/.claude/skills/policy/policy-hook.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+> **hook スクリプトパスは絶対パスを手で埋める**（settings 内では skill-dir 相対参照が効かない）。パスは環境で揺れる:
+>
+> - **user-scope**（`npx @ozzylabs/skills install`）: `~/.claude/skills/policy/policy-hook.mjs`（`~` は展開されないので `/home/<you>/.claude/…` の形でフルに書く）
+> - **dogfood**（skills/commons リポ内）: `<repo>/.claude/skills/policy/policy-hook.mjs`
+>
+> どちらも「`policy-read.mjs` と同じ階層の `policy-hook.mjs`」を指す。matcher は不可逆コマンドが Bash 経由なので `"Bash"` で十分（`"*"` でも可・非 Bash tool は command が無く素通し）。
+
+**無効化:** `touch ~/.claude/policy-guard/DISABLE`（即時・設定編集不要）、または settings から上記エントリを削除（恒久）。
+
 ## 適用範囲
 
-本 skill は **契約（schema）+ 読取 substrate** のみを提供する。以下は本契約の上に別 PR で構築する（本 PR には含めない）:
+本 skill は **契約（schema）+ 読取 substrate + PreToolUse enforcement hook** を提供する。以下は本契約の上に別 PR で構築する（本 PR には含めない）:
 
-- **各 skill の適用**（implement / lessons-triage / topics 等のゲート記述を「自アクションを分類して policy を引く」に置換）。
-- **Claude Code の PreToolUse hook**（`policy-hook.mjs`。`gh pr merge` / `gh release` 等を実行エンジン側で policy 参照して deny/allow）。
+- **各 skill の適用**（implement / lessons-triage / topics 等のゲート記述を「自アクションを分類して policy を引く」に置換。R3 PR2/PR3 で実装済み）。
+- **hook の自動配線**（`hooks add policy`。[#174](https://github.com/ozzy-labs/skills/issues/174) の hooks CLI に追加予定）。
 
 ## 注意事項
 

--- a/.agents/skills/policy/policy-hook.mjs
+++ b/.agents/skills/policy/policy-hook.mjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+// policy-hook — PreToolUse architecture-enforcement gate for the central
+// autonomy policy (ADR-0028 R3, ozzy-labs/skills#181 PR 4/4).
+//
+// Wired into ~/.claude/settings.local.json as a PreToolUse hook (same wiring
+// shape as usage-guard-hook.mjs), this fires BEFORE every tool call — including
+// ones originating inside subagents, which carry an `agent_id` in the payload.
+// It is the execution-engine side of the policy stack: the SKILL.md prose layer
+// asks a skill to "classify your action and read the gate", but prose is only a
+// request. This hook makes a SPECIFIC set of irreversible commands
+// (`gh pr merge`, `gh release create`, `git push --force`/`-f`, `npm publish`)
+// physically un-runnable when the resolved gate is `ask` — the model cannot
+// talk its way past it.
+//
+// Detection is intentionally NARROW. The hook only pulls the policy when the
+// tool call's command matches one of the irreversible matchers below; every
+// other tool call (reads, edits, safe git/gh/npm, non-Bash tools) is allowed
+// untouched. This is the core safety property: because we only gate on a match,
+// a bug in the matcher can at worst FAIL to gate a dangerous command — it can
+// never deny ALL tools and wedge the session.
+//
+// Decision (PreToolUse contract):
+//   - matched + gate `ask` → DENY (exit 2 + a reason on stderr). Exit 2 is the
+//     harness signal that blocks the call even on older harnesses that key off
+//     the exit code.
+//   - matched + gate `proceed`/`batch-confirm` → ALLOW (the hook only hard-
+//     blocks `ask`; a batch confirmation is the caller/prose layer's job).
+//   - not matched → ALLOW (exit 0, silent).
+//
+// Fail-open (inherited from usage-guard-hook — "never hard-stop on our own
+// bug"):
+//   (a) file kill-switch: if `~/.claude/policy-guard/DISABLE` exists, the hook
+//       is an instant no-op ALLOW (checked FIRST, before any I/O, and itself
+//       fail-open). Escape hatch for a wedged session, no settings edit needed.
+//   (b) policy unreadable / unparseable (policy-read returns `degraded`, or the
+//       resolver throws / is missing) → ALLOW + a stderr warning. If we cannot
+//       even trust the gate, we do NOT block: the resumable prose-layer
+//       checkpoint (drive / health / lessons-triage) consults the SAME
+//       policy-read — which is fail-SAFE to `ask` — and is the primary gate. The
+//       hook is a secondary net, so it errs open to avoid wedging the session on
+//       a broken policy file.
+//   (c) proceed-override: a caller that has ALREADY resolved the gate and been
+//       granted autonomy (e.g. `drive --merge`, whose prose overrides merge to
+//       `proceed`) exports `POLICY_GUARD_PROCEED=<action>[,<action>...]`; the
+//       hook then allows that action without re-gating. This is how a legitimate
+//       opt-in merge is not blocked by the enforcement net.
+//
+// Design-for-tests: the matcher (`matchAction`), payload parse (`parsePayload`),
+// override check (`resolveProceedOverride`) and gate resolution
+// (`resolveGateForAction`) are all pure/injectable, and `run()` takes every
+// effect (stdin, kill-switch, gate resolver, warn/deny sinks) as a dep, so tests
+// exercise the whole thing with no network, no real ~/.claude reads, no spawned
+// process.
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// PreToolUse "deny" is signaled to the harness with exit code 2 (stderr is
+// surfaced to the model); 0 = allow. Named for clarity.
+const EXIT_ALLOW = 0;
+const EXIT_DENY = 2;
+
+// File kill-switch — the escape hatch. Built with path.join (HOME-anchored) so
+// no rewritable `.claude/skills/` literal appears in source (the dist user-scope
+// rewrite only targets `.agents|.claude/skills/` refs; `policy-guard/` is safe).
+export const DISABLE_PATH = join(homedir(), ".claude", "policy-guard", "DISABLE");
+
+// Env var a caller sets to pre-authorize specific actions (comma-separated
+// action names, or `all`/`*`). This is the `--merge`→proceed override channel:
+// a caller that has already been granted autonomy names the action here so the
+// enforcement net does not re-block it.
+export const PROCEED_ENV = "POLICY_GUARD_PROCEED";
+
+// Force-push flag detector: `--force`, `--force-with-lease`, or a short flag
+// token containing `f` (`-f`, `-fq`, …). Anchored on a token boundary so it does
+// not fire on `--foo` or a filename.
+const FORCE_FLAG = /(?:--force(?:-with-lease)?\b|(?:^|\s)-[a-z]*f[a-z]*(?=\s|$))/i;
+
+/**
+ * The irreversible-command matchers. Each entry maps a command shape to the
+ * central-policy action name + class the gate resolves against. The `class` is
+ * passed alongside the action so `resolveGate` can fall back to the class
+ * default even for an action not in policy-read's ACTION_CLASSES map (so a new
+ * irreversible command still resolves to the `irreversible` default = `ask`).
+ *
+ * Kept deliberately short + irreversible-only (ADR-0028's "irreversible /
+ * destructive" class). Reversible-local and externally-visible actions are the
+ * prose layer's job — the hook does NOT gate `gh pr create`, plain `git push`,
+ * etc., which keeps the "can only ever fail to gate, never deny everything"
+ * property.
+ * @type {ReadonlyArray<{action: string, class: string, test: (cmd: string) => boolean}>}
+ */
+export const IRREVERSIBLE_MATCHERS = Object.freeze([
+  { action: "merge", class: "irreversible", test: (c) => /\bgh\s+pr\s+merge\b/.test(c) },
+  {
+    action: "release-create",
+    class: "irreversible",
+    test: (c) => /\bgh\s+release\s+create\b/.test(c),
+  },
+  {
+    action: "force-push",
+    class: "irreversible",
+    test: (c) => /\bgit\s+push\b/.test(c) && FORCE_FLAG.test(c),
+  },
+  {
+    action: "publish",
+    class: "irreversible",
+    test: (c) => /\b(?:npm|pnpm|yarn)\s+publish\b/.test(c),
+  },
+]);
+
+/**
+ * Classify a command string. Returns the first matching irreversible action +
+ * class, or null when the command is not one the hook gates.
+ * @param {string|null|undefined} command
+ * @returns {{ action: string, class: string }|null}
+ */
+export function matchAction(command) {
+  if (typeof command !== "string" || command.trim() === "") return null;
+  for (const m of IRREVERSIBLE_MATCHERS) {
+    if (m.test(command)) return { action: m.action, class: m.class };
+  }
+  return null;
+}
+
+/**
+ * Read the entire hook stdin payload. Mirrors usage-guard-hook: resolves on end
+ * or error, and does not hang on a TTY (nothing piped).
+ * @param {NodeJS.ReadableStream} [stream]
+ * @returns {Promise<string>}
+ */
+export function readStdin(stream = process.stdin) {
+  return new Promise((resolve) => {
+    let data = "";
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      resolve(data);
+    };
+    stream.setEncoding?.("utf8");
+    stream.on("data", (chunk) => {
+      data += chunk;
+    });
+    stream.on("end", done);
+    stream.on("error", done);
+    if (stream.isTTY) done();
+  });
+}
+
+/**
+ * Parse the PreToolUse payload for the fields the hook needs: the tool name, the
+ * Bash command string (`tool_input.command`), and `agent_id` (present for
+ * subagent-originated calls) for logging. Tolerates empty / malformed input.
+ * @param {string} raw
+ * @returns {{ toolName: string|null, command: string|null, agentId: string|null }}
+ */
+export function parsePayload(raw) {
+  if (!raw?.trim()) return { toolName: null, command: null, agentId: null };
+  try {
+    const obj = JSON.parse(raw);
+    const toolName =
+      typeof obj?.tool_name === "string"
+        ? obj.tool_name
+        : typeof obj?.toolName === "string"
+          ? obj.toolName
+          : null;
+    const input = obj?.tool_input ?? obj?.toolInput ?? {};
+    const command = typeof input?.command === "string" ? input.command : null;
+    const agentId = obj?.agent_id ?? obj?.agentId ?? null;
+    return { toolName, command, agentId: typeof agentId === "string" ? agentId : null };
+  } catch {
+    return { toolName: null, command: null, agentId: null };
+  }
+}
+
+/**
+ * Whether the caller pre-authorized `action` via the proceed-override env var.
+ * The value is a comma-separated list of action names; `all` / `*` authorize
+ * everything. Missing/blank → not authorized.
+ * @param {NodeJS.ProcessEnv} env
+ * @param {string} action
+ * @returns {boolean}
+ */
+export function resolveProceedOverride(env, action) {
+  const raw = env?.[PROCEED_ENV];
+  if (!raw || typeof raw !== "string") return false;
+  const list = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return list.includes(action) || list.includes("all") || list.includes("*");
+}
+
+/**
+ * Resolve the effective gate for one {action, class} against the central policy
+ * by importing the sibling policy-read.mjs and reusing ITS reader (`run`) +
+ * ITS resolver (`resolveGate`) — no policy logic is duplicated here. Returns a
+ * shape the hook interprets:
+ *   - { gate, degraded: false }            → a trusted gate token
+ *   - { gate: null, degraded: true, reason } → could not trust a gate (module
+ *       missing/broken, or policy-read reported `degraded`); caller fails open.
+ *
+ * A dynamic import (not static) is deliberate: an install missing a healthy
+ * policy-read must degrade (→ fail open) rather than crash the hook at load.
+ * @param {{ action: string, klass: string, repoRoot: string }} query
+ * @param {{ importImpl?: (u: string) => Promise<unknown> }} [deps]
+ * @returns {Promise<{ gate: string|null, degraded: boolean, reason?: string, source?: string }>}
+ */
+export async function resolveGateForAction({ action, klass, repoRoot }, { importImpl } = {}) {
+  const imp = importImpl ?? ((u) => import(u));
+  const url = new URL("./policy-read.mjs", import.meta.url).href;
+  const mod = await imp(url);
+  if (!mod || typeof mod.run !== "function" || typeof mod.resolveGate !== "function") {
+    return { gate: null, degraded: true, reason: "policy-read missing run/resolveGate" };
+  }
+  const effective = await mod.run(["--repo-root", repoRoot]);
+  if (!effective || effective.degraded === true) {
+    return { gate: null, degraded: true, reason: "policy unreadable/unparseable (degraded)" };
+  }
+  const resolved = mod.resolveGate(effective, { action, class: klass });
+  if (!resolved || typeof resolved.gate !== "string") {
+    return { gate: null, degraded: true, reason: "gate could not be resolved" };
+  }
+  return { gate: resolved.gate, degraded: false, source: resolved.source };
+}
+
+/**
+ * Build the deny reason for a gated action. Names the action, the gate, and the
+ * three ways to proceed (opt-in env, edit policy, or the kill-switch).
+ * @param {string} action
+ * @param {string} gate
+ * @returns {string}
+ */
+export function buildDenyReason(action, gate) {
+  return (
+    `policy-guard: '${action}' is an irreversible action gated by the central autonomy policy ` +
+    `(gate=${gate}). Tool call blocked pending explicit approval. To authorize: set ` +
+    `${PROCEED_ENV}=${action} for a pre-approved run (e.g. drive --merge), relax the gate in ` +
+    `~/.agents/policy.yaml, or touch ${DISABLE_PATH} to disable the hook.`
+  );
+}
+
+/**
+ * Run the hook end to end. Returns the intended exit code (the CLI wrapper
+ * applies it). Every effect goes through an injected dep so tests assert without
+ * spawning a process or touching the network / real ~/.claude.
+ *
+ * @param {object} [deps]
+ * @param {() => Promise<string>} [deps.readStdinImpl]
+ * @param {() => boolean} [deps.killSwitchImpl]   // true → hook disabled (no-op)
+ * @param {(command: string|null) => ({action:string,class:string}|null)} [deps.matchActionImpl]
+ * @param {(q: {action:string,klass:string,repoRoot:string}) => Promise<{gate:string|null,degraded:boolean,reason?:string}>} [deps.resolveGateImpl]
+ * @param {NodeJS.ProcessEnv} [deps.env]
+ * @param {string} [deps.cwd]
+ * @param {(msg: string) => void} [deps.warn]
+ * @param {(msg: string) => void} [deps.deny]
+ * @returns {Promise<number>} exit code (0 allow / 2 deny)
+ */
+export async function run({
+  readStdinImpl = () => readStdin(),
+  killSwitchImpl = () => existsSync(DISABLE_PATH),
+  matchActionImpl = matchAction,
+  resolveGateImpl = resolveGateForAction,
+  env = process.env,
+  cwd = process.cwd(),
+  warn = (msg) => process.stderr.write(`${msg}\n`),
+  deny = (msg) => process.stderr.write(`${msg}\n`),
+} = {}) {
+  // (a) File kill-switch — checked FIRST, before any I/O, and itself fail-open
+  // (a check error → treated as not disabled → continue normally).
+  let disabled = false;
+  try {
+    disabled = !!killSwitchImpl();
+  } catch {
+    disabled = false;
+  }
+  if (disabled) {
+    warn(`policy-guard hook: disabled via kill-switch (${DISABLE_PATH}); allowing (no-op)`);
+    return EXIT_ALLOW;
+  }
+
+  const { command, agentId } = parsePayload(await readStdinImpl());
+  const origin = agentId ? `subagent ${agentId}` : "main session";
+
+  // Narrow gating: only pull the policy for a matched irreversible command.
+  // Everything else is allowed untouched (the "never deny all tools" property).
+  const matched = matchActionImpl(command);
+  if (!matched) return EXIT_ALLOW;
+
+  // (c) proceed-override: a caller already granted autonomy for this action
+  // (e.g. drive --merge overriding merge→proceed) named it in the env var.
+  if (resolveProceedOverride(env, matched.action)) {
+    warn(
+      `policy-guard hook: '${matched.action}' pre-authorized via ${PROCEED_ENV} (${origin}); allowing.`,
+    );
+    return EXIT_ALLOW;
+  }
+
+  // Resolve the gate. Any failure to obtain a TRUSTED gate → fail open + warn.
+  let gateResult;
+  try {
+    gateResult = await resolveGateImpl({
+      action: matched.action,
+      klass: matched.class,
+      repoRoot: cwd,
+    });
+  } catch (err) {
+    warn(
+      `policy-guard hook: gate resolution failed (${err?.message ?? err}) (${origin}); allowing (fail-open) — the prose-layer checkpoint still guards.`,
+    );
+    return EXIT_ALLOW;
+  }
+  // (b) policy unreadable / unparseable / unresolvable → fail open + warn.
+  if (!gateResult || gateResult.degraded === true || typeof gateResult.gate !== "string") {
+    const why = gateResult?.reason ? ` (${gateResult.reason})` : "";
+    warn(
+      `policy-guard hook: policy unreadable/unparseable${why} (${origin}); allowing (fail-open) — the prose-layer checkpoint still guards.`,
+    );
+    return EXIT_ALLOW;
+  }
+
+  // The hook only HARD-blocks `ask`. `proceed` / `batch-confirm` → allow (a
+  // batch confirmation belongs to the caller / prose layer, not this net).
+  if (gateResult.gate === "ask") {
+    deny(`${buildDenyReason(matched.action, gateResult.gate)} [origin: ${origin}]`);
+    return EXIT_DENY;
+  }
+  return EXIT_ALLOW;
+}
+
+// CLI entry — only when executed directly (not when imported by tests).
+const __isMain = (() => {
+  try {
+    return import.meta.url === `file://${process.argv[1]}`;
+  } catch {
+    return false;
+  }
+})();
+
+if (__isMain) {
+  run()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((err) => {
+      // Any unexpected error in the hook itself must fail open, never block.
+      process.stderr.write(
+        `policy-guard hook: fatal ${err?.message ?? err}; allowing (fail-open)\n`,
+      );
+      process.exitCode = EXIT_ALLOW;
+    });
+}

--- a/.claude/skills/policy/SKILL.md
+++ b/.claude/skills/policy/SKILL.md
@@ -96,12 +96,62 @@ fail-safe の作法:
 - **parse 不能なファイル** → そのファイルを無視し `degraded: true`。もう一方のファイル + 既定で解決する（危険クラスの既定は元々 `ask`）。
 - あらゆる失敗で throw せず exit 0。`&&` で連結した caller を壊さない。
 
+## PreToolUse enforcement hook（Claude Code / `policy-hook.mjs`）
+
+prose 層（各 skill の「自アクションを分類して policy を引く」）はあくまで **依頼**であり、モデルが無視・迂回し得る。`policy-hook.mjs`（sibling・`usage-guard-hook.mjs` と同型の PreToolUse hook）は**実行エンジン側の gate 強制**で、これを物理的に塞ぐ。全 tool 呼び出し前（subagent 内含む）に発火し、**特定の不可逆コマンド**を検出したときだけ policy を引いて deny/allow を決める。
+
+| 検出コマンド | 引く action（class） | ゼロコンフィグ既定 gate | hook の挙動 |
+| --- | --- | --- | --- |
+| `gh pr merge …` | `merge`（`irreversible`） | `ask` | deny（exit 2） |
+| `gh release create …` | `release-create`（`irreversible`） | `ask` | deny |
+| `git push --force` / `-f` / `--force-with-lease` | `force-push`（`irreversible`） | `ask` | deny |
+| `npm` / `pnpm` / `yarn publish` | `publish`（`irreversible`） | `ask` | deny |
+
+- **gate → 判定:** 解決した gate が `ask` なら deny（exit 2 + 理由を stderr）、`proceed` / `batch-confirm` なら allow。hook が hard-block するのは `ask` のみ（batch 確認は caller / prose 層の責務）。
+- **narrow gating（全 tool deny 事故の防止）:** policy を引くのは**上表の不可逆コマンドにマッチした時だけ**。それ以外（読取・編集・safe な git/gh/npm・非 Bash tool）は素通し。matcher にバグがあっても「危険コマンドを取りこぼす」方向にしか倒れず、全 tool を deny してセッションを wedge させることはない。
+- **一過性で hard-stop させない（`usage-guard-hook.mjs` から踏襲）:**
+  - **(a) file kill-switch:** `~/.claude/policy-guard/DISABLE` があれば冒頭で即 no-op allow。`!` シェルから `touch` すれば設定編集不要・セッション内で即解除できる。
+  - **(b) policy 読取不能・パース不能 → allow + stderr 警告:** `policy-read.mjs` が `degraded` を返す／resolver が throw する等で **gate を信頼できないとき**は deny せず allow する。gate 対象コマンドの検出はできても gate 値を信頼できないなら通す。**resumable prose-layer checkpoint（drive / health / lessons-triage）が同じ `policy-read.mjs`（fail-safe に `ask`）を引く一次ゲート**であり、hook は二次的な網なので broken policy でセッションを止めない側に倒す。
+  - **(c) proceed 上書き（`--merge` 相当）:** すでに gate を解決し自律を委任された caller（例 `drive --merge` は prose で merge を `proceed` に上書き）は `POLICY_GUARD_PROCEED=<action>[,<action>…]`（`all` / `*` も可）を export する。hook はその action を再ゲートせず allow する。これで正当な opt-in マージが強制網に阻まれない。
+- **subagent:** payload の `agent_id` を deny メッセージに `[origin: subagent <id>]` として付す（走行中 worker の mid-unit ceiling として機能）。
+
+### 配線（本 PR では自動配線しない）
+
+hook スクリプトは全 adapter payload に同梱されるが、**settings への配線は本 PR の scope 外**。将来 `hooks add policy`（[#174](https://github.com/ozzy-labs/skills/issues/174) の hooks CLI に追加予定。現状 `usage-guard` / `observability` のみ対応）が担う。それまでは手動で `~/.claude/settings.local.json` に 1 エントリ追加する（settings は mid-session reload されるため再起動不要）:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /home/<you>/.claude/skills/policy/policy-hook.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+> **hook スクリプトパスは絶対パスを手で埋める**（settings 内では skill-dir 相対参照が効かない）。パスは環境で揺れる:
+>
+> - **user-scope**（`npx @ozzylabs/skills install`）: `~/.claude/skills/policy/policy-hook.mjs`（`~` は展開されないので `/home/<you>/.claude/…` の形でフルに書く）
+> - **dogfood**（skills/commons リポ内）: `<repo>/.claude/skills/policy/policy-hook.mjs`
+>
+> どちらも「`policy-read.mjs` と同じ階層の `policy-hook.mjs`」を指す。matcher は不可逆コマンドが Bash 経由なので `"Bash"` で十分（`"*"` でも可・非 Bash tool は command が無く素通し）。
+
+**無効化:** `touch ~/.claude/policy-guard/DISABLE`（即時・設定編集不要）、または settings から上記エントリを削除（恒久）。
+
 ## 適用範囲
 
-本 skill は **契約（schema）+ 読取 substrate** のみを提供する。以下は本契約の上に別 PR で構築する（本 PR には含めない）:
+本 skill は **契約（schema）+ 読取 substrate + PreToolUse enforcement hook** を提供する。以下は本契約の上に別 PR で構築する（本 PR には含めない）:
 
-- **各 skill の適用**（implement / lessons-triage / topics 等のゲート記述を「自アクションを分類して policy を引く」に置換）。
-- **Claude Code の PreToolUse hook**（`policy-hook.mjs`。`gh pr merge` / `gh release` 等を実行エンジン側で policy 参照して deny/allow）。
+- **各 skill の適用**（implement / lessons-triage / topics 等のゲート記述を「自アクションを分類して policy を引く」に置換。R3 PR2/PR3 で実装済み）。
+- **hook の自動配線**（`hooks add policy`。[#174](https://github.com/ozzy-labs/skills/issues/174) の hooks CLI に追加予定）。
 
 ## 注意事項
 

--- a/.claude/skills/policy/policy-hook.mjs
+++ b/.claude/skills/policy/policy-hook.mjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+// policy-hook — PreToolUse architecture-enforcement gate for the central
+// autonomy policy (ADR-0028 R3, ozzy-labs/skills#181 PR 4/4).
+//
+// Wired into ~/.claude/settings.local.json as a PreToolUse hook (same wiring
+// shape as usage-guard-hook.mjs), this fires BEFORE every tool call — including
+// ones originating inside subagents, which carry an `agent_id` in the payload.
+// It is the execution-engine side of the policy stack: the SKILL.md prose layer
+// asks a skill to "classify your action and read the gate", but prose is only a
+// request. This hook makes a SPECIFIC set of irreversible commands
+// (`gh pr merge`, `gh release create`, `git push --force`/`-f`, `npm publish`)
+// physically un-runnable when the resolved gate is `ask` — the model cannot
+// talk its way past it.
+//
+// Detection is intentionally NARROW. The hook only pulls the policy when the
+// tool call's command matches one of the irreversible matchers below; every
+// other tool call (reads, edits, safe git/gh/npm, non-Bash tools) is allowed
+// untouched. This is the core safety property: because we only gate on a match,
+// a bug in the matcher can at worst FAIL to gate a dangerous command — it can
+// never deny ALL tools and wedge the session.
+//
+// Decision (PreToolUse contract):
+//   - matched + gate `ask` → DENY (exit 2 + a reason on stderr). Exit 2 is the
+//     harness signal that blocks the call even on older harnesses that key off
+//     the exit code.
+//   - matched + gate `proceed`/`batch-confirm` → ALLOW (the hook only hard-
+//     blocks `ask`; a batch confirmation is the caller/prose layer's job).
+//   - not matched → ALLOW (exit 0, silent).
+//
+// Fail-open (inherited from usage-guard-hook — "never hard-stop on our own
+// bug"):
+//   (a) file kill-switch: if `~/.claude/policy-guard/DISABLE` exists, the hook
+//       is an instant no-op ALLOW (checked FIRST, before any I/O, and itself
+//       fail-open). Escape hatch for a wedged session, no settings edit needed.
+//   (b) policy unreadable / unparseable (policy-read returns `degraded`, or the
+//       resolver throws / is missing) → ALLOW + a stderr warning. If we cannot
+//       even trust the gate, we do NOT block: the resumable prose-layer
+//       checkpoint (drive / health / lessons-triage) consults the SAME
+//       policy-read — which is fail-SAFE to `ask` — and is the primary gate. The
+//       hook is a secondary net, so it errs open to avoid wedging the session on
+//       a broken policy file.
+//   (c) proceed-override: a caller that has ALREADY resolved the gate and been
+//       granted autonomy (e.g. `drive --merge`, whose prose overrides merge to
+//       `proceed`) exports `POLICY_GUARD_PROCEED=<action>[,<action>...]`; the
+//       hook then allows that action without re-gating. This is how a legitimate
+//       opt-in merge is not blocked by the enforcement net.
+//
+// Design-for-tests: the matcher (`matchAction`), payload parse (`parsePayload`),
+// override check (`resolveProceedOverride`) and gate resolution
+// (`resolveGateForAction`) are all pure/injectable, and `run()` takes every
+// effect (stdin, kill-switch, gate resolver, warn/deny sinks) as a dep, so tests
+// exercise the whole thing with no network, no real ~/.claude reads, no spawned
+// process.
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// PreToolUse "deny" is signaled to the harness with exit code 2 (stderr is
+// surfaced to the model); 0 = allow. Named for clarity.
+const EXIT_ALLOW = 0;
+const EXIT_DENY = 2;
+
+// File kill-switch — the escape hatch. Built with path.join (HOME-anchored) so
+// no rewritable `.claude/skills/` literal appears in source (the dist user-scope
+// rewrite only targets `.agents|.claude/skills/` refs; `policy-guard/` is safe).
+export const DISABLE_PATH = join(homedir(), ".claude", "policy-guard", "DISABLE");
+
+// Env var a caller sets to pre-authorize specific actions (comma-separated
+// action names, or `all`/`*`). This is the `--merge`→proceed override channel:
+// a caller that has already been granted autonomy names the action here so the
+// enforcement net does not re-block it.
+export const PROCEED_ENV = "POLICY_GUARD_PROCEED";
+
+// Force-push flag detector: `--force`, `--force-with-lease`, or a short flag
+// token containing `f` (`-f`, `-fq`, …). Anchored on a token boundary so it does
+// not fire on `--foo` or a filename.
+const FORCE_FLAG = /(?:--force(?:-with-lease)?\b|(?:^|\s)-[a-z]*f[a-z]*(?=\s|$))/i;
+
+/**
+ * The irreversible-command matchers. Each entry maps a command shape to the
+ * central-policy action name + class the gate resolves against. The `class` is
+ * passed alongside the action so `resolveGate` can fall back to the class
+ * default even for an action not in policy-read's ACTION_CLASSES map (so a new
+ * irreversible command still resolves to the `irreversible` default = `ask`).
+ *
+ * Kept deliberately short + irreversible-only (ADR-0028's "irreversible /
+ * destructive" class). Reversible-local and externally-visible actions are the
+ * prose layer's job — the hook does NOT gate `gh pr create`, plain `git push`,
+ * etc., which keeps the "can only ever fail to gate, never deny everything"
+ * property.
+ * @type {ReadonlyArray<{action: string, class: string, test: (cmd: string) => boolean}>}
+ */
+export const IRREVERSIBLE_MATCHERS = Object.freeze([
+  { action: "merge", class: "irreversible", test: (c) => /\bgh\s+pr\s+merge\b/.test(c) },
+  {
+    action: "release-create",
+    class: "irreversible",
+    test: (c) => /\bgh\s+release\s+create\b/.test(c),
+  },
+  {
+    action: "force-push",
+    class: "irreversible",
+    test: (c) => /\bgit\s+push\b/.test(c) && FORCE_FLAG.test(c),
+  },
+  {
+    action: "publish",
+    class: "irreversible",
+    test: (c) => /\b(?:npm|pnpm|yarn)\s+publish\b/.test(c),
+  },
+]);
+
+/**
+ * Classify a command string. Returns the first matching irreversible action +
+ * class, or null when the command is not one the hook gates.
+ * @param {string|null|undefined} command
+ * @returns {{ action: string, class: string }|null}
+ */
+export function matchAction(command) {
+  if (typeof command !== "string" || command.trim() === "") return null;
+  for (const m of IRREVERSIBLE_MATCHERS) {
+    if (m.test(command)) return { action: m.action, class: m.class };
+  }
+  return null;
+}
+
+/**
+ * Read the entire hook stdin payload. Mirrors usage-guard-hook: resolves on end
+ * or error, and does not hang on a TTY (nothing piped).
+ * @param {NodeJS.ReadableStream} [stream]
+ * @returns {Promise<string>}
+ */
+export function readStdin(stream = process.stdin) {
+  return new Promise((resolve) => {
+    let data = "";
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      resolve(data);
+    };
+    stream.setEncoding?.("utf8");
+    stream.on("data", (chunk) => {
+      data += chunk;
+    });
+    stream.on("end", done);
+    stream.on("error", done);
+    if (stream.isTTY) done();
+  });
+}
+
+/**
+ * Parse the PreToolUse payload for the fields the hook needs: the tool name, the
+ * Bash command string (`tool_input.command`), and `agent_id` (present for
+ * subagent-originated calls) for logging. Tolerates empty / malformed input.
+ * @param {string} raw
+ * @returns {{ toolName: string|null, command: string|null, agentId: string|null }}
+ */
+export function parsePayload(raw) {
+  if (!raw?.trim()) return { toolName: null, command: null, agentId: null };
+  try {
+    const obj = JSON.parse(raw);
+    const toolName =
+      typeof obj?.tool_name === "string"
+        ? obj.tool_name
+        : typeof obj?.toolName === "string"
+          ? obj.toolName
+          : null;
+    const input = obj?.tool_input ?? obj?.toolInput ?? {};
+    const command = typeof input?.command === "string" ? input.command : null;
+    const agentId = obj?.agent_id ?? obj?.agentId ?? null;
+    return { toolName, command, agentId: typeof agentId === "string" ? agentId : null };
+  } catch {
+    return { toolName: null, command: null, agentId: null };
+  }
+}
+
+/**
+ * Whether the caller pre-authorized `action` via the proceed-override env var.
+ * The value is a comma-separated list of action names; `all` / `*` authorize
+ * everything. Missing/blank → not authorized.
+ * @param {NodeJS.ProcessEnv} env
+ * @param {string} action
+ * @returns {boolean}
+ */
+export function resolveProceedOverride(env, action) {
+  const raw = env?.[PROCEED_ENV];
+  if (!raw || typeof raw !== "string") return false;
+  const list = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return list.includes(action) || list.includes("all") || list.includes("*");
+}
+
+/**
+ * Resolve the effective gate for one {action, class} against the central policy
+ * by importing the sibling policy-read.mjs and reusing ITS reader (`run`) +
+ * ITS resolver (`resolveGate`) — no policy logic is duplicated here. Returns a
+ * shape the hook interprets:
+ *   - { gate, degraded: false }            → a trusted gate token
+ *   - { gate: null, degraded: true, reason } → could not trust a gate (module
+ *       missing/broken, or policy-read reported `degraded`); caller fails open.
+ *
+ * A dynamic import (not static) is deliberate: an install missing a healthy
+ * policy-read must degrade (→ fail open) rather than crash the hook at load.
+ * @param {{ action: string, klass: string, repoRoot: string }} query
+ * @param {{ importImpl?: (u: string) => Promise<unknown> }} [deps]
+ * @returns {Promise<{ gate: string|null, degraded: boolean, reason?: string, source?: string }>}
+ */
+export async function resolveGateForAction({ action, klass, repoRoot }, { importImpl } = {}) {
+  const imp = importImpl ?? ((u) => import(u));
+  const url = new URL("./policy-read.mjs", import.meta.url).href;
+  const mod = await imp(url);
+  if (!mod || typeof mod.run !== "function" || typeof mod.resolveGate !== "function") {
+    return { gate: null, degraded: true, reason: "policy-read missing run/resolveGate" };
+  }
+  const effective = await mod.run(["--repo-root", repoRoot]);
+  if (!effective || effective.degraded === true) {
+    return { gate: null, degraded: true, reason: "policy unreadable/unparseable (degraded)" };
+  }
+  const resolved = mod.resolveGate(effective, { action, class: klass });
+  if (!resolved || typeof resolved.gate !== "string") {
+    return { gate: null, degraded: true, reason: "gate could not be resolved" };
+  }
+  return { gate: resolved.gate, degraded: false, source: resolved.source };
+}
+
+/**
+ * Build the deny reason for a gated action. Names the action, the gate, and the
+ * three ways to proceed (opt-in env, edit policy, or the kill-switch).
+ * @param {string} action
+ * @param {string} gate
+ * @returns {string}
+ */
+export function buildDenyReason(action, gate) {
+  return (
+    `policy-guard: '${action}' is an irreversible action gated by the central autonomy policy ` +
+    `(gate=${gate}). Tool call blocked pending explicit approval. To authorize: set ` +
+    `${PROCEED_ENV}=${action} for a pre-approved run (e.g. drive --merge), relax the gate in ` +
+    `~/.agents/policy.yaml, or touch ${DISABLE_PATH} to disable the hook.`
+  );
+}
+
+/**
+ * Run the hook end to end. Returns the intended exit code (the CLI wrapper
+ * applies it). Every effect goes through an injected dep so tests assert without
+ * spawning a process or touching the network / real ~/.claude.
+ *
+ * @param {object} [deps]
+ * @param {() => Promise<string>} [deps.readStdinImpl]
+ * @param {() => boolean} [deps.killSwitchImpl]   // true → hook disabled (no-op)
+ * @param {(command: string|null) => ({action:string,class:string}|null)} [deps.matchActionImpl]
+ * @param {(q: {action:string,klass:string,repoRoot:string}) => Promise<{gate:string|null,degraded:boolean,reason?:string}>} [deps.resolveGateImpl]
+ * @param {NodeJS.ProcessEnv} [deps.env]
+ * @param {string} [deps.cwd]
+ * @param {(msg: string) => void} [deps.warn]
+ * @param {(msg: string) => void} [deps.deny]
+ * @returns {Promise<number>} exit code (0 allow / 2 deny)
+ */
+export async function run({
+  readStdinImpl = () => readStdin(),
+  killSwitchImpl = () => existsSync(DISABLE_PATH),
+  matchActionImpl = matchAction,
+  resolveGateImpl = resolveGateForAction,
+  env = process.env,
+  cwd = process.cwd(),
+  warn = (msg) => process.stderr.write(`${msg}\n`),
+  deny = (msg) => process.stderr.write(`${msg}\n`),
+} = {}) {
+  // (a) File kill-switch — checked FIRST, before any I/O, and itself fail-open
+  // (a check error → treated as not disabled → continue normally).
+  let disabled = false;
+  try {
+    disabled = !!killSwitchImpl();
+  } catch {
+    disabled = false;
+  }
+  if (disabled) {
+    warn(`policy-guard hook: disabled via kill-switch (${DISABLE_PATH}); allowing (no-op)`);
+    return EXIT_ALLOW;
+  }
+
+  const { command, agentId } = parsePayload(await readStdinImpl());
+  const origin = agentId ? `subagent ${agentId}` : "main session";
+
+  // Narrow gating: only pull the policy for a matched irreversible command.
+  // Everything else is allowed untouched (the "never deny all tools" property).
+  const matched = matchActionImpl(command);
+  if (!matched) return EXIT_ALLOW;
+
+  // (c) proceed-override: a caller already granted autonomy for this action
+  // (e.g. drive --merge overriding merge→proceed) named it in the env var.
+  if (resolveProceedOverride(env, matched.action)) {
+    warn(
+      `policy-guard hook: '${matched.action}' pre-authorized via ${PROCEED_ENV} (${origin}); allowing.`,
+    );
+    return EXIT_ALLOW;
+  }
+
+  // Resolve the gate. Any failure to obtain a TRUSTED gate → fail open + warn.
+  let gateResult;
+  try {
+    gateResult = await resolveGateImpl({
+      action: matched.action,
+      klass: matched.class,
+      repoRoot: cwd,
+    });
+  } catch (err) {
+    warn(
+      `policy-guard hook: gate resolution failed (${err?.message ?? err}) (${origin}); allowing (fail-open) — the prose-layer checkpoint still guards.`,
+    );
+    return EXIT_ALLOW;
+  }
+  // (b) policy unreadable / unparseable / unresolvable → fail open + warn.
+  if (!gateResult || gateResult.degraded === true || typeof gateResult.gate !== "string") {
+    const why = gateResult?.reason ? ` (${gateResult.reason})` : "";
+    warn(
+      `policy-guard hook: policy unreadable/unparseable${why} (${origin}); allowing (fail-open) — the prose-layer checkpoint still guards.`,
+    );
+    return EXIT_ALLOW;
+  }
+
+  // The hook only HARD-blocks `ask`. `proceed` / `batch-confirm` → allow (a
+  // batch confirmation belongs to the caller / prose layer, not this net).
+  if (gateResult.gate === "ask") {
+    deny(`${buildDenyReason(matched.action, gateResult.gate)} [origin: ${origin}]`);
+    return EXIT_DENY;
+  }
+  return EXIT_ALLOW;
+}
+
+// CLI entry — only when executed directly (not when imported by tests).
+const __isMain = (() => {
+  try {
+    return import.meta.url === `file://${process.argv[1]}`;
+  } catch {
+    return false;
+  }
+})();
+
+if (__isMain) {
+  run()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((err) => {
+      // Any unexpected error in the hook itself must fail open, never block.
+      process.stderr.write(
+        `policy-guard hook: fatal ${err?.message ?? err}; allowing (fail-open)\n`,
+      );
+      process.exitCode = EXIT_ALLOW;
+    });
+}

--- a/dist/claude-code-project/.agents/skills/policy/SKILL.md
+++ b/dist/claude-code-project/.agents/skills/policy/SKILL.md
@@ -96,12 +96,62 @@ fail-safe の作法:
 - **parse 不能なファイル** → そのファイルを無視し `degraded: true`。もう一方のファイル + 既定で解決する（危険クラスの既定は元々 `ask`）。
 - あらゆる失敗で throw せず exit 0。`&&` で連結した caller を壊さない。
 
+## PreToolUse enforcement hook（Claude Code / `policy-hook.mjs`）
+
+prose 層（各 skill の「自アクションを分類して policy を引く」）はあくまで **依頼**であり、モデルが無視・迂回し得る。`policy-hook.mjs`（sibling・`usage-guard-hook.mjs` と同型の PreToolUse hook）は**実行エンジン側の gate 強制**で、これを物理的に塞ぐ。全 tool 呼び出し前（subagent 内含む）に発火し、**特定の不可逆コマンド**を検出したときだけ policy を引いて deny/allow を決める。
+
+| 検出コマンド | 引く action（class） | ゼロコンフィグ既定 gate | hook の挙動 |
+| --- | --- | --- | --- |
+| `gh pr merge …` | `merge`（`irreversible`） | `ask` | deny（exit 2） |
+| `gh release create …` | `release-create`（`irreversible`） | `ask` | deny |
+| `git push --force` / `-f` / `--force-with-lease` | `force-push`（`irreversible`） | `ask` | deny |
+| `npm` / `pnpm` / `yarn publish` | `publish`（`irreversible`） | `ask` | deny |
+
+- **gate → 判定:** 解決した gate が `ask` なら deny（exit 2 + 理由を stderr）、`proceed` / `batch-confirm` なら allow。hook が hard-block するのは `ask` のみ（batch 確認は caller / prose 層の責務）。
+- **narrow gating（全 tool deny 事故の防止）:** policy を引くのは**上表の不可逆コマンドにマッチした時だけ**。それ以外（読取・編集・safe な git/gh/npm・非 Bash tool）は素通し。matcher にバグがあっても「危険コマンドを取りこぼす」方向にしか倒れず、全 tool を deny してセッションを wedge させることはない。
+- **一過性で hard-stop させない（`usage-guard-hook.mjs` から踏襲）:**
+  - **(a) file kill-switch:** `~/.claude/policy-guard/DISABLE` があれば冒頭で即 no-op allow。`!` シェルから `touch` すれば設定編集不要・セッション内で即解除できる。
+  - **(b) policy 読取不能・パース不能 → allow + stderr 警告:** `policy-read.mjs` が `degraded` を返す／resolver が throw する等で **gate を信頼できないとき**は deny せず allow する。gate 対象コマンドの検出はできても gate 値を信頼できないなら通す。**resumable prose-layer checkpoint（drive / health / lessons-triage）が同じ `policy-read.mjs`（fail-safe に `ask`）を引く一次ゲート**であり、hook は二次的な網なので broken policy でセッションを止めない側に倒す。
+  - **(c) proceed 上書き（`--merge` 相当）:** すでに gate を解決し自律を委任された caller（例 `drive --merge` は prose で merge を `proceed` に上書き）は `POLICY_GUARD_PROCEED=<action>[,<action>…]`（`all` / `*` も可）を export する。hook はその action を再ゲートせず allow する。これで正当な opt-in マージが強制網に阻まれない。
+- **subagent:** payload の `agent_id` を deny メッセージに `[origin: subagent <id>]` として付す（走行中 worker の mid-unit ceiling として機能）。
+
+### 配線（本 PR では自動配線しない）
+
+hook スクリプトは全 adapter payload に同梱されるが、**settings への配線は本 PR の scope 外**。将来 `hooks add policy`（[#174](https://github.com/ozzy-labs/skills/issues/174) の hooks CLI に追加予定。現状 `usage-guard` / `observability` のみ対応）が担う。それまでは手動で `~/.claude/settings.local.json` に 1 エントリ追加する（settings は mid-session reload されるため再起動不要）:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /home/<you>/.claude/skills/policy/policy-hook.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+> **hook スクリプトパスは絶対パスを手で埋める**（settings 内では skill-dir 相対参照が効かない）。パスは環境で揺れる:
+>
+> - **user-scope**（`npx @ozzylabs/skills install`）: `~/.claude/skills/policy/policy-hook.mjs`（`~` は展開されないので `/home/<you>/.claude/…` の形でフルに書く）
+> - **dogfood**（skills/commons リポ内）: `<repo>/.claude/skills/policy/policy-hook.mjs`
+>
+> どちらも「`policy-read.mjs` と同じ階層の `policy-hook.mjs`」を指す。matcher は不可逆コマンドが Bash 経由なので `"Bash"` で十分（`"*"` でも可・非 Bash tool は command が無く素通し）。
+
+**無効化:** `touch ~/.claude/policy-guard/DISABLE`（即時・設定編集不要）、または settings から上記エントリを削除（恒久）。
+
 ## 適用範囲
 
-本 skill は **契約（schema）+ 読取 substrate** のみを提供する。以下は本契約の上に別 PR で構築する（本 PR には含めない）:
+本 skill は **契約（schema）+ 読取 substrate + PreToolUse enforcement hook** を提供する。以下は本契約の上に別 PR で構築する（本 PR には含めない）:
 
-- **各 skill の適用**（implement / lessons-triage / topics 等のゲート記述を「自アクションを分類して policy を引く」に置換）。
-- **Claude Code の PreToolUse hook**（`policy-hook.mjs`。`gh pr merge` / `gh release` 等を実行エンジン側で policy 参照して deny/allow）。
+- **各 skill の適用**（implement / lessons-triage / topics 等のゲート記述を「自アクションを分類して policy を引く」に置換。R3 PR2/PR3 で実装済み）。
+- **hook の自動配線**（`hooks add policy`。[#174](https://github.com/ozzy-labs/skills/issues/174) の hooks CLI に追加予定）。
 
 ## 注意事項
 

--- a/dist/claude-code-project/.agents/skills/policy/policy-hook.mjs
+++ b/dist/claude-code-project/.agents/skills/policy/policy-hook.mjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+// policy-hook — PreToolUse architecture-enforcement gate for the central
+// autonomy policy (ADR-0028 R3, ozzy-labs/skills#181 PR 4/4).
+//
+// Wired into ~/.claude/settings.local.json as a PreToolUse hook (same wiring
+// shape as usage-guard-hook.mjs), this fires BEFORE every tool call — including
+// ones originating inside subagents, which carry an `agent_id` in the payload.
+// It is the execution-engine side of the policy stack: the SKILL.md prose layer
+// asks a skill to "classify your action and read the gate", but prose is only a
+// request. This hook makes a SPECIFIC set of irreversible commands
+// (`gh pr merge`, `gh release create`, `git push --force`/`-f`, `npm publish`)
+// physically un-runnable when the resolved gate is `ask` — the model cannot
+// talk its way past it.
+//
+// Detection is intentionally NARROW. The hook only pulls the policy when the
+// tool call's command matches one of the irreversible matchers below; every
+// other tool call (reads, edits, safe git/gh/npm, non-Bash tools) is allowed
+// untouched. This is the core safety property: because we only gate on a match,
+// a bug in the matcher can at worst FAIL to gate a dangerous command — it can
+// never deny ALL tools and wedge the session.
+//
+// Decision (PreToolUse contract):
+//   - matched + gate `ask` → DENY (exit 2 + a reason on stderr). Exit 2 is the
+//     harness signal that blocks the call even on older harnesses that key off
+//     the exit code.
+//   - matched + gate `proceed`/`batch-confirm` → ALLOW (the hook only hard-
+//     blocks `ask`; a batch confirmation is the caller/prose layer's job).
+//   - not matched → ALLOW (exit 0, silent).
+//
+// Fail-open (inherited from usage-guard-hook — "never hard-stop on our own
+// bug"):
+//   (a) file kill-switch: if `~/.claude/policy-guard/DISABLE` exists, the hook
+//       is an instant no-op ALLOW (checked FIRST, before any I/O, and itself
+//       fail-open). Escape hatch for a wedged session, no settings edit needed.
+//   (b) policy unreadable / unparseable (policy-read returns `degraded`, or the
+//       resolver throws / is missing) → ALLOW + a stderr warning. If we cannot
+//       even trust the gate, we do NOT block: the resumable prose-layer
+//       checkpoint (drive / health / lessons-triage) consults the SAME
+//       policy-read — which is fail-SAFE to `ask` — and is the primary gate. The
+//       hook is a secondary net, so it errs open to avoid wedging the session on
+//       a broken policy file.
+//   (c) proceed-override: a caller that has ALREADY resolved the gate and been
+//       granted autonomy (e.g. `drive --merge`, whose prose overrides merge to
+//       `proceed`) exports `POLICY_GUARD_PROCEED=<action>[,<action>...]`; the
+//       hook then allows that action without re-gating. This is how a legitimate
+//       opt-in merge is not blocked by the enforcement net.
+//
+// Design-for-tests: the matcher (`matchAction`), payload parse (`parsePayload`),
+// override check (`resolveProceedOverride`) and gate resolution
+// (`resolveGateForAction`) are all pure/injectable, and `run()` takes every
+// effect (stdin, kill-switch, gate resolver, warn/deny sinks) as a dep, so tests
+// exercise the whole thing with no network, no real ~/.claude reads, no spawned
+// process.
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// PreToolUse "deny" is signaled to the harness with exit code 2 (stderr is
+// surfaced to the model); 0 = allow. Named for clarity.
+const EXIT_ALLOW = 0;
+const EXIT_DENY = 2;
+
+// File kill-switch — the escape hatch. Built with path.join (HOME-anchored) so
+// no rewritable `.claude/skills/` literal appears in source (the dist user-scope
+// rewrite only targets `.agents|.claude/skills/` refs; `policy-guard/` is safe).
+export const DISABLE_PATH = join(homedir(), ".claude", "policy-guard", "DISABLE");
+
+// Env var a caller sets to pre-authorize specific actions (comma-separated
+// action names, or `all`/`*`). This is the `--merge`→proceed override channel:
+// a caller that has already been granted autonomy names the action here so the
+// enforcement net does not re-block it.
+export const PROCEED_ENV = "POLICY_GUARD_PROCEED";
+
+// Force-push flag detector: `--force`, `--force-with-lease`, or a short flag
+// token containing `f` (`-f`, `-fq`, …). Anchored on a token boundary so it does
+// not fire on `--foo` or a filename.
+const FORCE_FLAG = /(?:--force(?:-with-lease)?\b|(?:^|\s)-[a-z]*f[a-z]*(?=\s|$))/i;
+
+/**
+ * The irreversible-command matchers. Each entry maps a command shape to the
+ * central-policy action name + class the gate resolves against. The `class` is
+ * passed alongside the action so `resolveGate` can fall back to the class
+ * default even for an action not in policy-read's ACTION_CLASSES map (so a new
+ * irreversible command still resolves to the `irreversible` default = `ask`).
+ *
+ * Kept deliberately short + irreversible-only (ADR-0028's "irreversible /
+ * destructive" class). Reversible-local and externally-visible actions are the
+ * prose layer's job — the hook does NOT gate `gh pr create`, plain `git push`,
+ * etc., which keeps the "can only ever fail to gate, never deny everything"
+ * property.
+ * @type {ReadonlyArray<{action: string, class: string, test: (cmd: string) => boolean}>}
+ */
+export const IRREVERSIBLE_MATCHERS = Object.freeze([
+  { action: "merge", class: "irreversible", test: (c) => /\bgh\s+pr\s+merge\b/.test(c) },
+  {
+    action: "release-create",
+    class: "irreversible",
+    test: (c) => /\bgh\s+release\s+create\b/.test(c),
+  },
+  {
+    action: "force-push",
+    class: "irreversible",
+    test: (c) => /\bgit\s+push\b/.test(c) && FORCE_FLAG.test(c),
+  },
+  {
+    action: "publish",
+    class: "irreversible",
+    test: (c) => /\b(?:npm|pnpm|yarn)\s+publish\b/.test(c),
+  },
+]);
+
+/**
+ * Classify a command string. Returns the first matching irreversible action +
+ * class, or null when the command is not one the hook gates.
+ * @param {string|null|undefined} command
+ * @returns {{ action: string, class: string }|null}
+ */
+export function matchAction(command) {
+  if (typeof command !== "string" || command.trim() === "") return null;
+  for (const m of IRREVERSIBLE_MATCHERS) {
+    if (m.test(command)) return { action: m.action, class: m.class };
+  }
+  return null;
+}
+
+/**
+ * Read the entire hook stdin payload. Mirrors usage-guard-hook: resolves on end
+ * or error, and does not hang on a TTY (nothing piped).
+ * @param {NodeJS.ReadableStream} [stream]
+ * @returns {Promise<string>}
+ */
+export function readStdin(stream = process.stdin) {
+  return new Promise((resolve) => {
+    let data = "";
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      resolve(data);
+    };
+    stream.setEncoding?.("utf8");
+    stream.on("data", (chunk) => {
+      data += chunk;
+    });
+    stream.on("end", done);
+    stream.on("error", done);
+    if (stream.isTTY) done();
+  });
+}
+
+/**
+ * Parse the PreToolUse payload for the fields the hook needs: the tool name, the
+ * Bash command string (`tool_input.command`), and `agent_id` (present for
+ * subagent-originated calls) for logging. Tolerates empty / malformed input.
+ * @param {string} raw
+ * @returns {{ toolName: string|null, command: string|null, agentId: string|null }}
+ */
+export function parsePayload(raw) {
+  if (!raw?.trim()) return { toolName: null, command: null, agentId: null };
+  try {
+    const obj = JSON.parse(raw);
+    const toolName =
+      typeof obj?.tool_name === "string"
+        ? obj.tool_name
+        : typeof obj?.toolName === "string"
+          ? obj.toolName
+          : null;
+    const input = obj?.tool_input ?? obj?.toolInput ?? {};
+    const command = typeof input?.command === "string" ? input.command : null;
+    const agentId = obj?.agent_id ?? obj?.agentId ?? null;
+    return { toolName, command, agentId: typeof agentId === "string" ? agentId : null };
+  } catch {
+    return { toolName: null, command: null, agentId: null };
+  }
+}
+
+/**
+ * Whether the caller pre-authorized `action` via the proceed-override env var.
+ * The value is a comma-separated list of action names; `all` / `*` authorize
+ * everything. Missing/blank → not authorized.
+ * @param {NodeJS.ProcessEnv} env
+ * @param {string} action
+ * @returns {boolean}
+ */
+export function resolveProceedOverride(env, action) {
+  const raw = env?.[PROCEED_ENV];
+  if (!raw || typeof raw !== "string") return false;
+  const list = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return list.includes(action) || list.includes("all") || list.includes("*");
+}
+
+/**
+ * Resolve the effective gate for one {action, class} against the central policy
+ * by importing the sibling policy-read.mjs and reusing ITS reader (`run`) +
+ * ITS resolver (`resolveGate`) — no policy logic is duplicated here. Returns a
+ * shape the hook interprets:
+ *   - { gate, degraded: false }            → a trusted gate token
+ *   - { gate: null, degraded: true, reason } → could not trust a gate (module
+ *       missing/broken, or policy-read reported `degraded`); caller fails open.
+ *
+ * A dynamic import (not static) is deliberate: an install missing a healthy
+ * policy-read must degrade (→ fail open) rather than crash the hook at load.
+ * @param {{ action: string, klass: string, repoRoot: string }} query
+ * @param {{ importImpl?: (u: string) => Promise<unknown> }} [deps]
+ * @returns {Promise<{ gate: string|null, degraded: boolean, reason?: string, source?: string }>}
+ */
+export async function resolveGateForAction({ action, klass, repoRoot }, { importImpl } = {}) {
+  const imp = importImpl ?? ((u) => import(u));
+  const url = new URL("./policy-read.mjs", import.meta.url).href;
+  const mod = await imp(url);
+  if (!mod || typeof mod.run !== "function" || typeof mod.resolveGate !== "function") {
+    return { gate: null, degraded: true, reason: "policy-read missing run/resolveGate" };
+  }
+  const effective = await mod.run(["--repo-root", repoRoot]);
+  if (!effective || effective.degraded === true) {
+    return { gate: null, degraded: true, reason: "policy unreadable/unparseable (degraded)" };
+  }
+  const resolved = mod.resolveGate(effective, { action, class: klass });
+  if (!resolved || typeof resolved.gate !== "string") {
+    return { gate: null, degraded: true, reason: "gate could not be resolved" };
+  }
+  return { gate: resolved.gate, degraded: false, source: resolved.source };
+}
+
+/**
+ * Build the deny reason for a gated action. Names the action, the gate, and the
+ * three ways to proceed (opt-in env, edit policy, or the kill-switch).
+ * @param {string} action
+ * @param {string} gate
+ * @returns {string}
+ */
+export function buildDenyReason(action, gate) {
+  return (
+    `policy-guard: '${action}' is an irreversible action gated by the central autonomy policy ` +
+    `(gate=${gate}). Tool call blocked pending explicit approval. To authorize: set ` +
+    `${PROCEED_ENV}=${action} for a pre-approved run (e.g. drive --merge), relax the gate in ` +
+    `~/.agents/policy.yaml, or touch ${DISABLE_PATH} to disable the hook.`
+  );
+}
+
+/**
+ * Run the hook end to end. Returns the intended exit code (the CLI wrapper
+ * applies it). Every effect goes through an injected dep so tests assert without
+ * spawning a process or touching the network / real ~/.claude.
+ *
+ * @param {object} [deps]
+ * @param {() => Promise<string>} [deps.readStdinImpl]
+ * @param {() => boolean} [deps.killSwitchImpl]   // true → hook disabled (no-op)
+ * @param {(command: string|null) => ({action:string,class:string}|null)} [deps.matchActionImpl]
+ * @param {(q: {action:string,klass:string,repoRoot:string}) => Promise<{gate:string|null,degraded:boolean,reason?:string}>} [deps.resolveGateImpl]
+ * @param {NodeJS.ProcessEnv} [deps.env]
+ * @param {string} [deps.cwd]
+ * @param {(msg: string) => void} [deps.warn]
+ * @param {(msg: string) => void} [deps.deny]
+ * @returns {Promise<number>} exit code (0 allow / 2 deny)
+ */
+export async function run({
+  readStdinImpl = () => readStdin(),
+  killSwitchImpl = () => existsSync(DISABLE_PATH),
+  matchActionImpl = matchAction,
+  resolveGateImpl = resolveGateForAction,
+  env = process.env,
+  cwd = process.cwd(),
+  warn = (msg) => process.stderr.write(`${msg}\n`),
+  deny = (msg) => process.stderr.write(`${msg}\n`),
+} = {}) {
+  // (a) File kill-switch — checked FIRST, before any I/O, and itself fail-open
+  // (a check error → treated as not disabled → continue normally).
+  let disabled = false;
+  try {
+    disabled = !!killSwitchImpl();
+  } catch {
+    disabled = false;
+  }
+  if (disabled) {
+    warn(`policy-guard hook: disabled via kill-switch (${DISABLE_PATH}); allowing (no-op)`);
+    return EXIT_ALLOW;
+  }
+
+  const { command, agentId } = parsePayload(await readStdinImpl());
+  const origin = agentId ? `subagent ${agentId}` : "main session";
+
+  // Narrow gating: only pull the policy for a matched irreversible command.
+  // Everything else is allowed untouched (the "never deny all tools" property).
+  const matched = matchActionImpl(command);
+  if (!matched) return EXIT_ALLOW;
+
+  // (c) proceed-override: a caller already granted autonomy for this action
+  // (e.g. drive --merge overriding merge→proceed) named it in the env var.
+  if (resolveProceedOverride(env, matched.action)) {
+    warn(
+      `policy-guard hook: '${matched.action}' pre-authorized via ${PROCEED_ENV} (${origin}); allowing.`,
+    );
+    return EXIT_ALLOW;
+  }
+
+  // Resolve the gate. Any failure to obtain a TRUSTED gate → fail open + warn.
+  let gateResult;
+  try {
+    gateResult = await resolveGateImpl({
+      action: matched.action,
+      klass: matched.class,
+      repoRoot: cwd,
+    });
+  } catch (err) {
+    warn(
+      `policy-guard hook: gate resolution failed (${err?.message ?? err}) (${origin}); allowing (fail-open) — the prose-layer checkpoint still guards.`,
+    );
+    return EXIT_ALLOW;
+  }
+  // (b) policy unreadable / unparseable / unresolvable → fail open + warn.
+  if (!gateResult || gateResult.degraded === true || typeof gateResult.gate !== "string") {
+    const why = gateResult?.reason ? ` (${gateResult.reason})` : "";
+    warn(
+      `policy-guard hook: policy unreadable/unparseable${why} (${origin}); allowing (fail-open) — the prose-layer checkpoint still guards.`,
+    );
+    return EXIT_ALLOW;
+  }
+
+  // The hook only HARD-blocks `ask`. `proceed` / `batch-confirm` → allow (a
+  // batch confirmation belongs to the caller / prose layer, not this net).
+  if (gateResult.gate === "ask") {
+    deny(`${buildDenyReason(matched.action, gateResult.gate)} [origin: ${origin}]`);
+    return EXIT_DENY;
+  }
+  return EXIT_ALLOW;
+}
+
+// CLI entry — only when executed directly (not when imported by tests).
+const __isMain = (() => {
+  try {
+    return import.meta.url === `file://${process.argv[1]}`;
+  } catch {
+    return false;
+  }
+})();
+
+if (__isMain) {
+  run()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((err) => {
+      // Any unexpected error in the hook itself must fail open, never block.
+      process.stderr.write(
+        `policy-guard hook: fatal ${err?.message ?? err}; allowing (fail-open)\n`,
+      );
+      process.exitCode = EXIT_ALLOW;
+    });
+}

--- a/dist/claude-code-project/.claude/skills/policy/SKILL.md
+++ b/dist/claude-code-project/.claude/skills/policy/SKILL.md
@@ -96,12 +96,62 @@ fail-safe の作法:
 - **parse 不能なファイル** → そのファイルを無視し `degraded: true`。もう一方のファイル + 既定で解決する（危険クラスの既定は元々 `ask`）。
 - あらゆる失敗で throw せず exit 0。`&&` で連結した caller を壊さない。
 
+## PreToolUse enforcement hook（Claude Code / `policy-hook.mjs`）
+
+prose 層（各 skill の「自アクションを分類して policy を引く」）はあくまで **依頼**であり、モデルが無視・迂回し得る。`policy-hook.mjs`（sibling・`usage-guard-hook.mjs` と同型の PreToolUse hook）は**実行エンジン側の gate 強制**で、これを物理的に塞ぐ。全 tool 呼び出し前（subagent 内含む）に発火し、**特定の不可逆コマンド**を検出したときだけ policy を引いて deny/allow を決める。
+
+| 検出コマンド | 引く action（class） | ゼロコンフィグ既定 gate | hook の挙動 |
+| --- | --- | --- | --- |
+| `gh pr merge …` | `merge`（`irreversible`） | `ask` | deny（exit 2） |
+| `gh release create …` | `release-create`（`irreversible`） | `ask` | deny |
+| `git push --force` / `-f` / `--force-with-lease` | `force-push`（`irreversible`） | `ask` | deny |
+| `npm` / `pnpm` / `yarn publish` | `publish`（`irreversible`） | `ask` | deny |
+
+- **gate → 判定:** 解決した gate が `ask` なら deny（exit 2 + 理由を stderr）、`proceed` / `batch-confirm` なら allow。hook が hard-block するのは `ask` のみ（batch 確認は caller / prose 層の責務）。
+- **narrow gating（全 tool deny 事故の防止）:** policy を引くのは**上表の不可逆コマンドにマッチした時だけ**。それ以外（読取・編集・safe な git/gh/npm・非 Bash tool）は素通し。matcher にバグがあっても「危険コマンドを取りこぼす」方向にしか倒れず、全 tool を deny してセッションを wedge させることはない。
+- **一過性で hard-stop させない（`usage-guard-hook.mjs` から踏襲）:**
+  - **(a) file kill-switch:** `~/.claude/policy-guard/DISABLE` があれば冒頭で即 no-op allow。`!` シェルから `touch` すれば設定編集不要・セッション内で即解除できる。
+  - **(b) policy 読取不能・パース不能 → allow + stderr 警告:** `policy-read.mjs` が `degraded` を返す／resolver が throw する等で **gate を信頼できないとき**は deny せず allow する。gate 対象コマンドの検出はできても gate 値を信頼できないなら通す。**resumable prose-layer checkpoint（drive / health / lessons-triage）が同じ `policy-read.mjs`（fail-safe に `ask`）を引く一次ゲート**であり、hook は二次的な網なので broken policy でセッションを止めない側に倒す。
+  - **(c) proceed 上書き（`--merge` 相当）:** すでに gate を解決し自律を委任された caller（例 `drive --merge` は prose で merge を `proceed` に上書き）は `POLICY_GUARD_PROCEED=<action>[,<action>…]`（`all` / `*` も可）を export する。hook はその action を再ゲートせず allow する。これで正当な opt-in マージが強制網に阻まれない。
+- **subagent:** payload の `agent_id` を deny メッセージに `[origin: subagent <id>]` として付す（走行中 worker の mid-unit ceiling として機能）。
+
+### 配線（本 PR では自動配線しない）
+
+hook スクリプトは全 adapter payload に同梱されるが、**settings への配線は本 PR の scope 外**。将来 `hooks add policy`（[#174](https://github.com/ozzy-labs/skills/issues/174) の hooks CLI に追加予定。現状 `usage-guard` / `observability` のみ対応）が担う。それまでは手動で `~/.claude/settings.local.json` に 1 エントリ追加する（settings は mid-session reload されるため再起動不要）:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /home/<you>/.claude/skills/policy/policy-hook.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+> **hook スクリプトパスは絶対パスを手で埋める**（settings 内では skill-dir 相対参照が効かない）。パスは環境で揺れる:
+>
+> - **user-scope**（`npx @ozzylabs/skills install`）: `~/.claude/skills/policy/policy-hook.mjs`（`~` は展開されないので `/home/<you>/.claude/…` の形でフルに書く）
+> - **dogfood**（skills/commons リポ内）: `<repo>/.claude/skills/policy/policy-hook.mjs`
+>
+> どちらも「`policy-read.mjs` と同じ階層の `policy-hook.mjs`」を指す。matcher は不可逆コマンドが Bash 経由なので `"Bash"` で十分（`"*"` でも可・非 Bash tool は command が無く素通し）。
+
+**無効化:** `touch ~/.claude/policy-guard/DISABLE`（即時・設定編集不要）、または settings から上記エントリを削除（恒久）。
+
 ## 適用範囲
 
-本 skill は **契約（schema）+ 読取 substrate** のみを提供する。以下は本契約の上に別 PR で構築する（本 PR には含めない）:
+本 skill は **契約（schema）+ 読取 substrate + PreToolUse enforcement hook** を提供する。以下は本契約の上に別 PR で構築する（本 PR には含めない）:
 
-- **各 skill の適用**（implement / lessons-triage / topics 等のゲート記述を「自アクションを分類して policy を引く」に置換）。
-- **Claude Code の PreToolUse hook**（`policy-hook.mjs`。`gh pr merge` / `gh release` 等を実行エンジン側で policy 参照して deny/allow）。
+- **各 skill の適用**（implement / lessons-triage / topics 等のゲート記述を「自アクションを分類して policy を引く」に置換。R3 PR2/PR3 で実装済み）。
+- **hook の自動配線**（`hooks add policy`。[#174](https://github.com/ozzy-labs/skills/issues/174) の hooks CLI に追加予定）。
 
 ## 注意事項
 

--- a/dist/claude-code-project/.claude/skills/policy/policy-hook.mjs
+++ b/dist/claude-code-project/.claude/skills/policy/policy-hook.mjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+// policy-hook — PreToolUse architecture-enforcement gate for the central
+// autonomy policy (ADR-0028 R3, ozzy-labs/skills#181 PR 4/4).
+//
+// Wired into ~/.claude/settings.local.json as a PreToolUse hook (same wiring
+// shape as usage-guard-hook.mjs), this fires BEFORE every tool call — including
+// ones originating inside subagents, which carry an `agent_id` in the payload.
+// It is the execution-engine side of the policy stack: the SKILL.md prose layer
+// asks a skill to "classify your action and read the gate", but prose is only a
+// request. This hook makes a SPECIFIC set of irreversible commands
+// (`gh pr merge`, `gh release create`, `git push --force`/`-f`, `npm publish`)
+// physically un-runnable when the resolved gate is `ask` — the model cannot
+// talk its way past it.
+//
+// Detection is intentionally NARROW. The hook only pulls the policy when the
+// tool call's command matches one of the irreversible matchers below; every
+// other tool call (reads, edits, safe git/gh/npm, non-Bash tools) is allowed
+// untouched. This is the core safety property: because we only gate on a match,
+// a bug in the matcher can at worst FAIL to gate a dangerous command — it can
+// never deny ALL tools and wedge the session.
+//
+// Decision (PreToolUse contract):
+//   - matched + gate `ask` → DENY (exit 2 + a reason on stderr). Exit 2 is the
+//     harness signal that blocks the call even on older harnesses that key off
+//     the exit code.
+//   - matched + gate `proceed`/`batch-confirm` → ALLOW (the hook only hard-
+//     blocks `ask`; a batch confirmation is the caller/prose layer's job).
+//   - not matched → ALLOW (exit 0, silent).
+//
+// Fail-open (inherited from usage-guard-hook — "never hard-stop on our own
+// bug"):
+//   (a) file kill-switch: if `~/.claude/policy-guard/DISABLE` exists, the hook
+//       is an instant no-op ALLOW (checked FIRST, before any I/O, and itself
+//       fail-open). Escape hatch for a wedged session, no settings edit needed.
+//   (b) policy unreadable / unparseable (policy-read returns `degraded`, or the
+//       resolver throws / is missing) → ALLOW + a stderr warning. If we cannot
+//       even trust the gate, we do NOT block: the resumable prose-layer
+//       checkpoint (drive / health / lessons-triage) consults the SAME
+//       policy-read — which is fail-SAFE to `ask` — and is the primary gate. The
+//       hook is a secondary net, so it errs open to avoid wedging the session on
+//       a broken policy file.
+//   (c) proceed-override: a caller that has ALREADY resolved the gate and been
+//       granted autonomy (e.g. `drive --merge`, whose prose overrides merge to
+//       `proceed`) exports `POLICY_GUARD_PROCEED=<action>[,<action>...]`; the
+//       hook then allows that action without re-gating. This is how a legitimate
+//       opt-in merge is not blocked by the enforcement net.
+//
+// Design-for-tests: the matcher (`matchAction`), payload parse (`parsePayload`),
+// override check (`resolveProceedOverride`) and gate resolution
+// (`resolveGateForAction`) are all pure/injectable, and `run()` takes every
+// effect (stdin, kill-switch, gate resolver, warn/deny sinks) as a dep, so tests
+// exercise the whole thing with no network, no real ~/.claude reads, no spawned
+// process.
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// PreToolUse "deny" is signaled to the harness with exit code 2 (stderr is
+// surfaced to the model); 0 = allow. Named for clarity.
+const EXIT_ALLOW = 0;
+const EXIT_DENY = 2;
+
+// File kill-switch — the escape hatch. Built with path.join (HOME-anchored) so
+// no rewritable `.claude/skills/` literal appears in source (the dist user-scope
+// rewrite only targets `.agents|.claude/skills/` refs; `policy-guard/` is safe).
+export const DISABLE_PATH = join(homedir(), ".claude", "policy-guard", "DISABLE");
+
+// Env var a caller sets to pre-authorize specific actions (comma-separated
+// action names, or `all`/`*`). This is the `--merge`→proceed override channel:
+// a caller that has already been granted autonomy names the action here so the
+// enforcement net does not re-block it.
+export const PROCEED_ENV = "POLICY_GUARD_PROCEED";
+
+// Force-push flag detector: `--force`, `--force-with-lease`, or a short flag
+// token containing `f` (`-f`, `-fq`, …). Anchored on a token boundary so it does
+// not fire on `--foo` or a filename.
+const FORCE_FLAG = /(?:--force(?:-with-lease)?\b|(?:^|\s)-[a-z]*f[a-z]*(?=\s|$))/i;
+
+/**
+ * The irreversible-command matchers. Each entry maps a command shape to the
+ * central-policy action name + class the gate resolves against. The `class` is
+ * passed alongside the action so `resolveGate` can fall back to the class
+ * default even for an action not in policy-read's ACTION_CLASSES map (so a new
+ * irreversible command still resolves to the `irreversible` default = `ask`).
+ *
+ * Kept deliberately short + irreversible-only (ADR-0028's "irreversible /
+ * destructive" class). Reversible-local and externally-visible actions are the
+ * prose layer's job — the hook does NOT gate `gh pr create`, plain `git push`,
+ * etc., which keeps the "can only ever fail to gate, never deny everything"
+ * property.
+ * @type {ReadonlyArray<{action: string, class: string, test: (cmd: string) => boolean}>}
+ */
+export const IRREVERSIBLE_MATCHERS = Object.freeze([
+  { action: "merge", class: "irreversible", test: (c) => /\bgh\s+pr\s+merge\b/.test(c) },
+  {
+    action: "release-create",
+    class: "irreversible",
+    test: (c) => /\bgh\s+release\s+create\b/.test(c),
+  },
+  {
+    action: "force-push",
+    class: "irreversible",
+    test: (c) => /\bgit\s+push\b/.test(c) && FORCE_FLAG.test(c),
+  },
+  {
+    action: "publish",
+    class: "irreversible",
+    test: (c) => /\b(?:npm|pnpm|yarn)\s+publish\b/.test(c),
+  },
+]);
+
+/**
+ * Classify a command string. Returns the first matching irreversible action +
+ * class, or null when the command is not one the hook gates.
+ * @param {string|null|undefined} command
+ * @returns {{ action: string, class: string }|null}
+ */
+export function matchAction(command) {
+  if (typeof command !== "string" || command.trim() === "") return null;
+  for (const m of IRREVERSIBLE_MATCHERS) {
+    if (m.test(command)) return { action: m.action, class: m.class };
+  }
+  return null;
+}
+
+/**
+ * Read the entire hook stdin payload. Mirrors usage-guard-hook: resolves on end
+ * or error, and does not hang on a TTY (nothing piped).
+ * @param {NodeJS.ReadableStream} [stream]
+ * @returns {Promise<string>}
+ */
+export function readStdin(stream = process.stdin) {
+  return new Promise((resolve) => {
+    let data = "";
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      resolve(data);
+    };
+    stream.setEncoding?.("utf8");
+    stream.on("data", (chunk) => {
+      data += chunk;
+    });
+    stream.on("end", done);
+    stream.on("error", done);
+    if (stream.isTTY) done();
+  });
+}
+
+/**
+ * Parse the PreToolUse payload for the fields the hook needs: the tool name, the
+ * Bash command string (`tool_input.command`), and `agent_id` (present for
+ * subagent-originated calls) for logging. Tolerates empty / malformed input.
+ * @param {string} raw
+ * @returns {{ toolName: string|null, command: string|null, agentId: string|null }}
+ */
+export function parsePayload(raw) {
+  if (!raw?.trim()) return { toolName: null, command: null, agentId: null };
+  try {
+    const obj = JSON.parse(raw);
+    const toolName =
+      typeof obj?.tool_name === "string"
+        ? obj.tool_name
+        : typeof obj?.toolName === "string"
+          ? obj.toolName
+          : null;
+    const input = obj?.tool_input ?? obj?.toolInput ?? {};
+    const command = typeof input?.command === "string" ? input.command : null;
+    const agentId = obj?.agent_id ?? obj?.agentId ?? null;
+    return { toolName, command, agentId: typeof agentId === "string" ? agentId : null };
+  } catch {
+    return { toolName: null, command: null, agentId: null };
+  }
+}
+
+/**
+ * Whether the caller pre-authorized `action` via the proceed-override env var.
+ * The value is a comma-separated list of action names; `all` / `*` authorize
+ * everything. Missing/blank → not authorized.
+ * @param {NodeJS.ProcessEnv} env
+ * @param {string} action
+ * @returns {boolean}
+ */
+export function resolveProceedOverride(env, action) {
+  const raw = env?.[PROCEED_ENV];
+  if (!raw || typeof raw !== "string") return false;
+  const list = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return list.includes(action) || list.includes("all") || list.includes("*");
+}
+
+/**
+ * Resolve the effective gate for one {action, class} against the central policy
+ * by importing the sibling policy-read.mjs and reusing ITS reader (`run`) +
+ * ITS resolver (`resolveGate`) — no policy logic is duplicated here. Returns a
+ * shape the hook interprets:
+ *   - { gate, degraded: false }            → a trusted gate token
+ *   - { gate: null, degraded: true, reason } → could not trust a gate (module
+ *       missing/broken, or policy-read reported `degraded`); caller fails open.
+ *
+ * A dynamic import (not static) is deliberate: an install missing a healthy
+ * policy-read must degrade (→ fail open) rather than crash the hook at load.
+ * @param {{ action: string, klass: string, repoRoot: string }} query
+ * @param {{ importImpl?: (u: string) => Promise<unknown> }} [deps]
+ * @returns {Promise<{ gate: string|null, degraded: boolean, reason?: string, source?: string }>}
+ */
+export async function resolveGateForAction({ action, klass, repoRoot }, { importImpl } = {}) {
+  const imp = importImpl ?? ((u) => import(u));
+  const url = new URL("./policy-read.mjs", import.meta.url).href;
+  const mod = await imp(url);
+  if (!mod || typeof mod.run !== "function" || typeof mod.resolveGate !== "function") {
+    return { gate: null, degraded: true, reason: "policy-read missing run/resolveGate" };
+  }
+  const effective = await mod.run(["--repo-root", repoRoot]);
+  if (!effective || effective.degraded === true) {
+    return { gate: null, degraded: true, reason: "policy unreadable/unparseable (degraded)" };
+  }
+  const resolved = mod.resolveGate(effective, { action, class: klass });
+  if (!resolved || typeof resolved.gate !== "string") {
+    return { gate: null, degraded: true, reason: "gate could not be resolved" };
+  }
+  return { gate: resolved.gate, degraded: false, source: resolved.source };
+}
+
+/**
+ * Build the deny reason for a gated action. Names the action, the gate, and the
+ * three ways to proceed (opt-in env, edit policy, or the kill-switch).
+ * @param {string} action
+ * @param {string} gate
+ * @returns {string}
+ */
+export function buildDenyReason(action, gate) {
+  return (
+    `policy-guard: '${action}' is an irreversible action gated by the central autonomy policy ` +
+    `(gate=${gate}). Tool call blocked pending explicit approval. To authorize: set ` +
+    `${PROCEED_ENV}=${action} for a pre-approved run (e.g. drive --merge), relax the gate in ` +
+    `~/.agents/policy.yaml, or touch ${DISABLE_PATH} to disable the hook.`
+  );
+}
+
+/**
+ * Run the hook end to end. Returns the intended exit code (the CLI wrapper
+ * applies it). Every effect goes through an injected dep so tests assert without
+ * spawning a process or touching the network / real ~/.claude.
+ *
+ * @param {object} [deps]
+ * @param {() => Promise<string>} [deps.readStdinImpl]
+ * @param {() => boolean} [deps.killSwitchImpl]   // true → hook disabled (no-op)
+ * @param {(command: string|null) => ({action:string,class:string}|null)} [deps.matchActionImpl]
+ * @param {(q: {action:string,klass:string,repoRoot:string}) => Promise<{gate:string|null,degraded:boolean,reason?:string}>} [deps.resolveGateImpl]
+ * @param {NodeJS.ProcessEnv} [deps.env]
+ * @param {string} [deps.cwd]
+ * @param {(msg: string) => void} [deps.warn]
+ * @param {(msg: string) => void} [deps.deny]
+ * @returns {Promise<number>} exit code (0 allow / 2 deny)
+ */
+export async function run({
+  readStdinImpl = () => readStdin(),
+  killSwitchImpl = () => existsSync(DISABLE_PATH),
+  matchActionImpl = matchAction,
+  resolveGateImpl = resolveGateForAction,
+  env = process.env,
+  cwd = process.cwd(),
+  warn = (msg) => process.stderr.write(`${msg}\n`),
+  deny = (msg) => process.stderr.write(`${msg}\n`),
+} = {}) {
+  // (a) File kill-switch — checked FIRST, before any I/O, and itself fail-open
+  // (a check error → treated as not disabled → continue normally).
+  let disabled = false;
+  try {
+    disabled = !!killSwitchImpl();
+  } catch {
+    disabled = false;
+  }
+  if (disabled) {
+    warn(`policy-guard hook: disabled via kill-switch (${DISABLE_PATH}); allowing (no-op)`);
+    return EXIT_ALLOW;
+  }
+
+  const { command, agentId } = parsePayload(await readStdinImpl());
+  const origin = agentId ? `subagent ${agentId}` : "main session";
+
+  // Narrow gating: only pull the policy for a matched irreversible command.
+  // Everything else is allowed untouched (the "never deny all tools" property).
+  const matched = matchActionImpl(command);
+  if (!matched) return EXIT_ALLOW;
+
+  // (c) proceed-override: a caller already granted autonomy for this action
+  // (e.g. drive --merge overriding merge→proceed) named it in the env var.
+  if (resolveProceedOverride(env, matched.action)) {
+    warn(
+      `policy-guard hook: '${matched.action}' pre-authorized via ${PROCEED_ENV} (${origin}); allowing.`,
+    );
+    return EXIT_ALLOW;
+  }
+
+  // Resolve the gate. Any failure to obtain a TRUSTED gate → fail open + warn.
+  let gateResult;
+  try {
+    gateResult = await resolveGateImpl({
+      action: matched.action,
+      klass: matched.class,
+      repoRoot: cwd,
+    });
+  } catch (err) {
+    warn(
+      `policy-guard hook: gate resolution failed (${err?.message ?? err}) (${origin}); allowing (fail-open) — the prose-layer checkpoint still guards.`,
+    );
+    return EXIT_ALLOW;
+  }
+  // (b) policy unreadable / unparseable / unresolvable → fail open + warn.
+  if (!gateResult || gateResult.degraded === true || typeof gateResult.gate !== "string") {
+    const why = gateResult?.reason ? ` (${gateResult.reason})` : "";
+    warn(
+      `policy-guard hook: policy unreadable/unparseable${why} (${origin}); allowing (fail-open) — the prose-layer checkpoint still guards.`,
+    );
+    return EXIT_ALLOW;
+  }
+
+  // The hook only HARD-blocks `ask`. `proceed` / `batch-confirm` → allow (a
+  // batch confirmation belongs to the caller / prose layer, not this net).
+  if (gateResult.gate === "ask") {
+    deny(`${buildDenyReason(matched.action, gateResult.gate)} [origin: ${origin}]`);
+    return EXIT_DENY;
+  }
+  return EXIT_ALLOW;
+}
+
+// CLI entry — only when executed directly (not when imported by tests).
+const __isMain = (() => {
+  try {
+    return import.meta.url === `file://${process.argv[1]}`;
+  } catch {
+    return false;
+  }
+})();
+
+if (__isMain) {
+  run()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((err) => {
+      // Any unexpected error in the hook itself must fail open, never block.
+      process.stderr.write(
+        `policy-guard hook: fatal ${err?.message ?? err}; allowing (fail-open)\n`,
+      );
+      process.exitCode = EXIT_ALLOW;
+    });
+}

--- a/dist/claude-code/.agents/skills/policy/SKILL.md
+++ b/dist/claude-code/.agents/skills/policy/SKILL.md
@@ -96,12 +96,62 @@ fail-safe の作法:
 - **parse 不能なファイル** → そのファイルを無視し `degraded: true`。もう一方のファイル + 既定で解決する（危険クラスの既定は元々 `ask`）。
 - あらゆる失敗で throw せず exit 0。`&&` で連結した caller を壊さない。
 
+## PreToolUse enforcement hook（Claude Code / `policy-hook.mjs`）
+
+prose 層（各 skill の「自アクションを分類して policy を引く」）はあくまで **依頼**であり、モデルが無視・迂回し得る。`policy-hook.mjs`（sibling・`usage-guard-hook.mjs` と同型の PreToolUse hook）は**実行エンジン側の gate 強制**で、これを物理的に塞ぐ。全 tool 呼び出し前（subagent 内含む）に発火し、**特定の不可逆コマンド**を検出したときだけ policy を引いて deny/allow を決める。
+
+| 検出コマンド | 引く action（class） | ゼロコンフィグ既定 gate | hook の挙動 |
+| --- | --- | --- | --- |
+| `gh pr merge …` | `merge`（`irreversible`） | `ask` | deny（exit 2） |
+| `gh release create …` | `release-create`（`irreversible`） | `ask` | deny |
+| `git push --force` / `-f` / `--force-with-lease` | `force-push`（`irreversible`） | `ask` | deny |
+| `npm` / `pnpm` / `yarn publish` | `publish`（`irreversible`） | `ask` | deny |
+
+- **gate → 判定:** 解決した gate が `ask` なら deny（exit 2 + 理由を stderr）、`proceed` / `batch-confirm` なら allow。hook が hard-block するのは `ask` のみ（batch 確認は caller / prose 層の責務）。
+- **narrow gating（全 tool deny 事故の防止）:** policy を引くのは**上表の不可逆コマンドにマッチした時だけ**。それ以外（読取・編集・safe な git/gh/npm・非 Bash tool）は素通し。matcher にバグがあっても「危険コマンドを取りこぼす」方向にしか倒れず、全 tool を deny してセッションを wedge させることはない。
+- **一過性で hard-stop させない（`usage-guard-hook.mjs` から踏襲）:**
+  - **(a) file kill-switch:** `~/.claude/policy-guard/DISABLE` があれば冒頭で即 no-op allow。`!` シェルから `touch` すれば設定編集不要・セッション内で即解除できる。
+  - **(b) policy 読取不能・パース不能 → allow + stderr 警告:** `policy-read.mjs` が `degraded` を返す／resolver が throw する等で **gate を信頼できないとき**は deny せず allow する。gate 対象コマンドの検出はできても gate 値を信頼できないなら通す。**resumable prose-layer checkpoint（drive / health / lessons-triage）が同じ `policy-read.mjs`（fail-safe に `ask`）を引く一次ゲート**であり、hook は二次的な網なので broken policy でセッションを止めない側に倒す。
+  - **(c) proceed 上書き（`--merge` 相当）:** すでに gate を解決し自律を委任された caller（例 `drive --merge` は prose で merge を `proceed` に上書き）は `POLICY_GUARD_PROCEED=<action>[,<action>…]`（`all` / `*` も可）を export する。hook はその action を再ゲートせず allow する。これで正当な opt-in マージが強制網に阻まれない。
+- **subagent:** payload の `agent_id` を deny メッセージに `[origin: subagent <id>]` として付す（走行中 worker の mid-unit ceiling として機能）。
+
+### 配線（本 PR では自動配線しない）
+
+hook スクリプトは全 adapter payload に同梱されるが、**settings への配線は本 PR の scope 外**。将来 `hooks add policy`（[#174](https://github.com/ozzy-labs/skills/issues/174) の hooks CLI に追加予定。現状 `usage-guard` / `observability` のみ対応）が担う。それまでは手動で `~/.claude/settings.local.json` に 1 エントリ追加する（settings は mid-session reload されるため再起動不要）:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /home/<you>/.claude/skills/policy/policy-hook.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+> **hook スクリプトパスは絶対パスを手で埋める**（settings 内では skill-dir 相対参照が効かない）。パスは環境で揺れる:
+>
+> - **user-scope**（`npx @ozzylabs/skills install`）: `~/.claude/skills/policy/policy-hook.mjs`（`~` は展開されないので `/home/<you>/.claude/…` の形でフルに書く）
+> - **dogfood**（skills/commons リポ内）: `<repo>/.claude/skills/policy/policy-hook.mjs`
+>
+> どちらも「`policy-read.mjs` と同じ階層の `policy-hook.mjs`」を指す。matcher は不可逆コマンドが Bash 経由なので `"Bash"` で十分（`"*"` でも可・非 Bash tool は command が無く素通し）。
+
+**無効化:** `touch ~/.claude/policy-guard/DISABLE`（即時・設定編集不要）、または settings から上記エントリを削除（恒久）。
+
 ## 適用範囲
 
-本 skill は **契約（schema）+ 読取 substrate** のみを提供する。以下は本契約の上に別 PR で構築する（本 PR には含めない）:
+本 skill は **契約（schema）+ 読取 substrate + PreToolUse enforcement hook** を提供する。以下は本契約の上に別 PR で構築する（本 PR には含めない）:
 
-- **各 skill の適用**（implement / lessons-triage / topics 等のゲート記述を「自アクションを分類して policy を引く」に置換）。
-- **Claude Code の PreToolUse hook**（`policy-hook.mjs`。`gh pr merge` / `gh release` 等を実行エンジン側で policy 参照して deny/allow）。
+- **各 skill の適用**（implement / lessons-triage / topics 等のゲート記述を「自アクションを分類して policy を引く」に置換。R3 PR2/PR3 で実装済み）。
+- **hook の自動配線**（`hooks add policy`。[#174](https://github.com/ozzy-labs/skills/issues/174) の hooks CLI に追加予定）。
 
 ## 注意事項
 

--- a/dist/claude-code/.agents/skills/policy/policy-hook.mjs
+++ b/dist/claude-code/.agents/skills/policy/policy-hook.mjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+// policy-hook — PreToolUse architecture-enforcement gate for the central
+// autonomy policy (ADR-0028 R3, ozzy-labs/skills#181 PR 4/4).
+//
+// Wired into ~/.claude/settings.local.json as a PreToolUse hook (same wiring
+// shape as usage-guard-hook.mjs), this fires BEFORE every tool call — including
+// ones originating inside subagents, which carry an `agent_id` in the payload.
+// It is the execution-engine side of the policy stack: the SKILL.md prose layer
+// asks a skill to "classify your action and read the gate", but prose is only a
+// request. This hook makes a SPECIFIC set of irreversible commands
+// (`gh pr merge`, `gh release create`, `git push --force`/`-f`, `npm publish`)
+// physically un-runnable when the resolved gate is `ask` — the model cannot
+// talk its way past it.
+//
+// Detection is intentionally NARROW. The hook only pulls the policy when the
+// tool call's command matches one of the irreversible matchers below; every
+// other tool call (reads, edits, safe git/gh/npm, non-Bash tools) is allowed
+// untouched. This is the core safety property: because we only gate on a match,
+// a bug in the matcher can at worst FAIL to gate a dangerous command — it can
+// never deny ALL tools and wedge the session.
+//
+// Decision (PreToolUse contract):
+//   - matched + gate `ask` → DENY (exit 2 + a reason on stderr). Exit 2 is the
+//     harness signal that blocks the call even on older harnesses that key off
+//     the exit code.
+//   - matched + gate `proceed`/`batch-confirm` → ALLOW (the hook only hard-
+//     blocks `ask`; a batch confirmation is the caller/prose layer's job).
+//   - not matched → ALLOW (exit 0, silent).
+//
+// Fail-open (inherited from usage-guard-hook — "never hard-stop on our own
+// bug"):
+//   (a) file kill-switch: if `~/.claude/policy-guard/DISABLE` exists, the hook
+//       is an instant no-op ALLOW (checked FIRST, before any I/O, and itself
+//       fail-open). Escape hatch for a wedged session, no settings edit needed.
+//   (b) policy unreadable / unparseable (policy-read returns `degraded`, or the
+//       resolver throws / is missing) → ALLOW + a stderr warning. If we cannot
+//       even trust the gate, we do NOT block: the resumable prose-layer
+//       checkpoint (drive / health / lessons-triage) consults the SAME
+//       policy-read — which is fail-SAFE to `ask` — and is the primary gate. The
+//       hook is a secondary net, so it errs open to avoid wedging the session on
+//       a broken policy file.
+//   (c) proceed-override: a caller that has ALREADY resolved the gate and been
+//       granted autonomy (e.g. `drive --merge`, whose prose overrides merge to
+//       `proceed`) exports `POLICY_GUARD_PROCEED=<action>[,<action>...]`; the
+//       hook then allows that action without re-gating. This is how a legitimate
+//       opt-in merge is not blocked by the enforcement net.
+//
+// Design-for-tests: the matcher (`matchAction`), payload parse (`parsePayload`),
+// override check (`resolveProceedOverride`) and gate resolution
+// (`resolveGateForAction`) are all pure/injectable, and `run()` takes every
+// effect (stdin, kill-switch, gate resolver, warn/deny sinks) as a dep, so tests
+// exercise the whole thing with no network, no real ~/.claude reads, no spawned
+// process.
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// PreToolUse "deny" is signaled to the harness with exit code 2 (stderr is
+// surfaced to the model); 0 = allow. Named for clarity.
+const EXIT_ALLOW = 0;
+const EXIT_DENY = 2;
+
+// File kill-switch — the escape hatch. Built with path.join (HOME-anchored) so
+// no rewritable `~/.claude/skills/` literal appears in source (the dist user-scope
+// rewrite only targets `.agents|~/.claude/skills/` refs; `policy-guard/` is safe).
+export const DISABLE_PATH = join(homedir(), ".claude", "policy-guard", "DISABLE");
+
+// Env var a caller sets to pre-authorize specific actions (comma-separated
+// action names, or `all`/`*`). This is the `--merge`→proceed override channel:
+// a caller that has already been granted autonomy names the action here so the
+// enforcement net does not re-block it.
+export const PROCEED_ENV = "POLICY_GUARD_PROCEED";
+
+// Force-push flag detector: `--force`, `--force-with-lease`, or a short flag
+// token containing `f` (`-f`, `-fq`, …). Anchored on a token boundary so it does
+// not fire on `--foo` or a filename.
+const FORCE_FLAG = /(?:--force(?:-with-lease)?\b|(?:^|\s)-[a-z]*f[a-z]*(?=\s|$))/i;
+
+/**
+ * The irreversible-command matchers. Each entry maps a command shape to the
+ * central-policy action name + class the gate resolves against. The `class` is
+ * passed alongside the action so `resolveGate` can fall back to the class
+ * default even for an action not in policy-read's ACTION_CLASSES map (so a new
+ * irreversible command still resolves to the `irreversible` default = `ask`).
+ *
+ * Kept deliberately short + irreversible-only (ADR-0028's "irreversible /
+ * destructive" class). Reversible-local and externally-visible actions are the
+ * prose layer's job — the hook does NOT gate `gh pr create`, plain `git push`,
+ * etc., which keeps the "can only ever fail to gate, never deny everything"
+ * property.
+ * @type {ReadonlyArray<{action: string, class: string, test: (cmd: string) => boolean}>}
+ */
+export const IRREVERSIBLE_MATCHERS = Object.freeze([
+  { action: "merge", class: "irreversible", test: (c) => /\bgh\s+pr\s+merge\b/.test(c) },
+  {
+    action: "release-create",
+    class: "irreversible",
+    test: (c) => /\bgh\s+release\s+create\b/.test(c),
+  },
+  {
+    action: "force-push",
+    class: "irreversible",
+    test: (c) => /\bgit\s+push\b/.test(c) && FORCE_FLAG.test(c),
+  },
+  {
+    action: "publish",
+    class: "irreversible",
+    test: (c) => /\b(?:npm|pnpm|yarn)\s+publish\b/.test(c),
+  },
+]);
+
+/**
+ * Classify a command string. Returns the first matching irreversible action +
+ * class, or null when the command is not one the hook gates.
+ * @param {string|null|undefined} command
+ * @returns {{ action: string, class: string }|null}
+ */
+export function matchAction(command) {
+  if (typeof command !== "string" || command.trim() === "") return null;
+  for (const m of IRREVERSIBLE_MATCHERS) {
+    if (m.test(command)) return { action: m.action, class: m.class };
+  }
+  return null;
+}
+
+/**
+ * Read the entire hook stdin payload. Mirrors usage-guard-hook: resolves on end
+ * or error, and does not hang on a TTY (nothing piped).
+ * @param {NodeJS.ReadableStream} [stream]
+ * @returns {Promise<string>}
+ */
+export function readStdin(stream = process.stdin) {
+  return new Promise((resolve) => {
+    let data = "";
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      resolve(data);
+    };
+    stream.setEncoding?.("utf8");
+    stream.on("data", (chunk) => {
+      data += chunk;
+    });
+    stream.on("end", done);
+    stream.on("error", done);
+    if (stream.isTTY) done();
+  });
+}
+
+/**
+ * Parse the PreToolUse payload for the fields the hook needs: the tool name, the
+ * Bash command string (`tool_input.command`), and `agent_id` (present for
+ * subagent-originated calls) for logging. Tolerates empty / malformed input.
+ * @param {string} raw
+ * @returns {{ toolName: string|null, command: string|null, agentId: string|null }}
+ */
+export function parsePayload(raw) {
+  if (!raw?.trim()) return { toolName: null, command: null, agentId: null };
+  try {
+    const obj = JSON.parse(raw);
+    const toolName =
+      typeof obj?.tool_name === "string"
+        ? obj.tool_name
+        : typeof obj?.toolName === "string"
+          ? obj.toolName
+          : null;
+    const input = obj?.tool_input ?? obj?.toolInput ?? {};
+    const command = typeof input?.command === "string" ? input.command : null;
+    const agentId = obj?.agent_id ?? obj?.agentId ?? null;
+    return { toolName, command, agentId: typeof agentId === "string" ? agentId : null };
+  } catch {
+    return { toolName: null, command: null, agentId: null };
+  }
+}
+
+/**
+ * Whether the caller pre-authorized `action` via the proceed-override env var.
+ * The value is a comma-separated list of action names; `all` / `*` authorize
+ * everything. Missing/blank → not authorized.
+ * @param {NodeJS.ProcessEnv} env
+ * @param {string} action
+ * @returns {boolean}
+ */
+export function resolveProceedOverride(env, action) {
+  const raw = env?.[PROCEED_ENV];
+  if (!raw || typeof raw !== "string") return false;
+  const list = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return list.includes(action) || list.includes("all") || list.includes("*");
+}
+
+/**
+ * Resolve the effective gate for one {action, class} against the central policy
+ * by importing the sibling policy-read.mjs and reusing ITS reader (`run`) +
+ * ITS resolver (`resolveGate`) — no policy logic is duplicated here. Returns a
+ * shape the hook interprets:
+ *   - { gate, degraded: false }            → a trusted gate token
+ *   - { gate: null, degraded: true, reason } → could not trust a gate (module
+ *       missing/broken, or policy-read reported `degraded`); caller fails open.
+ *
+ * A dynamic import (not static) is deliberate: an install missing a healthy
+ * policy-read must degrade (→ fail open) rather than crash the hook at load.
+ * @param {{ action: string, klass: string, repoRoot: string }} query
+ * @param {{ importImpl?: (u: string) => Promise<unknown> }} [deps]
+ * @returns {Promise<{ gate: string|null, degraded: boolean, reason?: string, source?: string }>}
+ */
+export async function resolveGateForAction({ action, klass, repoRoot }, { importImpl } = {}) {
+  const imp = importImpl ?? ((u) => import(u));
+  const url = new URL("./policy-read.mjs", import.meta.url).href;
+  const mod = await imp(url);
+  if (!mod || typeof mod.run !== "function" || typeof mod.resolveGate !== "function") {
+    return { gate: null, degraded: true, reason: "policy-read missing run/resolveGate" };
+  }
+  const effective = await mod.run(["--repo-root", repoRoot]);
+  if (!effective || effective.degraded === true) {
+    return { gate: null, degraded: true, reason: "policy unreadable/unparseable (degraded)" };
+  }
+  const resolved = mod.resolveGate(effective, { action, class: klass });
+  if (!resolved || typeof resolved.gate !== "string") {
+    return { gate: null, degraded: true, reason: "gate could not be resolved" };
+  }
+  return { gate: resolved.gate, degraded: false, source: resolved.source };
+}
+
+/**
+ * Build the deny reason for a gated action. Names the action, the gate, and the
+ * three ways to proceed (opt-in env, edit policy, or the kill-switch).
+ * @param {string} action
+ * @param {string} gate
+ * @returns {string}
+ */
+export function buildDenyReason(action, gate) {
+  return (
+    `policy-guard: '${action}' is an irreversible action gated by the central autonomy policy ` +
+    `(gate=${gate}). Tool call blocked pending explicit approval. To authorize: set ` +
+    `${PROCEED_ENV}=${action} for a pre-approved run (e.g. drive --merge), relax the gate in ` +
+    `~/.agents/policy.yaml, or touch ${DISABLE_PATH} to disable the hook.`
+  );
+}
+
+/**
+ * Run the hook end to end. Returns the intended exit code (the CLI wrapper
+ * applies it). Every effect goes through an injected dep so tests assert without
+ * spawning a process or touching the network / real ~/.claude.
+ *
+ * @param {object} [deps]
+ * @param {() => Promise<string>} [deps.readStdinImpl]
+ * @param {() => boolean} [deps.killSwitchImpl]   // true → hook disabled (no-op)
+ * @param {(command: string|null) => ({action:string,class:string}|null)} [deps.matchActionImpl]
+ * @param {(q: {action:string,klass:string,repoRoot:string}) => Promise<{gate:string|null,degraded:boolean,reason?:string}>} [deps.resolveGateImpl]
+ * @param {NodeJS.ProcessEnv} [deps.env]
+ * @param {string} [deps.cwd]
+ * @param {(msg: string) => void} [deps.warn]
+ * @param {(msg: string) => void} [deps.deny]
+ * @returns {Promise<number>} exit code (0 allow / 2 deny)
+ */
+export async function run({
+  readStdinImpl = () => readStdin(),
+  killSwitchImpl = () => existsSync(DISABLE_PATH),
+  matchActionImpl = matchAction,
+  resolveGateImpl = resolveGateForAction,
+  env = process.env,
+  cwd = process.cwd(),
+  warn = (msg) => process.stderr.write(`${msg}\n`),
+  deny = (msg) => process.stderr.write(`${msg}\n`),
+} = {}) {
+  // (a) File kill-switch — checked FIRST, before any I/O, and itself fail-open
+  // (a check error → treated as not disabled → continue normally).
+  let disabled = false;
+  try {
+    disabled = !!killSwitchImpl();
+  } catch {
+    disabled = false;
+  }
+  if (disabled) {
+    warn(`policy-guard hook: disabled via kill-switch (${DISABLE_PATH}); allowing (no-op)`);
+    return EXIT_ALLOW;
+  }
+
+  const { command, agentId } = parsePayload(await readStdinImpl());
+  const origin = agentId ? `subagent ${agentId}` : "main session";
+
+  // Narrow gating: only pull the policy for a matched irreversible command.
+  // Everything else is allowed untouched (the "never deny all tools" property).
+  const matched = matchActionImpl(command);
+  if (!matched) return EXIT_ALLOW;
+
+  // (c) proceed-override: a caller already granted autonomy for this action
+  // (e.g. drive --merge overriding merge→proceed) named it in the env var.
+  if (resolveProceedOverride(env, matched.action)) {
+    warn(
+      `policy-guard hook: '${matched.action}' pre-authorized via ${PROCEED_ENV} (${origin}); allowing.`,
+    );
+    return EXIT_ALLOW;
+  }
+
+  // Resolve the gate. Any failure to obtain a TRUSTED gate → fail open + warn.
+  let gateResult;
+  try {
+    gateResult = await resolveGateImpl({
+      action: matched.action,
+      klass: matched.class,
+      repoRoot: cwd,
+    });
+  } catch (err) {
+    warn(
+      `policy-guard hook: gate resolution failed (${err?.message ?? err}) (${origin}); allowing (fail-open) — the prose-layer checkpoint still guards.`,
+    );
+    return EXIT_ALLOW;
+  }
+  // (b) policy unreadable / unparseable / unresolvable → fail open + warn.
+  if (!gateResult || gateResult.degraded === true || typeof gateResult.gate !== "string") {
+    const why = gateResult?.reason ? ` (${gateResult.reason})` : "";
+    warn(
+      `policy-guard hook: policy unreadable/unparseable${why} (${origin}); allowing (fail-open) — the prose-layer checkpoint still guards.`,
+    );
+    return EXIT_ALLOW;
+  }
+
+  // The hook only HARD-blocks `ask`. `proceed` / `batch-confirm` → allow (a
+  // batch confirmation belongs to the caller / prose layer, not this net).
+  if (gateResult.gate === "ask") {
+    deny(`${buildDenyReason(matched.action, gateResult.gate)} [origin: ${origin}]`);
+    return EXIT_DENY;
+  }
+  return EXIT_ALLOW;
+}
+
+// CLI entry — only when executed directly (not when imported by tests).
+const __isMain = (() => {
+  try {
+    return import.meta.url === `file://${process.argv[1]}`;
+  } catch {
+    return false;
+  }
+})();
+
+if (__isMain) {
+  run()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((err) => {
+      // Any unexpected error in the hook itself must fail open, never block.
+      process.stderr.write(
+        `policy-guard hook: fatal ${err?.message ?? err}; allowing (fail-open)\n`,
+      );
+      process.exitCode = EXIT_ALLOW;
+    });
+}

--- a/dist/claude-code/.claude/skills/policy/SKILL.md
+++ b/dist/claude-code/.claude/skills/policy/SKILL.md
@@ -96,12 +96,62 @@ fail-safe の作法:
 - **parse 不能なファイル** → そのファイルを無視し `degraded: true`。もう一方のファイル + 既定で解決する（危険クラスの既定は元々 `ask`）。
 - あらゆる失敗で throw せず exit 0。`&&` で連結した caller を壊さない。
 
+## PreToolUse enforcement hook（Claude Code / `policy-hook.mjs`）
+
+prose 層（各 skill の「自アクションを分類して policy を引く」）はあくまで **依頼**であり、モデルが無視・迂回し得る。`policy-hook.mjs`（sibling・`usage-guard-hook.mjs` と同型の PreToolUse hook）は**実行エンジン側の gate 強制**で、これを物理的に塞ぐ。全 tool 呼び出し前（subagent 内含む）に発火し、**特定の不可逆コマンド**を検出したときだけ policy を引いて deny/allow を決める。
+
+| 検出コマンド | 引く action（class） | ゼロコンフィグ既定 gate | hook の挙動 |
+| --- | --- | --- | --- |
+| `gh pr merge …` | `merge`（`irreversible`） | `ask` | deny（exit 2） |
+| `gh release create …` | `release-create`（`irreversible`） | `ask` | deny |
+| `git push --force` / `-f` / `--force-with-lease` | `force-push`（`irreversible`） | `ask` | deny |
+| `npm` / `pnpm` / `yarn publish` | `publish`（`irreversible`） | `ask` | deny |
+
+- **gate → 判定:** 解決した gate が `ask` なら deny（exit 2 + 理由を stderr）、`proceed` / `batch-confirm` なら allow。hook が hard-block するのは `ask` のみ（batch 確認は caller / prose 層の責務）。
+- **narrow gating（全 tool deny 事故の防止）:** policy を引くのは**上表の不可逆コマンドにマッチした時だけ**。それ以外（読取・編集・safe な git/gh/npm・非 Bash tool）は素通し。matcher にバグがあっても「危険コマンドを取りこぼす」方向にしか倒れず、全 tool を deny してセッションを wedge させることはない。
+- **一過性で hard-stop させない（`usage-guard-hook.mjs` から踏襲）:**
+  - **(a) file kill-switch:** `~/.claude/policy-guard/DISABLE` があれば冒頭で即 no-op allow。`!` シェルから `touch` すれば設定編集不要・セッション内で即解除できる。
+  - **(b) policy 読取不能・パース不能 → allow + stderr 警告:** `policy-read.mjs` が `degraded` を返す／resolver が throw する等で **gate を信頼できないとき**は deny せず allow する。gate 対象コマンドの検出はできても gate 値を信頼できないなら通す。**resumable prose-layer checkpoint（drive / health / lessons-triage）が同じ `policy-read.mjs`（fail-safe に `ask`）を引く一次ゲート**であり、hook は二次的な網なので broken policy でセッションを止めない側に倒す。
+  - **(c) proceed 上書き（`--merge` 相当）:** すでに gate を解決し自律を委任された caller（例 `drive --merge` は prose で merge を `proceed` に上書き）は `POLICY_GUARD_PROCEED=<action>[,<action>…]`（`all` / `*` も可）を export する。hook はその action を再ゲートせず allow する。これで正当な opt-in マージが強制網に阻まれない。
+- **subagent:** payload の `agent_id` を deny メッセージに `[origin: subagent <id>]` として付す（走行中 worker の mid-unit ceiling として機能）。
+
+### 配線（本 PR では自動配線しない）
+
+hook スクリプトは全 adapter payload に同梱されるが、**settings への配線は本 PR の scope 外**。将来 `hooks add policy`（[#174](https://github.com/ozzy-labs/skills/issues/174) の hooks CLI に追加予定。現状 `usage-guard` / `observability` のみ対応）が担う。それまでは手動で `~/.claude/settings.local.json` に 1 エントリ追加する（settings は mid-session reload されるため再起動不要）:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /home/<you>/.claude/skills/policy/policy-hook.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+> **hook スクリプトパスは絶対パスを手で埋める**（settings 内では skill-dir 相対参照が効かない）。パスは環境で揺れる:
+>
+> - **user-scope**（`npx @ozzylabs/skills install`）: `~/.claude/skills/policy/policy-hook.mjs`（`~` は展開されないので `/home/<you>/.claude/…` の形でフルに書く）
+> - **dogfood**（skills/commons リポ内）: `<repo>/.claude/skills/policy/policy-hook.mjs`
+>
+> どちらも「`policy-read.mjs` と同じ階層の `policy-hook.mjs`」を指す。matcher は不可逆コマンドが Bash 経由なので `"Bash"` で十分（`"*"` でも可・非 Bash tool は command が無く素通し）。
+
+**無効化:** `touch ~/.claude/policy-guard/DISABLE`（即時・設定編集不要）、または settings から上記エントリを削除（恒久）。
+
 ## 適用範囲
 
-本 skill は **契約（schema）+ 読取 substrate** のみを提供する。以下は本契約の上に別 PR で構築する（本 PR には含めない）:
+本 skill は **契約（schema）+ 読取 substrate + PreToolUse enforcement hook** を提供する。以下は本契約の上に別 PR で構築する（本 PR には含めない）:
 
-- **各 skill の適用**（implement / lessons-triage / topics 等のゲート記述を「自アクションを分類して policy を引く」に置換）。
-- **Claude Code の PreToolUse hook**（`policy-hook.mjs`。`gh pr merge` / `gh release` 等を実行エンジン側で policy 参照して deny/allow）。
+- **各 skill の適用**（implement / lessons-triage / topics 等のゲート記述を「自アクションを分類して policy を引く」に置換。R3 PR2/PR3 で実装済み）。
+- **hook の自動配線**（`hooks add policy`。[#174](https://github.com/ozzy-labs/skills/issues/174) の hooks CLI に追加予定）。
 
 ## 注意事項
 

--- a/dist/claude-code/.claude/skills/policy/policy-hook.mjs
+++ b/dist/claude-code/.claude/skills/policy/policy-hook.mjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+// policy-hook — PreToolUse architecture-enforcement gate for the central
+// autonomy policy (ADR-0028 R3, ozzy-labs/skills#181 PR 4/4).
+//
+// Wired into ~/.claude/settings.local.json as a PreToolUse hook (same wiring
+// shape as usage-guard-hook.mjs), this fires BEFORE every tool call — including
+// ones originating inside subagents, which carry an `agent_id` in the payload.
+// It is the execution-engine side of the policy stack: the SKILL.md prose layer
+// asks a skill to "classify your action and read the gate", but prose is only a
+// request. This hook makes a SPECIFIC set of irreversible commands
+// (`gh pr merge`, `gh release create`, `git push --force`/`-f`, `npm publish`)
+// physically un-runnable when the resolved gate is `ask` — the model cannot
+// talk its way past it.
+//
+// Detection is intentionally NARROW. The hook only pulls the policy when the
+// tool call's command matches one of the irreversible matchers below; every
+// other tool call (reads, edits, safe git/gh/npm, non-Bash tools) is allowed
+// untouched. This is the core safety property: because we only gate on a match,
+// a bug in the matcher can at worst FAIL to gate a dangerous command — it can
+// never deny ALL tools and wedge the session.
+//
+// Decision (PreToolUse contract):
+//   - matched + gate `ask` → DENY (exit 2 + a reason on stderr). Exit 2 is the
+//     harness signal that blocks the call even on older harnesses that key off
+//     the exit code.
+//   - matched + gate `proceed`/`batch-confirm` → ALLOW (the hook only hard-
+//     blocks `ask`; a batch confirmation is the caller/prose layer's job).
+//   - not matched → ALLOW (exit 0, silent).
+//
+// Fail-open (inherited from usage-guard-hook — "never hard-stop on our own
+// bug"):
+//   (a) file kill-switch: if `~/.claude/policy-guard/DISABLE` exists, the hook
+//       is an instant no-op ALLOW (checked FIRST, before any I/O, and itself
+//       fail-open). Escape hatch for a wedged session, no settings edit needed.
+//   (b) policy unreadable / unparseable (policy-read returns `degraded`, or the
+//       resolver throws / is missing) → ALLOW + a stderr warning. If we cannot
+//       even trust the gate, we do NOT block: the resumable prose-layer
+//       checkpoint (drive / health / lessons-triage) consults the SAME
+//       policy-read — which is fail-SAFE to `ask` — and is the primary gate. The
+//       hook is a secondary net, so it errs open to avoid wedging the session on
+//       a broken policy file.
+//   (c) proceed-override: a caller that has ALREADY resolved the gate and been
+//       granted autonomy (e.g. `drive --merge`, whose prose overrides merge to
+//       `proceed`) exports `POLICY_GUARD_PROCEED=<action>[,<action>...]`; the
+//       hook then allows that action without re-gating. This is how a legitimate
+//       opt-in merge is not blocked by the enforcement net.
+//
+// Design-for-tests: the matcher (`matchAction`), payload parse (`parsePayload`),
+// override check (`resolveProceedOverride`) and gate resolution
+// (`resolveGateForAction`) are all pure/injectable, and `run()` takes every
+// effect (stdin, kill-switch, gate resolver, warn/deny sinks) as a dep, so tests
+// exercise the whole thing with no network, no real ~/.claude reads, no spawned
+// process.
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// PreToolUse "deny" is signaled to the harness with exit code 2 (stderr is
+// surfaced to the model); 0 = allow. Named for clarity.
+const EXIT_ALLOW = 0;
+const EXIT_DENY = 2;
+
+// File kill-switch — the escape hatch. Built with path.join (HOME-anchored) so
+// no rewritable `~/.claude/skills/` literal appears in source (the dist user-scope
+// rewrite only targets `.agents|~/.claude/skills/` refs; `policy-guard/` is safe).
+export const DISABLE_PATH = join(homedir(), ".claude", "policy-guard", "DISABLE");
+
+// Env var a caller sets to pre-authorize specific actions (comma-separated
+// action names, or `all`/`*`). This is the `--merge`→proceed override channel:
+// a caller that has already been granted autonomy names the action here so the
+// enforcement net does not re-block it.
+export const PROCEED_ENV = "POLICY_GUARD_PROCEED";
+
+// Force-push flag detector: `--force`, `--force-with-lease`, or a short flag
+// token containing `f` (`-f`, `-fq`, …). Anchored on a token boundary so it does
+// not fire on `--foo` or a filename.
+const FORCE_FLAG = /(?:--force(?:-with-lease)?\b|(?:^|\s)-[a-z]*f[a-z]*(?=\s|$))/i;
+
+/**
+ * The irreversible-command matchers. Each entry maps a command shape to the
+ * central-policy action name + class the gate resolves against. The `class` is
+ * passed alongside the action so `resolveGate` can fall back to the class
+ * default even for an action not in policy-read's ACTION_CLASSES map (so a new
+ * irreversible command still resolves to the `irreversible` default = `ask`).
+ *
+ * Kept deliberately short + irreversible-only (ADR-0028's "irreversible /
+ * destructive" class). Reversible-local and externally-visible actions are the
+ * prose layer's job — the hook does NOT gate `gh pr create`, plain `git push`,
+ * etc., which keeps the "can only ever fail to gate, never deny everything"
+ * property.
+ * @type {ReadonlyArray<{action: string, class: string, test: (cmd: string) => boolean}>}
+ */
+export const IRREVERSIBLE_MATCHERS = Object.freeze([
+  { action: "merge", class: "irreversible", test: (c) => /\bgh\s+pr\s+merge\b/.test(c) },
+  {
+    action: "release-create",
+    class: "irreversible",
+    test: (c) => /\bgh\s+release\s+create\b/.test(c),
+  },
+  {
+    action: "force-push",
+    class: "irreversible",
+    test: (c) => /\bgit\s+push\b/.test(c) && FORCE_FLAG.test(c),
+  },
+  {
+    action: "publish",
+    class: "irreversible",
+    test: (c) => /\b(?:npm|pnpm|yarn)\s+publish\b/.test(c),
+  },
+]);
+
+/**
+ * Classify a command string. Returns the first matching irreversible action +
+ * class, or null when the command is not one the hook gates.
+ * @param {string|null|undefined} command
+ * @returns {{ action: string, class: string }|null}
+ */
+export function matchAction(command) {
+  if (typeof command !== "string" || command.trim() === "") return null;
+  for (const m of IRREVERSIBLE_MATCHERS) {
+    if (m.test(command)) return { action: m.action, class: m.class };
+  }
+  return null;
+}
+
+/**
+ * Read the entire hook stdin payload. Mirrors usage-guard-hook: resolves on end
+ * or error, and does not hang on a TTY (nothing piped).
+ * @param {NodeJS.ReadableStream} [stream]
+ * @returns {Promise<string>}
+ */
+export function readStdin(stream = process.stdin) {
+  return new Promise((resolve) => {
+    let data = "";
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      resolve(data);
+    };
+    stream.setEncoding?.("utf8");
+    stream.on("data", (chunk) => {
+      data += chunk;
+    });
+    stream.on("end", done);
+    stream.on("error", done);
+    if (stream.isTTY) done();
+  });
+}
+
+/**
+ * Parse the PreToolUse payload for the fields the hook needs: the tool name, the
+ * Bash command string (`tool_input.command`), and `agent_id` (present for
+ * subagent-originated calls) for logging. Tolerates empty / malformed input.
+ * @param {string} raw
+ * @returns {{ toolName: string|null, command: string|null, agentId: string|null }}
+ */
+export function parsePayload(raw) {
+  if (!raw?.trim()) return { toolName: null, command: null, agentId: null };
+  try {
+    const obj = JSON.parse(raw);
+    const toolName =
+      typeof obj?.tool_name === "string"
+        ? obj.tool_name
+        : typeof obj?.toolName === "string"
+          ? obj.toolName
+          : null;
+    const input = obj?.tool_input ?? obj?.toolInput ?? {};
+    const command = typeof input?.command === "string" ? input.command : null;
+    const agentId = obj?.agent_id ?? obj?.agentId ?? null;
+    return { toolName, command, agentId: typeof agentId === "string" ? agentId : null };
+  } catch {
+    return { toolName: null, command: null, agentId: null };
+  }
+}
+
+/**
+ * Whether the caller pre-authorized `action` via the proceed-override env var.
+ * The value is a comma-separated list of action names; `all` / `*` authorize
+ * everything. Missing/blank → not authorized.
+ * @param {NodeJS.ProcessEnv} env
+ * @param {string} action
+ * @returns {boolean}
+ */
+export function resolveProceedOverride(env, action) {
+  const raw = env?.[PROCEED_ENV];
+  if (!raw || typeof raw !== "string") return false;
+  const list = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return list.includes(action) || list.includes("all") || list.includes("*");
+}
+
+/**
+ * Resolve the effective gate for one {action, class} against the central policy
+ * by importing the sibling policy-read.mjs and reusing ITS reader (`run`) +
+ * ITS resolver (`resolveGate`) — no policy logic is duplicated here. Returns a
+ * shape the hook interprets:
+ *   - { gate, degraded: false }            → a trusted gate token
+ *   - { gate: null, degraded: true, reason } → could not trust a gate (module
+ *       missing/broken, or policy-read reported `degraded`); caller fails open.
+ *
+ * A dynamic import (not static) is deliberate: an install missing a healthy
+ * policy-read must degrade (→ fail open) rather than crash the hook at load.
+ * @param {{ action: string, klass: string, repoRoot: string }} query
+ * @param {{ importImpl?: (u: string) => Promise<unknown> }} [deps]
+ * @returns {Promise<{ gate: string|null, degraded: boolean, reason?: string, source?: string }>}
+ */
+export async function resolveGateForAction({ action, klass, repoRoot }, { importImpl } = {}) {
+  const imp = importImpl ?? ((u) => import(u));
+  const url = new URL("./policy-read.mjs", import.meta.url).href;
+  const mod = await imp(url);
+  if (!mod || typeof mod.run !== "function" || typeof mod.resolveGate !== "function") {
+    return { gate: null, degraded: true, reason: "policy-read missing run/resolveGate" };
+  }
+  const effective = await mod.run(["--repo-root", repoRoot]);
+  if (!effective || effective.degraded === true) {
+    return { gate: null, degraded: true, reason: "policy unreadable/unparseable (degraded)" };
+  }
+  const resolved = mod.resolveGate(effective, { action, class: klass });
+  if (!resolved || typeof resolved.gate !== "string") {
+    return { gate: null, degraded: true, reason: "gate could not be resolved" };
+  }
+  return { gate: resolved.gate, degraded: false, source: resolved.source };
+}
+
+/**
+ * Build the deny reason for a gated action. Names the action, the gate, and the
+ * three ways to proceed (opt-in env, edit policy, or the kill-switch).
+ * @param {string} action
+ * @param {string} gate
+ * @returns {string}
+ */
+export function buildDenyReason(action, gate) {
+  return (
+    `policy-guard: '${action}' is an irreversible action gated by the central autonomy policy ` +
+    `(gate=${gate}). Tool call blocked pending explicit approval. To authorize: set ` +
+    `${PROCEED_ENV}=${action} for a pre-approved run (e.g. drive --merge), relax the gate in ` +
+    `~/.agents/policy.yaml, or touch ${DISABLE_PATH} to disable the hook.`
+  );
+}
+
+/**
+ * Run the hook end to end. Returns the intended exit code (the CLI wrapper
+ * applies it). Every effect goes through an injected dep so tests assert without
+ * spawning a process or touching the network / real ~/.claude.
+ *
+ * @param {object} [deps]
+ * @param {() => Promise<string>} [deps.readStdinImpl]
+ * @param {() => boolean} [deps.killSwitchImpl]   // true → hook disabled (no-op)
+ * @param {(command: string|null) => ({action:string,class:string}|null)} [deps.matchActionImpl]
+ * @param {(q: {action:string,klass:string,repoRoot:string}) => Promise<{gate:string|null,degraded:boolean,reason?:string}>} [deps.resolveGateImpl]
+ * @param {NodeJS.ProcessEnv} [deps.env]
+ * @param {string} [deps.cwd]
+ * @param {(msg: string) => void} [deps.warn]
+ * @param {(msg: string) => void} [deps.deny]
+ * @returns {Promise<number>} exit code (0 allow / 2 deny)
+ */
+export async function run({
+  readStdinImpl = () => readStdin(),
+  killSwitchImpl = () => existsSync(DISABLE_PATH),
+  matchActionImpl = matchAction,
+  resolveGateImpl = resolveGateForAction,
+  env = process.env,
+  cwd = process.cwd(),
+  warn = (msg) => process.stderr.write(`${msg}\n`),
+  deny = (msg) => process.stderr.write(`${msg}\n`),
+} = {}) {
+  // (a) File kill-switch — checked FIRST, before any I/O, and itself fail-open
+  // (a check error → treated as not disabled → continue normally).
+  let disabled = false;
+  try {
+    disabled = !!killSwitchImpl();
+  } catch {
+    disabled = false;
+  }
+  if (disabled) {
+    warn(`policy-guard hook: disabled via kill-switch (${DISABLE_PATH}); allowing (no-op)`);
+    return EXIT_ALLOW;
+  }
+
+  const { command, agentId } = parsePayload(await readStdinImpl());
+  const origin = agentId ? `subagent ${agentId}` : "main session";
+
+  // Narrow gating: only pull the policy for a matched irreversible command.
+  // Everything else is allowed untouched (the "never deny all tools" property).
+  const matched = matchActionImpl(command);
+  if (!matched) return EXIT_ALLOW;
+
+  // (c) proceed-override: a caller already granted autonomy for this action
+  // (e.g. drive --merge overriding merge→proceed) named it in the env var.
+  if (resolveProceedOverride(env, matched.action)) {
+    warn(
+      `policy-guard hook: '${matched.action}' pre-authorized via ${PROCEED_ENV} (${origin}); allowing.`,
+    );
+    return EXIT_ALLOW;
+  }
+
+  // Resolve the gate. Any failure to obtain a TRUSTED gate → fail open + warn.
+  let gateResult;
+  try {
+    gateResult = await resolveGateImpl({
+      action: matched.action,
+      klass: matched.class,
+      repoRoot: cwd,
+    });
+  } catch (err) {
+    warn(
+      `policy-guard hook: gate resolution failed (${err?.message ?? err}) (${origin}); allowing (fail-open) — the prose-layer checkpoint still guards.`,
+    );
+    return EXIT_ALLOW;
+  }
+  // (b) policy unreadable / unparseable / unresolvable → fail open + warn.
+  if (!gateResult || gateResult.degraded === true || typeof gateResult.gate !== "string") {
+    const why = gateResult?.reason ? ` (${gateResult.reason})` : "";
+    warn(
+      `policy-guard hook: policy unreadable/unparseable${why} (${origin}); allowing (fail-open) — the prose-layer checkpoint still guards.`,
+    );
+    return EXIT_ALLOW;
+  }
+
+  // The hook only HARD-blocks `ask`. `proceed` / `batch-confirm` → allow (a
+  // batch confirmation belongs to the caller / prose layer, not this net).
+  if (gateResult.gate === "ask") {
+    deny(`${buildDenyReason(matched.action, gateResult.gate)} [origin: ${origin}]`);
+    return EXIT_DENY;
+  }
+  return EXIT_ALLOW;
+}
+
+// CLI entry — only when executed directly (not when imported by tests).
+const __isMain = (() => {
+  try {
+    return import.meta.url === `file://${process.argv[1]}`;
+  } catch {
+    return false;
+  }
+})();
+
+if (__isMain) {
+  run()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((err) => {
+      // Any unexpected error in the hook itself must fail open, never block.
+      process.stderr.write(
+        `policy-guard hook: fatal ${err?.message ?? err}; allowing (fail-open)\n`,
+      );
+      process.exitCode = EXIT_ALLOW;
+    });
+}

--- a/dist/codex-cli/.agents/skills/policy/SKILL.md
+++ b/dist/codex-cli/.agents/skills/policy/SKILL.md
@@ -96,12 +96,62 @@ fail-safe の作法:
 - **parse 不能なファイル** → そのファイルを無視し `degraded: true`。もう一方のファイル + 既定で解決する（危険クラスの既定は元々 `ask`）。
 - あらゆる失敗で throw せず exit 0。`&&` で連結した caller を壊さない。
 
+## PreToolUse enforcement hook（Claude Code / `policy-hook.mjs`）
+
+prose 層（各 skill の「自アクションを分類して policy を引く」）はあくまで **依頼**であり、モデルが無視・迂回し得る。`policy-hook.mjs`（sibling・`usage-guard-hook.mjs` と同型の PreToolUse hook）は**実行エンジン側の gate 強制**で、これを物理的に塞ぐ。全 tool 呼び出し前（subagent 内含む）に発火し、**特定の不可逆コマンド**を検出したときだけ policy を引いて deny/allow を決める。
+
+| 検出コマンド | 引く action（class） | ゼロコンフィグ既定 gate | hook の挙動 |
+| --- | --- | --- | --- |
+| `gh pr merge …` | `merge`（`irreversible`） | `ask` | deny（exit 2） |
+| `gh release create …` | `release-create`（`irreversible`） | `ask` | deny |
+| `git push --force` / `-f` / `--force-with-lease` | `force-push`（`irreversible`） | `ask` | deny |
+| `npm` / `pnpm` / `yarn publish` | `publish`（`irreversible`） | `ask` | deny |
+
+- **gate → 判定:** 解決した gate が `ask` なら deny（exit 2 + 理由を stderr）、`proceed` / `batch-confirm` なら allow。hook が hard-block するのは `ask` のみ（batch 確認は caller / prose 層の責務）。
+- **narrow gating（全 tool deny 事故の防止）:** policy を引くのは**上表の不可逆コマンドにマッチした時だけ**。それ以外（読取・編集・safe な git/gh/npm・非 Bash tool）は素通し。matcher にバグがあっても「危険コマンドを取りこぼす」方向にしか倒れず、全 tool を deny してセッションを wedge させることはない。
+- **一過性で hard-stop させない（`usage-guard-hook.mjs` から踏襲）:**
+  - **(a) file kill-switch:** `~/.claude/policy-guard/DISABLE` があれば冒頭で即 no-op allow。`!` シェルから `touch` すれば設定編集不要・セッション内で即解除できる。
+  - **(b) policy 読取不能・パース不能 → allow + stderr 警告:** `policy-read.mjs` が `degraded` を返す／resolver が throw する等で **gate を信頼できないとき**は deny せず allow する。gate 対象コマンドの検出はできても gate 値を信頼できないなら通す。**resumable prose-layer checkpoint（drive / health / lessons-triage）が同じ `policy-read.mjs`（fail-safe に `ask`）を引く一次ゲート**であり、hook は二次的な網なので broken policy でセッションを止めない側に倒す。
+  - **(c) proceed 上書き（`--merge` 相当）:** すでに gate を解決し自律を委任された caller（例 `drive --merge` は prose で merge を `proceed` に上書き）は `POLICY_GUARD_PROCEED=<action>[,<action>…]`（`all` / `*` も可）を export する。hook はその action を再ゲートせず allow する。これで正当な opt-in マージが強制網に阻まれない。
+- **subagent:** payload の `agent_id` を deny メッセージに `[origin: subagent <id>]` として付す（走行中 worker の mid-unit ceiling として機能）。
+
+### 配線（本 PR では自動配線しない）
+
+hook スクリプトは全 adapter payload に同梱されるが、**settings への配線は本 PR の scope 外**。将来 `hooks add policy`（[#174](https://github.com/ozzy-labs/skills/issues/174) の hooks CLI に追加予定。現状 `usage-guard` / `observability` のみ対応）が担う。それまでは手動で `~/.claude/settings.local.json` に 1 エントリ追加する（settings は mid-session reload されるため再起動不要）:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /home/<you>/.claude/skills/policy/policy-hook.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+> **hook スクリプトパスは絶対パスを手で埋める**（settings 内では skill-dir 相対参照が効かない）。パスは環境で揺れる:
+>
+> - **user-scope**（`npx @ozzylabs/skills install`）: `~/.claude/skills/policy/policy-hook.mjs`（`~` は展開されないので `/home/<you>/.claude/…` の形でフルに書く）
+> - **dogfood**（skills/commons リポ内）: `<repo>/.claude/skills/policy/policy-hook.mjs`
+>
+> どちらも「`policy-read.mjs` と同じ階層の `policy-hook.mjs`」を指す。matcher は不可逆コマンドが Bash 経由なので `"Bash"` で十分（`"*"` でも可・非 Bash tool は command が無く素通し）。
+
+**無効化:** `touch ~/.claude/policy-guard/DISABLE`（即時・設定編集不要）、または settings から上記エントリを削除（恒久）。
+
 ## 適用範囲
 
-本 skill は **契約（schema）+ 読取 substrate** のみを提供する。以下は本契約の上に別 PR で構築する（本 PR には含めない）:
+本 skill は **契約（schema）+ 読取 substrate + PreToolUse enforcement hook** を提供する。以下は本契約の上に別 PR で構築する（本 PR には含めない）:
 
-- **各 skill の適用**（implement / lessons-triage / topics 等のゲート記述を「自アクションを分類して policy を引く」に置換）。
-- **Claude Code の PreToolUse hook**（`policy-hook.mjs`。`gh pr merge` / `gh release` 等を実行エンジン側で policy 参照して deny/allow）。
+- **各 skill の適用**（implement / lessons-triage / topics 等のゲート記述を「自アクションを分類して policy を引く」に置換。R3 PR2/PR3 で実装済み）。
+- **hook の自動配線**（`hooks add policy`。[#174](https://github.com/ozzy-labs/skills/issues/174) の hooks CLI に追加予定）。
 
 ## 注意事項
 

--- a/dist/codex-cli/.agents/skills/policy/policy-hook.mjs
+++ b/dist/codex-cli/.agents/skills/policy/policy-hook.mjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+// policy-hook — PreToolUse architecture-enforcement gate for the central
+// autonomy policy (ADR-0028 R3, ozzy-labs/skills#181 PR 4/4).
+//
+// Wired into ~/.claude/settings.local.json as a PreToolUse hook (same wiring
+// shape as usage-guard-hook.mjs), this fires BEFORE every tool call — including
+// ones originating inside subagents, which carry an `agent_id` in the payload.
+// It is the execution-engine side of the policy stack: the SKILL.md prose layer
+// asks a skill to "classify your action and read the gate", but prose is only a
+// request. This hook makes a SPECIFIC set of irreversible commands
+// (`gh pr merge`, `gh release create`, `git push --force`/`-f`, `npm publish`)
+// physically un-runnable when the resolved gate is `ask` — the model cannot
+// talk its way past it.
+//
+// Detection is intentionally NARROW. The hook only pulls the policy when the
+// tool call's command matches one of the irreversible matchers below; every
+// other tool call (reads, edits, safe git/gh/npm, non-Bash tools) is allowed
+// untouched. This is the core safety property: because we only gate on a match,
+// a bug in the matcher can at worst FAIL to gate a dangerous command — it can
+// never deny ALL tools and wedge the session.
+//
+// Decision (PreToolUse contract):
+//   - matched + gate `ask` → DENY (exit 2 + a reason on stderr). Exit 2 is the
+//     harness signal that blocks the call even on older harnesses that key off
+//     the exit code.
+//   - matched + gate `proceed`/`batch-confirm` → ALLOW (the hook only hard-
+//     blocks `ask`; a batch confirmation is the caller/prose layer's job).
+//   - not matched → ALLOW (exit 0, silent).
+//
+// Fail-open (inherited from usage-guard-hook — "never hard-stop on our own
+// bug"):
+//   (a) file kill-switch: if `~/.claude/policy-guard/DISABLE` exists, the hook
+//       is an instant no-op ALLOW (checked FIRST, before any I/O, and itself
+//       fail-open). Escape hatch for a wedged session, no settings edit needed.
+//   (b) policy unreadable / unparseable (policy-read returns `degraded`, or the
+//       resolver throws / is missing) → ALLOW + a stderr warning. If we cannot
+//       even trust the gate, we do NOT block: the resumable prose-layer
+//       checkpoint (drive / health / lessons-triage) consults the SAME
+//       policy-read — which is fail-SAFE to `ask` — and is the primary gate. The
+//       hook is a secondary net, so it errs open to avoid wedging the session on
+//       a broken policy file.
+//   (c) proceed-override: a caller that has ALREADY resolved the gate and been
+//       granted autonomy (e.g. `drive --merge`, whose prose overrides merge to
+//       `proceed`) exports `POLICY_GUARD_PROCEED=<action>[,<action>...]`; the
+//       hook then allows that action without re-gating. This is how a legitimate
+//       opt-in merge is not blocked by the enforcement net.
+//
+// Design-for-tests: the matcher (`matchAction`), payload parse (`parsePayload`),
+// override check (`resolveProceedOverride`) and gate resolution
+// (`resolveGateForAction`) are all pure/injectable, and `run()` takes every
+// effect (stdin, kill-switch, gate resolver, warn/deny sinks) as a dep, so tests
+// exercise the whole thing with no network, no real ~/.claude reads, no spawned
+// process.
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// PreToolUse "deny" is signaled to the harness with exit code 2 (stderr is
+// surfaced to the model); 0 = allow. Named for clarity.
+const EXIT_ALLOW = 0;
+const EXIT_DENY = 2;
+
+// File kill-switch — the escape hatch. Built with path.join (HOME-anchored) so
+// no rewritable `~/.claude/skills/` literal appears in source (the dist user-scope
+// rewrite only targets `.agents|~/.claude/skills/` refs; `policy-guard/` is safe).
+export const DISABLE_PATH = join(homedir(), ".claude", "policy-guard", "DISABLE");
+
+// Env var a caller sets to pre-authorize specific actions (comma-separated
+// action names, or `all`/`*`). This is the `--merge`→proceed override channel:
+// a caller that has already been granted autonomy names the action here so the
+// enforcement net does not re-block it.
+export const PROCEED_ENV = "POLICY_GUARD_PROCEED";
+
+// Force-push flag detector: `--force`, `--force-with-lease`, or a short flag
+// token containing `f` (`-f`, `-fq`, …). Anchored on a token boundary so it does
+// not fire on `--foo` or a filename.
+const FORCE_FLAG = /(?:--force(?:-with-lease)?\b|(?:^|\s)-[a-z]*f[a-z]*(?=\s|$))/i;
+
+/**
+ * The irreversible-command matchers. Each entry maps a command shape to the
+ * central-policy action name + class the gate resolves against. The `class` is
+ * passed alongside the action so `resolveGate` can fall back to the class
+ * default even for an action not in policy-read's ACTION_CLASSES map (so a new
+ * irreversible command still resolves to the `irreversible` default = `ask`).
+ *
+ * Kept deliberately short + irreversible-only (ADR-0028's "irreversible /
+ * destructive" class). Reversible-local and externally-visible actions are the
+ * prose layer's job — the hook does NOT gate `gh pr create`, plain `git push`,
+ * etc., which keeps the "can only ever fail to gate, never deny everything"
+ * property.
+ * @type {ReadonlyArray<{action: string, class: string, test: (cmd: string) => boolean}>}
+ */
+export const IRREVERSIBLE_MATCHERS = Object.freeze([
+  { action: "merge", class: "irreversible", test: (c) => /\bgh\s+pr\s+merge\b/.test(c) },
+  {
+    action: "release-create",
+    class: "irreversible",
+    test: (c) => /\bgh\s+release\s+create\b/.test(c),
+  },
+  {
+    action: "force-push",
+    class: "irreversible",
+    test: (c) => /\bgit\s+push\b/.test(c) && FORCE_FLAG.test(c),
+  },
+  {
+    action: "publish",
+    class: "irreversible",
+    test: (c) => /\b(?:npm|pnpm|yarn)\s+publish\b/.test(c),
+  },
+]);
+
+/**
+ * Classify a command string. Returns the first matching irreversible action +
+ * class, or null when the command is not one the hook gates.
+ * @param {string|null|undefined} command
+ * @returns {{ action: string, class: string }|null}
+ */
+export function matchAction(command) {
+  if (typeof command !== "string" || command.trim() === "") return null;
+  for (const m of IRREVERSIBLE_MATCHERS) {
+    if (m.test(command)) return { action: m.action, class: m.class };
+  }
+  return null;
+}
+
+/**
+ * Read the entire hook stdin payload. Mirrors usage-guard-hook: resolves on end
+ * or error, and does not hang on a TTY (nothing piped).
+ * @param {NodeJS.ReadableStream} [stream]
+ * @returns {Promise<string>}
+ */
+export function readStdin(stream = process.stdin) {
+  return new Promise((resolve) => {
+    let data = "";
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      resolve(data);
+    };
+    stream.setEncoding?.("utf8");
+    stream.on("data", (chunk) => {
+      data += chunk;
+    });
+    stream.on("end", done);
+    stream.on("error", done);
+    if (stream.isTTY) done();
+  });
+}
+
+/**
+ * Parse the PreToolUse payload for the fields the hook needs: the tool name, the
+ * Bash command string (`tool_input.command`), and `agent_id` (present for
+ * subagent-originated calls) for logging. Tolerates empty / malformed input.
+ * @param {string} raw
+ * @returns {{ toolName: string|null, command: string|null, agentId: string|null }}
+ */
+export function parsePayload(raw) {
+  if (!raw?.trim()) return { toolName: null, command: null, agentId: null };
+  try {
+    const obj = JSON.parse(raw);
+    const toolName =
+      typeof obj?.tool_name === "string"
+        ? obj.tool_name
+        : typeof obj?.toolName === "string"
+          ? obj.toolName
+          : null;
+    const input = obj?.tool_input ?? obj?.toolInput ?? {};
+    const command = typeof input?.command === "string" ? input.command : null;
+    const agentId = obj?.agent_id ?? obj?.agentId ?? null;
+    return { toolName, command, agentId: typeof agentId === "string" ? agentId : null };
+  } catch {
+    return { toolName: null, command: null, agentId: null };
+  }
+}
+
+/**
+ * Whether the caller pre-authorized `action` via the proceed-override env var.
+ * The value is a comma-separated list of action names; `all` / `*` authorize
+ * everything. Missing/blank → not authorized.
+ * @param {NodeJS.ProcessEnv} env
+ * @param {string} action
+ * @returns {boolean}
+ */
+export function resolveProceedOverride(env, action) {
+  const raw = env?.[PROCEED_ENV];
+  if (!raw || typeof raw !== "string") return false;
+  const list = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return list.includes(action) || list.includes("all") || list.includes("*");
+}
+
+/**
+ * Resolve the effective gate for one {action, class} against the central policy
+ * by importing the sibling policy-read.mjs and reusing ITS reader (`run`) +
+ * ITS resolver (`resolveGate`) — no policy logic is duplicated here. Returns a
+ * shape the hook interprets:
+ *   - { gate, degraded: false }            → a trusted gate token
+ *   - { gate: null, degraded: true, reason } → could not trust a gate (module
+ *       missing/broken, or policy-read reported `degraded`); caller fails open.
+ *
+ * A dynamic import (not static) is deliberate: an install missing a healthy
+ * policy-read must degrade (→ fail open) rather than crash the hook at load.
+ * @param {{ action: string, klass: string, repoRoot: string }} query
+ * @param {{ importImpl?: (u: string) => Promise<unknown> }} [deps]
+ * @returns {Promise<{ gate: string|null, degraded: boolean, reason?: string, source?: string }>}
+ */
+export async function resolveGateForAction({ action, klass, repoRoot }, { importImpl } = {}) {
+  const imp = importImpl ?? ((u) => import(u));
+  const url = new URL("./policy-read.mjs", import.meta.url).href;
+  const mod = await imp(url);
+  if (!mod || typeof mod.run !== "function" || typeof mod.resolveGate !== "function") {
+    return { gate: null, degraded: true, reason: "policy-read missing run/resolveGate" };
+  }
+  const effective = await mod.run(["--repo-root", repoRoot]);
+  if (!effective || effective.degraded === true) {
+    return { gate: null, degraded: true, reason: "policy unreadable/unparseable (degraded)" };
+  }
+  const resolved = mod.resolveGate(effective, { action, class: klass });
+  if (!resolved || typeof resolved.gate !== "string") {
+    return { gate: null, degraded: true, reason: "gate could not be resolved" };
+  }
+  return { gate: resolved.gate, degraded: false, source: resolved.source };
+}
+
+/**
+ * Build the deny reason for a gated action. Names the action, the gate, and the
+ * three ways to proceed (opt-in env, edit policy, or the kill-switch).
+ * @param {string} action
+ * @param {string} gate
+ * @returns {string}
+ */
+export function buildDenyReason(action, gate) {
+  return (
+    `policy-guard: '${action}' is an irreversible action gated by the central autonomy policy ` +
+    `(gate=${gate}). Tool call blocked pending explicit approval. To authorize: set ` +
+    `${PROCEED_ENV}=${action} for a pre-approved run (e.g. drive --merge), relax the gate in ` +
+    `~/.agents/policy.yaml, or touch ${DISABLE_PATH} to disable the hook.`
+  );
+}
+
+/**
+ * Run the hook end to end. Returns the intended exit code (the CLI wrapper
+ * applies it). Every effect goes through an injected dep so tests assert without
+ * spawning a process or touching the network / real ~/.claude.
+ *
+ * @param {object} [deps]
+ * @param {() => Promise<string>} [deps.readStdinImpl]
+ * @param {() => boolean} [deps.killSwitchImpl]   // true → hook disabled (no-op)
+ * @param {(command: string|null) => ({action:string,class:string}|null)} [deps.matchActionImpl]
+ * @param {(q: {action:string,klass:string,repoRoot:string}) => Promise<{gate:string|null,degraded:boolean,reason?:string}>} [deps.resolveGateImpl]
+ * @param {NodeJS.ProcessEnv} [deps.env]
+ * @param {string} [deps.cwd]
+ * @param {(msg: string) => void} [deps.warn]
+ * @param {(msg: string) => void} [deps.deny]
+ * @returns {Promise<number>} exit code (0 allow / 2 deny)
+ */
+export async function run({
+  readStdinImpl = () => readStdin(),
+  killSwitchImpl = () => existsSync(DISABLE_PATH),
+  matchActionImpl = matchAction,
+  resolveGateImpl = resolveGateForAction,
+  env = process.env,
+  cwd = process.cwd(),
+  warn = (msg) => process.stderr.write(`${msg}\n`),
+  deny = (msg) => process.stderr.write(`${msg}\n`),
+} = {}) {
+  // (a) File kill-switch — checked FIRST, before any I/O, and itself fail-open
+  // (a check error → treated as not disabled → continue normally).
+  let disabled = false;
+  try {
+    disabled = !!killSwitchImpl();
+  } catch {
+    disabled = false;
+  }
+  if (disabled) {
+    warn(`policy-guard hook: disabled via kill-switch (${DISABLE_PATH}); allowing (no-op)`);
+    return EXIT_ALLOW;
+  }
+
+  const { command, agentId } = parsePayload(await readStdinImpl());
+  const origin = agentId ? `subagent ${agentId}` : "main session";
+
+  // Narrow gating: only pull the policy for a matched irreversible command.
+  // Everything else is allowed untouched (the "never deny all tools" property).
+  const matched = matchActionImpl(command);
+  if (!matched) return EXIT_ALLOW;
+
+  // (c) proceed-override: a caller already granted autonomy for this action
+  // (e.g. drive --merge overriding merge→proceed) named it in the env var.
+  if (resolveProceedOverride(env, matched.action)) {
+    warn(
+      `policy-guard hook: '${matched.action}' pre-authorized via ${PROCEED_ENV} (${origin}); allowing.`,
+    );
+    return EXIT_ALLOW;
+  }
+
+  // Resolve the gate. Any failure to obtain a TRUSTED gate → fail open + warn.
+  let gateResult;
+  try {
+    gateResult = await resolveGateImpl({
+      action: matched.action,
+      klass: matched.class,
+      repoRoot: cwd,
+    });
+  } catch (err) {
+    warn(
+      `policy-guard hook: gate resolution failed (${err?.message ?? err}) (${origin}); allowing (fail-open) — the prose-layer checkpoint still guards.`,
+    );
+    return EXIT_ALLOW;
+  }
+  // (b) policy unreadable / unparseable / unresolvable → fail open + warn.
+  if (!gateResult || gateResult.degraded === true || typeof gateResult.gate !== "string") {
+    const why = gateResult?.reason ? ` (${gateResult.reason})` : "";
+    warn(
+      `policy-guard hook: policy unreadable/unparseable${why} (${origin}); allowing (fail-open) — the prose-layer checkpoint still guards.`,
+    );
+    return EXIT_ALLOW;
+  }
+
+  // The hook only HARD-blocks `ask`. `proceed` / `batch-confirm` → allow (a
+  // batch confirmation belongs to the caller / prose layer, not this net).
+  if (gateResult.gate === "ask") {
+    deny(`${buildDenyReason(matched.action, gateResult.gate)} [origin: ${origin}]`);
+    return EXIT_DENY;
+  }
+  return EXIT_ALLOW;
+}
+
+// CLI entry — only when executed directly (not when imported by tests).
+const __isMain = (() => {
+  try {
+    return import.meta.url === `file://${process.argv[1]}`;
+  } catch {
+    return false;
+  }
+})();
+
+if (__isMain) {
+  run()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((err) => {
+      // Any unexpected error in the hook itself must fail open, never block.
+      process.stderr.write(
+        `policy-guard hook: fatal ${err?.message ?? err}; allowing (fail-open)\n`,
+      );
+      process.exitCode = EXIT_ALLOW;
+    });
+}

--- a/dist/copilot/.agents/skills/policy/SKILL.md
+++ b/dist/copilot/.agents/skills/policy/SKILL.md
@@ -96,12 +96,62 @@ fail-safe の作法:
 - **parse 不能なファイル** → そのファイルを無視し `degraded: true`。もう一方のファイル + 既定で解決する（危険クラスの既定は元々 `ask`）。
 - あらゆる失敗で throw せず exit 0。`&&` で連結した caller を壊さない。
 
+## PreToolUse enforcement hook（Claude Code / `policy-hook.mjs`）
+
+prose 層（各 skill の「自アクションを分類して policy を引く」）はあくまで **依頼**であり、モデルが無視・迂回し得る。`policy-hook.mjs`（sibling・`usage-guard-hook.mjs` と同型の PreToolUse hook）は**実行エンジン側の gate 強制**で、これを物理的に塞ぐ。全 tool 呼び出し前（subagent 内含む）に発火し、**特定の不可逆コマンド**を検出したときだけ policy を引いて deny/allow を決める。
+
+| 検出コマンド | 引く action（class） | ゼロコンフィグ既定 gate | hook の挙動 |
+| --- | --- | --- | --- |
+| `gh pr merge …` | `merge`（`irreversible`） | `ask` | deny（exit 2） |
+| `gh release create …` | `release-create`（`irreversible`） | `ask` | deny |
+| `git push --force` / `-f` / `--force-with-lease` | `force-push`（`irreversible`） | `ask` | deny |
+| `npm` / `pnpm` / `yarn publish` | `publish`（`irreversible`） | `ask` | deny |
+
+- **gate → 判定:** 解決した gate が `ask` なら deny（exit 2 + 理由を stderr）、`proceed` / `batch-confirm` なら allow。hook が hard-block するのは `ask` のみ（batch 確認は caller / prose 層の責務）。
+- **narrow gating（全 tool deny 事故の防止）:** policy を引くのは**上表の不可逆コマンドにマッチした時だけ**。それ以外（読取・編集・safe な git/gh/npm・非 Bash tool）は素通し。matcher にバグがあっても「危険コマンドを取りこぼす」方向にしか倒れず、全 tool を deny してセッションを wedge させることはない。
+- **一過性で hard-stop させない（`usage-guard-hook.mjs` から踏襲）:**
+  - **(a) file kill-switch:** `~/.claude/policy-guard/DISABLE` があれば冒頭で即 no-op allow。`!` シェルから `touch` すれば設定編集不要・セッション内で即解除できる。
+  - **(b) policy 読取不能・パース不能 → allow + stderr 警告:** `policy-read.mjs` が `degraded` を返す／resolver が throw する等で **gate を信頼できないとき**は deny せず allow する。gate 対象コマンドの検出はできても gate 値を信頼できないなら通す。**resumable prose-layer checkpoint（drive / health / lessons-triage）が同じ `policy-read.mjs`（fail-safe に `ask`）を引く一次ゲート**であり、hook は二次的な網なので broken policy でセッションを止めない側に倒す。
+  - **(c) proceed 上書き（`--merge` 相当）:** すでに gate を解決し自律を委任された caller（例 `drive --merge` は prose で merge を `proceed` に上書き）は `POLICY_GUARD_PROCEED=<action>[,<action>…]`（`all` / `*` も可）を export する。hook はその action を再ゲートせず allow する。これで正当な opt-in マージが強制網に阻まれない。
+- **subagent:** payload の `agent_id` を deny メッセージに `[origin: subagent <id>]` として付す（走行中 worker の mid-unit ceiling として機能）。
+
+### 配線（本 PR では自動配線しない）
+
+hook スクリプトは全 adapter payload に同梱されるが、**settings への配線は本 PR の scope 外**。将来 `hooks add policy`（[#174](https://github.com/ozzy-labs/skills/issues/174) の hooks CLI に追加予定。現状 `usage-guard` / `observability` のみ対応）が担う。それまでは手動で `~/.claude/settings.local.json` に 1 エントリ追加する（settings は mid-session reload されるため再起動不要）:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /home/<you>/.claude/skills/policy/policy-hook.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+> **hook スクリプトパスは絶対パスを手で埋める**（settings 内では skill-dir 相対参照が効かない）。パスは環境で揺れる:
+>
+> - **user-scope**（`npx @ozzylabs/skills install`）: `~/.claude/skills/policy/policy-hook.mjs`（`~` は展開されないので `/home/<you>/.claude/…` の形でフルに書く）
+> - **dogfood**（skills/commons リポ内）: `<repo>/.claude/skills/policy/policy-hook.mjs`
+>
+> どちらも「`policy-read.mjs` と同じ階層の `policy-hook.mjs`」を指す。matcher は不可逆コマンドが Bash 経由なので `"Bash"` で十分（`"*"` でも可・非 Bash tool は command が無く素通し）。
+
+**無効化:** `touch ~/.claude/policy-guard/DISABLE`（即時・設定編集不要）、または settings から上記エントリを削除（恒久）。
+
 ## 適用範囲
 
-本 skill は **契約（schema）+ 読取 substrate** のみを提供する。以下は本契約の上に別 PR で構築する（本 PR には含めない）:
+本 skill は **契約（schema）+ 読取 substrate + PreToolUse enforcement hook** を提供する。以下は本契約の上に別 PR で構築する（本 PR には含めない）:
 
-- **各 skill の適用**（implement / lessons-triage / topics 等のゲート記述を「自アクションを分類して policy を引く」に置換）。
-- **Claude Code の PreToolUse hook**（`policy-hook.mjs`。`gh pr merge` / `gh release` 等を実行エンジン側で policy 参照して deny/allow）。
+- **各 skill の適用**（implement / lessons-triage / topics 等のゲート記述を「自アクションを分類して policy を引く」に置換。R3 PR2/PR3 で実装済み）。
+- **hook の自動配線**（`hooks add policy`。[#174](https://github.com/ozzy-labs/skills/issues/174) の hooks CLI に追加予定）。
 
 ## 注意事項
 

--- a/dist/copilot/.agents/skills/policy/policy-hook.mjs
+++ b/dist/copilot/.agents/skills/policy/policy-hook.mjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+// policy-hook — PreToolUse architecture-enforcement gate for the central
+// autonomy policy (ADR-0028 R3, ozzy-labs/skills#181 PR 4/4).
+//
+// Wired into ~/.claude/settings.local.json as a PreToolUse hook (same wiring
+// shape as usage-guard-hook.mjs), this fires BEFORE every tool call — including
+// ones originating inside subagents, which carry an `agent_id` in the payload.
+// It is the execution-engine side of the policy stack: the SKILL.md prose layer
+// asks a skill to "classify your action and read the gate", but prose is only a
+// request. This hook makes a SPECIFIC set of irreversible commands
+// (`gh pr merge`, `gh release create`, `git push --force`/`-f`, `npm publish`)
+// physically un-runnable when the resolved gate is `ask` — the model cannot
+// talk its way past it.
+//
+// Detection is intentionally NARROW. The hook only pulls the policy when the
+// tool call's command matches one of the irreversible matchers below; every
+// other tool call (reads, edits, safe git/gh/npm, non-Bash tools) is allowed
+// untouched. This is the core safety property: because we only gate on a match,
+// a bug in the matcher can at worst FAIL to gate a dangerous command — it can
+// never deny ALL tools and wedge the session.
+//
+// Decision (PreToolUse contract):
+//   - matched + gate `ask` → DENY (exit 2 + a reason on stderr). Exit 2 is the
+//     harness signal that blocks the call even on older harnesses that key off
+//     the exit code.
+//   - matched + gate `proceed`/`batch-confirm` → ALLOW (the hook only hard-
+//     blocks `ask`; a batch confirmation is the caller/prose layer's job).
+//   - not matched → ALLOW (exit 0, silent).
+//
+// Fail-open (inherited from usage-guard-hook — "never hard-stop on our own
+// bug"):
+//   (a) file kill-switch: if `~/.claude/policy-guard/DISABLE` exists, the hook
+//       is an instant no-op ALLOW (checked FIRST, before any I/O, and itself
+//       fail-open). Escape hatch for a wedged session, no settings edit needed.
+//   (b) policy unreadable / unparseable (policy-read returns `degraded`, or the
+//       resolver throws / is missing) → ALLOW + a stderr warning. If we cannot
+//       even trust the gate, we do NOT block: the resumable prose-layer
+//       checkpoint (drive / health / lessons-triage) consults the SAME
+//       policy-read — which is fail-SAFE to `ask` — and is the primary gate. The
+//       hook is a secondary net, so it errs open to avoid wedging the session on
+//       a broken policy file.
+//   (c) proceed-override: a caller that has ALREADY resolved the gate and been
+//       granted autonomy (e.g. `drive --merge`, whose prose overrides merge to
+//       `proceed`) exports `POLICY_GUARD_PROCEED=<action>[,<action>...]`; the
+//       hook then allows that action without re-gating. This is how a legitimate
+//       opt-in merge is not blocked by the enforcement net.
+//
+// Design-for-tests: the matcher (`matchAction`), payload parse (`parsePayload`),
+// override check (`resolveProceedOverride`) and gate resolution
+// (`resolveGateForAction`) are all pure/injectable, and `run()` takes every
+// effect (stdin, kill-switch, gate resolver, warn/deny sinks) as a dep, so tests
+// exercise the whole thing with no network, no real ~/.claude reads, no spawned
+// process.
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// PreToolUse "deny" is signaled to the harness with exit code 2 (stderr is
+// surfaced to the model); 0 = allow. Named for clarity.
+const EXIT_ALLOW = 0;
+const EXIT_DENY = 2;
+
+// File kill-switch — the escape hatch. Built with path.join (HOME-anchored) so
+// no rewritable `~/.claude/skills/` literal appears in source (the dist user-scope
+// rewrite only targets `.agents|~/.claude/skills/` refs; `policy-guard/` is safe).
+export const DISABLE_PATH = join(homedir(), ".claude", "policy-guard", "DISABLE");
+
+// Env var a caller sets to pre-authorize specific actions (comma-separated
+// action names, or `all`/`*`). This is the `--merge`→proceed override channel:
+// a caller that has already been granted autonomy names the action here so the
+// enforcement net does not re-block it.
+export const PROCEED_ENV = "POLICY_GUARD_PROCEED";
+
+// Force-push flag detector: `--force`, `--force-with-lease`, or a short flag
+// token containing `f` (`-f`, `-fq`, …). Anchored on a token boundary so it does
+// not fire on `--foo` or a filename.
+const FORCE_FLAG = /(?:--force(?:-with-lease)?\b|(?:^|\s)-[a-z]*f[a-z]*(?=\s|$))/i;
+
+/**
+ * The irreversible-command matchers. Each entry maps a command shape to the
+ * central-policy action name + class the gate resolves against. The `class` is
+ * passed alongside the action so `resolveGate` can fall back to the class
+ * default even for an action not in policy-read's ACTION_CLASSES map (so a new
+ * irreversible command still resolves to the `irreversible` default = `ask`).
+ *
+ * Kept deliberately short + irreversible-only (ADR-0028's "irreversible /
+ * destructive" class). Reversible-local and externally-visible actions are the
+ * prose layer's job — the hook does NOT gate `gh pr create`, plain `git push`,
+ * etc., which keeps the "can only ever fail to gate, never deny everything"
+ * property.
+ * @type {ReadonlyArray<{action: string, class: string, test: (cmd: string) => boolean}>}
+ */
+export const IRREVERSIBLE_MATCHERS = Object.freeze([
+  { action: "merge", class: "irreversible", test: (c) => /\bgh\s+pr\s+merge\b/.test(c) },
+  {
+    action: "release-create",
+    class: "irreversible",
+    test: (c) => /\bgh\s+release\s+create\b/.test(c),
+  },
+  {
+    action: "force-push",
+    class: "irreversible",
+    test: (c) => /\bgit\s+push\b/.test(c) && FORCE_FLAG.test(c),
+  },
+  {
+    action: "publish",
+    class: "irreversible",
+    test: (c) => /\b(?:npm|pnpm|yarn)\s+publish\b/.test(c),
+  },
+]);
+
+/**
+ * Classify a command string. Returns the first matching irreversible action +
+ * class, or null when the command is not one the hook gates.
+ * @param {string|null|undefined} command
+ * @returns {{ action: string, class: string }|null}
+ */
+export function matchAction(command) {
+  if (typeof command !== "string" || command.trim() === "") return null;
+  for (const m of IRREVERSIBLE_MATCHERS) {
+    if (m.test(command)) return { action: m.action, class: m.class };
+  }
+  return null;
+}
+
+/**
+ * Read the entire hook stdin payload. Mirrors usage-guard-hook: resolves on end
+ * or error, and does not hang on a TTY (nothing piped).
+ * @param {NodeJS.ReadableStream} [stream]
+ * @returns {Promise<string>}
+ */
+export function readStdin(stream = process.stdin) {
+  return new Promise((resolve) => {
+    let data = "";
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      resolve(data);
+    };
+    stream.setEncoding?.("utf8");
+    stream.on("data", (chunk) => {
+      data += chunk;
+    });
+    stream.on("end", done);
+    stream.on("error", done);
+    if (stream.isTTY) done();
+  });
+}
+
+/**
+ * Parse the PreToolUse payload for the fields the hook needs: the tool name, the
+ * Bash command string (`tool_input.command`), and `agent_id` (present for
+ * subagent-originated calls) for logging. Tolerates empty / malformed input.
+ * @param {string} raw
+ * @returns {{ toolName: string|null, command: string|null, agentId: string|null }}
+ */
+export function parsePayload(raw) {
+  if (!raw?.trim()) return { toolName: null, command: null, agentId: null };
+  try {
+    const obj = JSON.parse(raw);
+    const toolName =
+      typeof obj?.tool_name === "string"
+        ? obj.tool_name
+        : typeof obj?.toolName === "string"
+          ? obj.toolName
+          : null;
+    const input = obj?.tool_input ?? obj?.toolInput ?? {};
+    const command = typeof input?.command === "string" ? input.command : null;
+    const agentId = obj?.agent_id ?? obj?.agentId ?? null;
+    return { toolName, command, agentId: typeof agentId === "string" ? agentId : null };
+  } catch {
+    return { toolName: null, command: null, agentId: null };
+  }
+}
+
+/**
+ * Whether the caller pre-authorized `action` via the proceed-override env var.
+ * The value is a comma-separated list of action names; `all` / `*` authorize
+ * everything. Missing/blank → not authorized.
+ * @param {NodeJS.ProcessEnv} env
+ * @param {string} action
+ * @returns {boolean}
+ */
+export function resolveProceedOverride(env, action) {
+  const raw = env?.[PROCEED_ENV];
+  if (!raw || typeof raw !== "string") return false;
+  const list = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return list.includes(action) || list.includes("all") || list.includes("*");
+}
+
+/**
+ * Resolve the effective gate for one {action, class} against the central policy
+ * by importing the sibling policy-read.mjs and reusing ITS reader (`run`) +
+ * ITS resolver (`resolveGate`) — no policy logic is duplicated here. Returns a
+ * shape the hook interprets:
+ *   - { gate, degraded: false }            → a trusted gate token
+ *   - { gate: null, degraded: true, reason } → could not trust a gate (module
+ *       missing/broken, or policy-read reported `degraded`); caller fails open.
+ *
+ * A dynamic import (not static) is deliberate: an install missing a healthy
+ * policy-read must degrade (→ fail open) rather than crash the hook at load.
+ * @param {{ action: string, klass: string, repoRoot: string }} query
+ * @param {{ importImpl?: (u: string) => Promise<unknown> }} [deps]
+ * @returns {Promise<{ gate: string|null, degraded: boolean, reason?: string, source?: string }>}
+ */
+export async function resolveGateForAction({ action, klass, repoRoot }, { importImpl } = {}) {
+  const imp = importImpl ?? ((u) => import(u));
+  const url = new URL("./policy-read.mjs", import.meta.url).href;
+  const mod = await imp(url);
+  if (!mod || typeof mod.run !== "function" || typeof mod.resolveGate !== "function") {
+    return { gate: null, degraded: true, reason: "policy-read missing run/resolveGate" };
+  }
+  const effective = await mod.run(["--repo-root", repoRoot]);
+  if (!effective || effective.degraded === true) {
+    return { gate: null, degraded: true, reason: "policy unreadable/unparseable (degraded)" };
+  }
+  const resolved = mod.resolveGate(effective, { action, class: klass });
+  if (!resolved || typeof resolved.gate !== "string") {
+    return { gate: null, degraded: true, reason: "gate could not be resolved" };
+  }
+  return { gate: resolved.gate, degraded: false, source: resolved.source };
+}
+
+/**
+ * Build the deny reason for a gated action. Names the action, the gate, and the
+ * three ways to proceed (opt-in env, edit policy, or the kill-switch).
+ * @param {string} action
+ * @param {string} gate
+ * @returns {string}
+ */
+export function buildDenyReason(action, gate) {
+  return (
+    `policy-guard: '${action}' is an irreversible action gated by the central autonomy policy ` +
+    `(gate=${gate}). Tool call blocked pending explicit approval. To authorize: set ` +
+    `${PROCEED_ENV}=${action} for a pre-approved run (e.g. drive --merge), relax the gate in ` +
+    `~/.agents/policy.yaml, or touch ${DISABLE_PATH} to disable the hook.`
+  );
+}
+
+/**
+ * Run the hook end to end. Returns the intended exit code (the CLI wrapper
+ * applies it). Every effect goes through an injected dep so tests assert without
+ * spawning a process or touching the network / real ~/.claude.
+ *
+ * @param {object} [deps]
+ * @param {() => Promise<string>} [deps.readStdinImpl]
+ * @param {() => boolean} [deps.killSwitchImpl]   // true → hook disabled (no-op)
+ * @param {(command: string|null) => ({action:string,class:string}|null)} [deps.matchActionImpl]
+ * @param {(q: {action:string,klass:string,repoRoot:string}) => Promise<{gate:string|null,degraded:boolean,reason?:string}>} [deps.resolveGateImpl]
+ * @param {NodeJS.ProcessEnv} [deps.env]
+ * @param {string} [deps.cwd]
+ * @param {(msg: string) => void} [deps.warn]
+ * @param {(msg: string) => void} [deps.deny]
+ * @returns {Promise<number>} exit code (0 allow / 2 deny)
+ */
+export async function run({
+  readStdinImpl = () => readStdin(),
+  killSwitchImpl = () => existsSync(DISABLE_PATH),
+  matchActionImpl = matchAction,
+  resolveGateImpl = resolveGateForAction,
+  env = process.env,
+  cwd = process.cwd(),
+  warn = (msg) => process.stderr.write(`${msg}\n`),
+  deny = (msg) => process.stderr.write(`${msg}\n`),
+} = {}) {
+  // (a) File kill-switch — checked FIRST, before any I/O, and itself fail-open
+  // (a check error → treated as not disabled → continue normally).
+  let disabled = false;
+  try {
+    disabled = !!killSwitchImpl();
+  } catch {
+    disabled = false;
+  }
+  if (disabled) {
+    warn(`policy-guard hook: disabled via kill-switch (${DISABLE_PATH}); allowing (no-op)`);
+    return EXIT_ALLOW;
+  }
+
+  const { command, agentId } = parsePayload(await readStdinImpl());
+  const origin = agentId ? `subagent ${agentId}` : "main session";
+
+  // Narrow gating: only pull the policy for a matched irreversible command.
+  // Everything else is allowed untouched (the "never deny all tools" property).
+  const matched = matchActionImpl(command);
+  if (!matched) return EXIT_ALLOW;
+
+  // (c) proceed-override: a caller already granted autonomy for this action
+  // (e.g. drive --merge overriding merge→proceed) named it in the env var.
+  if (resolveProceedOverride(env, matched.action)) {
+    warn(
+      `policy-guard hook: '${matched.action}' pre-authorized via ${PROCEED_ENV} (${origin}); allowing.`,
+    );
+    return EXIT_ALLOW;
+  }
+
+  // Resolve the gate. Any failure to obtain a TRUSTED gate → fail open + warn.
+  let gateResult;
+  try {
+    gateResult = await resolveGateImpl({
+      action: matched.action,
+      klass: matched.class,
+      repoRoot: cwd,
+    });
+  } catch (err) {
+    warn(
+      `policy-guard hook: gate resolution failed (${err?.message ?? err}) (${origin}); allowing (fail-open) — the prose-layer checkpoint still guards.`,
+    );
+    return EXIT_ALLOW;
+  }
+  // (b) policy unreadable / unparseable / unresolvable → fail open + warn.
+  if (!gateResult || gateResult.degraded === true || typeof gateResult.gate !== "string") {
+    const why = gateResult?.reason ? ` (${gateResult.reason})` : "";
+    warn(
+      `policy-guard hook: policy unreadable/unparseable${why} (${origin}); allowing (fail-open) — the prose-layer checkpoint still guards.`,
+    );
+    return EXIT_ALLOW;
+  }
+
+  // The hook only HARD-blocks `ask`. `proceed` / `batch-confirm` → allow (a
+  // batch confirmation belongs to the caller / prose layer, not this net).
+  if (gateResult.gate === "ask") {
+    deny(`${buildDenyReason(matched.action, gateResult.gate)} [origin: ${origin}]`);
+    return EXIT_DENY;
+  }
+  return EXIT_ALLOW;
+}
+
+// CLI entry — only when executed directly (not when imported by tests).
+const __isMain = (() => {
+  try {
+    return import.meta.url === `file://${process.argv[1]}`;
+  } catch {
+    return false;
+  }
+})();
+
+if (__isMain) {
+  run()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((err) => {
+      // Any unexpected error in the hook itself must fail open, never block.
+      process.stderr.write(
+        `policy-guard hook: fatal ${err?.message ?? err}; allowing (fail-open)\n`,
+      );
+      process.exitCode = EXIT_ALLOW;
+    });
+}

--- a/dist/gemini-cli/.agents/skills/policy/SKILL.md
+++ b/dist/gemini-cli/.agents/skills/policy/SKILL.md
@@ -96,12 +96,62 @@ fail-safe の作法:
 - **parse 不能なファイル** → そのファイルを無視し `degraded: true`。もう一方のファイル + 既定で解決する（危険クラスの既定は元々 `ask`）。
 - あらゆる失敗で throw せず exit 0。`&&` で連結した caller を壊さない。
 
+## PreToolUse enforcement hook（Claude Code / `policy-hook.mjs`）
+
+prose 層（各 skill の「自アクションを分類して policy を引く」）はあくまで **依頼**であり、モデルが無視・迂回し得る。`policy-hook.mjs`（sibling・`usage-guard-hook.mjs` と同型の PreToolUse hook）は**実行エンジン側の gate 強制**で、これを物理的に塞ぐ。全 tool 呼び出し前（subagent 内含む）に発火し、**特定の不可逆コマンド**を検出したときだけ policy を引いて deny/allow を決める。
+
+| 検出コマンド | 引く action（class） | ゼロコンフィグ既定 gate | hook の挙動 |
+| --- | --- | --- | --- |
+| `gh pr merge …` | `merge`（`irreversible`） | `ask` | deny（exit 2） |
+| `gh release create …` | `release-create`（`irreversible`） | `ask` | deny |
+| `git push --force` / `-f` / `--force-with-lease` | `force-push`（`irreversible`） | `ask` | deny |
+| `npm` / `pnpm` / `yarn publish` | `publish`（`irreversible`） | `ask` | deny |
+
+- **gate → 判定:** 解決した gate が `ask` なら deny（exit 2 + 理由を stderr）、`proceed` / `batch-confirm` なら allow。hook が hard-block するのは `ask` のみ（batch 確認は caller / prose 層の責務）。
+- **narrow gating（全 tool deny 事故の防止）:** policy を引くのは**上表の不可逆コマンドにマッチした時だけ**。それ以外（読取・編集・safe な git/gh/npm・非 Bash tool）は素通し。matcher にバグがあっても「危険コマンドを取りこぼす」方向にしか倒れず、全 tool を deny してセッションを wedge させることはない。
+- **一過性で hard-stop させない（`usage-guard-hook.mjs` から踏襲）:**
+  - **(a) file kill-switch:** `~/.claude/policy-guard/DISABLE` があれば冒頭で即 no-op allow。`!` シェルから `touch` すれば設定編集不要・セッション内で即解除できる。
+  - **(b) policy 読取不能・パース不能 → allow + stderr 警告:** `policy-read.mjs` が `degraded` を返す／resolver が throw する等で **gate を信頼できないとき**は deny せず allow する。gate 対象コマンドの検出はできても gate 値を信頼できないなら通す。**resumable prose-layer checkpoint（drive / health / lessons-triage）が同じ `policy-read.mjs`（fail-safe に `ask`）を引く一次ゲート**であり、hook は二次的な網なので broken policy でセッションを止めない側に倒す。
+  - **(c) proceed 上書き（`--merge` 相当）:** すでに gate を解決し自律を委任された caller（例 `drive --merge` は prose で merge を `proceed` に上書き）は `POLICY_GUARD_PROCEED=<action>[,<action>…]`（`all` / `*` も可）を export する。hook はその action を再ゲートせず allow する。これで正当な opt-in マージが強制網に阻まれない。
+- **subagent:** payload の `agent_id` を deny メッセージに `[origin: subagent <id>]` として付す（走行中 worker の mid-unit ceiling として機能）。
+
+### 配線（本 PR では自動配線しない）
+
+hook スクリプトは全 adapter payload に同梱されるが、**settings への配線は本 PR の scope 外**。将来 `hooks add policy`（[#174](https://github.com/ozzy-labs/skills/issues/174) の hooks CLI に追加予定。現状 `usage-guard` / `observability` のみ対応）が担う。それまでは手動で `~/.claude/settings.local.json` に 1 エントリ追加する（settings は mid-session reload されるため再起動不要）:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /home/<you>/.claude/skills/policy/policy-hook.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+> **hook スクリプトパスは絶対パスを手で埋める**（settings 内では skill-dir 相対参照が効かない）。パスは環境で揺れる:
+>
+> - **user-scope**（`npx @ozzylabs/skills install`）: `~/.claude/skills/policy/policy-hook.mjs`（`~` は展開されないので `/home/<you>/.claude/…` の形でフルに書く）
+> - **dogfood**（skills/commons リポ内）: `<repo>/.claude/skills/policy/policy-hook.mjs`
+>
+> どちらも「`policy-read.mjs` と同じ階層の `policy-hook.mjs`」を指す。matcher は不可逆コマンドが Bash 経由なので `"Bash"` で十分（`"*"` でも可・非 Bash tool は command が無く素通し）。
+
+**無効化:** `touch ~/.claude/policy-guard/DISABLE`（即時・設定編集不要）、または settings から上記エントリを削除（恒久）。
+
 ## 適用範囲
 
-本 skill は **契約（schema）+ 読取 substrate** のみを提供する。以下は本契約の上に別 PR で構築する（本 PR には含めない）:
+本 skill は **契約（schema）+ 読取 substrate + PreToolUse enforcement hook** を提供する。以下は本契約の上に別 PR で構築する（本 PR には含めない）:
 
-- **各 skill の適用**（implement / lessons-triage / topics 等のゲート記述を「自アクションを分類して policy を引く」に置換）。
-- **Claude Code の PreToolUse hook**（`policy-hook.mjs`。`gh pr merge` / `gh release` 等を実行エンジン側で policy 参照して deny/allow）。
+- **各 skill の適用**（implement / lessons-triage / topics 等のゲート記述を「自アクションを分類して policy を引く」に置換。R3 PR2/PR3 で実装済み）。
+- **hook の自動配線**（`hooks add policy`。[#174](https://github.com/ozzy-labs/skills/issues/174) の hooks CLI に追加予定）。
 
 ## 注意事項
 

--- a/dist/gemini-cli/.agents/skills/policy/policy-hook.mjs
+++ b/dist/gemini-cli/.agents/skills/policy/policy-hook.mjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+// policy-hook — PreToolUse architecture-enforcement gate for the central
+// autonomy policy (ADR-0028 R3, ozzy-labs/skills#181 PR 4/4).
+//
+// Wired into ~/.claude/settings.local.json as a PreToolUse hook (same wiring
+// shape as usage-guard-hook.mjs), this fires BEFORE every tool call — including
+// ones originating inside subagents, which carry an `agent_id` in the payload.
+// It is the execution-engine side of the policy stack: the SKILL.md prose layer
+// asks a skill to "classify your action and read the gate", but prose is only a
+// request. This hook makes a SPECIFIC set of irreversible commands
+// (`gh pr merge`, `gh release create`, `git push --force`/`-f`, `npm publish`)
+// physically un-runnable when the resolved gate is `ask` — the model cannot
+// talk its way past it.
+//
+// Detection is intentionally NARROW. The hook only pulls the policy when the
+// tool call's command matches one of the irreversible matchers below; every
+// other tool call (reads, edits, safe git/gh/npm, non-Bash tools) is allowed
+// untouched. This is the core safety property: because we only gate on a match,
+// a bug in the matcher can at worst FAIL to gate a dangerous command — it can
+// never deny ALL tools and wedge the session.
+//
+// Decision (PreToolUse contract):
+//   - matched + gate `ask` → DENY (exit 2 + a reason on stderr). Exit 2 is the
+//     harness signal that blocks the call even on older harnesses that key off
+//     the exit code.
+//   - matched + gate `proceed`/`batch-confirm` → ALLOW (the hook only hard-
+//     blocks `ask`; a batch confirmation is the caller/prose layer's job).
+//   - not matched → ALLOW (exit 0, silent).
+//
+// Fail-open (inherited from usage-guard-hook — "never hard-stop on our own
+// bug"):
+//   (a) file kill-switch: if `~/.claude/policy-guard/DISABLE` exists, the hook
+//       is an instant no-op ALLOW (checked FIRST, before any I/O, and itself
+//       fail-open). Escape hatch for a wedged session, no settings edit needed.
+//   (b) policy unreadable / unparseable (policy-read returns `degraded`, or the
+//       resolver throws / is missing) → ALLOW + a stderr warning. If we cannot
+//       even trust the gate, we do NOT block: the resumable prose-layer
+//       checkpoint (drive / health / lessons-triage) consults the SAME
+//       policy-read — which is fail-SAFE to `ask` — and is the primary gate. The
+//       hook is a secondary net, so it errs open to avoid wedging the session on
+//       a broken policy file.
+//   (c) proceed-override: a caller that has ALREADY resolved the gate and been
+//       granted autonomy (e.g. `drive --merge`, whose prose overrides merge to
+//       `proceed`) exports `POLICY_GUARD_PROCEED=<action>[,<action>...]`; the
+//       hook then allows that action without re-gating. This is how a legitimate
+//       opt-in merge is not blocked by the enforcement net.
+//
+// Design-for-tests: the matcher (`matchAction`), payload parse (`parsePayload`),
+// override check (`resolveProceedOverride`) and gate resolution
+// (`resolveGateForAction`) are all pure/injectable, and `run()` takes every
+// effect (stdin, kill-switch, gate resolver, warn/deny sinks) as a dep, so tests
+// exercise the whole thing with no network, no real ~/.claude reads, no spawned
+// process.
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// PreToolUse "deny" is signaled to the harness with exit code 2 (stderr is
+// surfaced to the model); 0 = allow. Named for clarity.
+const EXIT_ALLOW = 0;
+const EXIT_DENY = 2;
+
+// File kill-switch — the escape hatch. Built with path.join (HOME-anchored) so
+// no rewritable `~/.claude/skills/` literal appears in source (the dist user-scope
+// rewrite only targets `.agents|~/.claude/skills/` refs; `policy-guard/` is safe).
+export const DISABLE_PATH = join(homedir(), ".claude", "policy-guard", "DISABLE");
+
+// Env var a caller sets to pre-authorize specific actions (comma-separated
+// action names, or `all`/`*`). This is the `--merge`→proceed override channel:
+// a caller that has already been granted autonomy names the action here so the
+// enforcement net does not re-block it.
+export const PROCEED_ENV = "POLICY_GUARD_PROCEED";
+
+// Force-push flag detector: `--force`, `--force-with-lease`, or a short flag
+// token containing `f` (`-f`, `-fq`, …). Anchored on a token boundary so it does
+// not fire on `--foo` or a filename.
+const FORCE_FLAG = /(?:--force(?:-with-lease)?\b|(?:^|\s)-[a-z]*f[a-z]*(?=\s|$))/i;
+
+/**
+ * The irreversible-command matchers. Each entry maps a command shape to the
+ * central-policy action name + class the gate resolves against. The `class` is
+ * passed alongside the action so `resolveGate` can fall back to the class
+ * default even for an action not in policy-read's ACTION_CLASSES map (so a new
+ * irreversible command still resolves to the `irreversible` default = `ask`).
+ *
+ * Kept deliberately short + irreversible-only (ADR-0028's "irreversible /
+ * destructive" class). Reversible-local and externally-visible actions are the
+ * prose layer's job — the hook does NOT gate `gh pr create`, plain `git push`,
+ * etc., which keeps the "can only ever fail to gate, never deny everything"
+ * property.
+ * @type {ReadonlyArray<{action: string, class: string, test: (cmd: string) => boolean}>}
+ */
+export const IRREVERSIBLE_MATCHERS = Object.freeze([
+  { action: "merge", class: "irreversible", test: (c) => /\bgh\s+pr\s+merge\b/.test(c) },
+  {
+    action: "release-create",
+    class: "irreversible",
+    test: (c) => /\bgh\s+release\s+create\b/.test(c),
+  },
+  {
+    action: "force-push",
+    class: "irreversible",
+    test: (c) => /\bgit\s+push\b/.test(c) && FORCE_FLAG.test(c),
+  },
+  {
+    action: "publish",
+    class: "irreversible",
+    test: (c) => /\b(?:npm|pnpm|yarn)\s+publish\b/.test(c),
+  },
+]);
+
+/**
+ * Classify a command string. Returns the first matching irreversible action +
+ * class, or null when the command is not one the hook gates.
+ * @param {string|null|undefined} command
+ * @returns {{ action: string, class: string }|null}
+ */
+export function matchAction(command) {
+  if (typeof command !== "string" || command.trim() === "") return null;
+  for (const m of IRREVERSIBLE_MATCHERS) {
+    if (m.test(command)) return { action: m.action, class: m.class };
+  }
+  return null;
+}
+
+/**
+ * Read the entire hook stdin payload. Mirrors usage-guard-hook: resolves on end
+ * or error, and does not hang on a TTY (nothing piped).
+ * @param {NodeJS.ReadableStream} [stream]
+ * @returns {Promise<string>}
+ */
+export function readStdin(stream = process.stdin) {
+  return new Promise((resolve) => {
+    let data = "";
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      resolve(data);
+    };
+    stream.setEncoding?.("utf8");
+    stream.on("data", (chunk) => {
+      data += chunk;
+    });
+    stream.on("end", done);
+    stream.on("error", done);
+    if (stream.isTTY) done();
+  });
+}
+
+/**
+ * Parse the PreToolUse payload for the fields the hook needs: the tool name, the
+ * Bash command string (`tool_input.command`), and `agent_id` (present for
+ * subagent-originated calls) for logging. Tolerates empty / malformed input.
+ * @param {string} raw
+ * @returns {{ toolName: string|null, command: string|null, agentId: string|null }}
+ */
+export function parsePayload(raw) {
+  if (!raw?.trim()) return { toolName: null, command: null, agentId: null };
+  try {
+    const obj = JSON.parse(raw);
+    const toolName =
+      typeof obj?.tool_name === "string"
+        ? obj.tool_name
+        : typeof obj?.toolName === "string"
+          ? obj.toolName
+          : null;
+    const input = obj?.tool_input ?? obj?.toolInput ?? {};
+    const command = typeof input?.command === "string" ? input.command : null;
+    const agentId = obj?.agent_id ?? obj?.agentId ?? null;
+    return { toolName, command, agentId: typeof agentId === "string" ? agentId : null };
+  } catch {
+    return { toolName: null, command: null, agentId: null };
+  }
+}
+
+/**
+ * Whether the caller pre-authorized `action` via the proceed-override env var.
+ * The value is a comma-separated list of action names; `all` / `*` authorize
+ * everything. Missing/blank → not authorized.
+ * @param {NodeJS.ProcessEnv} env
+ * @param {string} action
+ * @returns {boolean}
+ */
+export function resolveProceedOverride(env, action) {
+  const raw = env?.[PROCEED_ENV];
+  if (!raw || typeof raw !== "string") return false;
+  const list = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return list.includes(action) || list.includes("all") || list.includes("*");
+}
+
+/**
+ * Resolve the effective gate for one {action, class} against the central policy
+ * by importing the sibling policy-read.mjs and reusing ITS reader (`run`) +
+ * ITS resolver (`resolveGate`) — no policy logic is duplicated here. Returns a
+ * shape the hook interprets:
+ *   - { gate, degraded: false }            → a trusted gate token
+ *   - { gate: null, degraded: true, reason } → could not trust a gate (module
+ *       missing/broken, or policy-read reported `degraded`); caller fails open.
+ *
+ * A dynamic import (not static) is deliberate: an install missing a healthy
+ * policy-read must degrade (→ fail open) rather than crash the hook at load.
+ * @param {{ action: string, klass: string, repoRoot: string }} query
+ * @param {{ importImpl?: (u: string) => Promise<unknown> }} [deps]
+ * @returns {Promise<{ gate: string|null, degraded: boolean, reason?: string, source?: string }>}
+ */
+export async function resolveGateForAction({ action, klass, repoRoot }, { importImpl } = {}) {
+  const imp = importImpl ?? ((u) => import(u));
+  const url = new URL("./policy-read.mjs", import.meta.url).href;
+  const mod = await imp(url);
+  if (!mod || typeof mod.run !== "function" || typeof mod.resolveGate !== "function") {
+    return { gate: null, degraded: true, reason: "policy-read missing run/resolveGate" };
+  }
+  const effective = await mod.run(["--repo-root", repoRoot]);
+  if (!effective || effective.degraded === true) {
+    return { gate: null, degraded: true, reason: "policy unreadable/unparseable (degraded)" };
+  }
+  const resolved = mod.resolveGate(effective, { action, class: klass });
+  if (!resolved || typeof resolved.gate !== "string") {
+    return { gate: null, degraded: true, reason: "gate could not be resolved" };
+  }
+  return { gate: resolved.gate, degraded: false, source: resolved.source };
+}
+
+/**
+ * Build the deny reason for a gated action. Names the action, the gate, and the
+ * three ways to proceed (opt-in env, edit policy, or the kill-switch).
+ * @param {string} action
+ * @param {string} gate
+ * @returns {string}
+ */
+export function buildDenyReason(action, gate) {
+  return (
+    `policy-guard: '${action}' is an irreversible action gated by the central autonomy policy ` +
+    `(gate=${gate}). Tool call blocked pending explicit approval. To authorize: set ` +
+    `${PROCEED_ENV}=${action} for a pre-approved run (e.g. drive --merge), relax the gate in ` +
+    `~/.agents/policy.yaml, or touch ${DISABLE_PATH} to disable the hook.`
+  );
+}
+
+/**
+ * Run the hook end to end. Returns the intended exit code (the CLI wrapper
+ * applies it). Every effect goes through an injected dep so tests assert without
+ * spawning a process or touching the network / real ~/.claude.
+ *
+ * @param {object} [deps]
+ * @param {() => Promise<string>} [deps.readStdinImpl]
+ * @param {() => boolean} [deps.killSwitchImpl]   // true → hook disabled (no-op)
+ * @param {(command: string|null) => ({action:string,class:string}|null)} [deps.matchActionImpl]
+ * @param {(q: {action:string,klass:string,repoRoot:string}) => Promise<{gate:string|null,degraded:boolean,reason?:string}>} [deps.resolveGateImpl]
+ * @param {NodeJS.ProcessEnv} [deps.env]
+ * @param {string} [deps.cwd]
+ * @param {(msg: string) => void} [deps.warn]
+ * @param {(msg: string) => void} [deps.deny]
+ * @returns {Promise<number>} exit code (0 allow / 2 deny)
+ */
+export async function run({
+  readStdinImpl = () => readStdin(),
+  killSwitchImpl = () => existsSync(DISABLE_PATH),
+  matchActionImpl = matchAction,
+  resolveGateImpl = resolveGateForAction,
+  env = process.env,
+  cwd = process.cwd(),
+  warn = (msg) => process.stderr.write(`${msg}\n`),
+  deny = (msg) => process.stderr.write(`${msg}\n`),
+} = {}) {
+  // (a) File kill-switch — checked FIRST, before any I/O, and itself fail-open
+  // (a check error → treated as not disabled → continue normally).
+  let disabled = false;
+  try {
+    disabled = !!killSwitchImpl();
+  } catch {
+    disabled = false;
+  }
+  if (disabled) {
+    warn(`policy-guard hook: disabled via kill-switch (${DISABLE_PATH}); allowing (no-op)`);
+    return EXIT_ALLOW;
+  }
+
+  const { command, agentId } = parsePayload(await readStdinImpl());
+  const origin = agentId ? `subagent ${agentId}` : "main session";
+
+  // Narrow gating: only pull the policy for a matched irreversible command.
+  // Everything else is allowed untouched (the "never deny all tools" property).
+  const matched = matchActionImpl(command);
+  if (!matched) return EXIT_ALLOW;
+
+  // (c) proceed-override: a caller already granted autonomy for this action
+  // (e.g. drive --merge overriding merge→proceed) named it in the env var.
+  if (resolveProceedOverride(env, matched.action)) {
+    warn(
+      `policy-guard hook: '${matched.action}' pre-authorized via ${PROCEED_ENV} (${origin}); allowing.`,
+    );
+    return EXIT_ALLOW;
+  }
+
+  // Resolve the gate. Any failure to obtain a TRUSTED gate → fail open + warn.
+  let gateResult;
+  try {
+    gateResult = await resolveGateImpl({
+      action: matched.action,
+      klass: matched.class,
+      repoRoot: cwd,
+    });
+  } catch (err) {
+    warn(
+      `policy-guard hook: gate resolution failed (${err?.message ?? err}) (${origin}); allowing (fail-open) — the prose-layer checkpoint still guards.`,
+    );
+    return EXIT_ALLOW;
+  }
+  // (b) policy unreadable / unparseable / unresolvable → fail open + warn.
+  if (!gateResult || gateResult.degraded === true || typeof gateResult.gate !== "string") {
+    const why = gateResult?.reason ? ` (${gateResult.reason})` : "";
+    warn(
+      `policy-guard hook: policy unreadable/unparseable${why} (${origin}); allowing (fail-open) — the prose-layer checkpoint still guards.`,
+    );
+    return EXIT_ALLOW;
+  }
+
+  // The hook only HARD-blocks `ask`. `proceed` / `batch-confirm` → allow (a
+  // batch confirmation belongs to the caller / prose layer, not this net).
+  if (gateResult.gate === "ask") {
+    deny(`${buildDenyReason(matched.action, gateResult.gate)} [origin: ${origin}]`);
+    return EXIT_DENY;
+  }
+  return EXIT_ALLOW;
+}
+
+// CLI entry — only when executed directly (not when imported by tests).
+const __isMain = (() => {
+  try {
+    return import.meta.url === `file://${process.argv[1]}`;
+  } catch {
+    return false;
+  }
+})();
+
+if (__isMain) {
+  run()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((err) => {
+      // Any unexpected error in the hook itself must fail open, never block.
+      process.stderr.write(
+        `policy-guard hook: fatal ${err?.message ?? err}; allowing (fail-open)\n`,
+      );
+      process.exitCode = EXIT_ALLOW;
+    });
+}

--- a/tests/policy-hook.test.mjs
+++ b/tests/policy-hook.test.mjs
@@ -1,0 +1,435 @@
+// Tests for the policy PreToolUse enforcement hook (ozzy-labs/skills#181 PR 4/4,
+// ADR-0028 R3). Everything is exercised through injected deps (payload, kill-
+// switch, gate resolver, warn/deny sinks) — no network, no real ~/.claude reads,
+// no spawned process. Mirrors tests/usage-guard-hook.test.mjs.
+//
+// Required cases (issue #181 PR4):
+//   - irreversible command + gate=ask → deny (exit 2)
+//   - gate=proceed / batch-confirm → allow
+//   - non-target command → allow
+//   - kill-switch present → allow (no-op)
+//   - policy unreadable/unparseable → allow (fail-open) + stderr warn
+//   - `--merge`-style proceed override context → allow
+// Plus: matcher unit coverage, payload parsing, deny message content, real
+// resolveGate wiring against policy-read.mjs, and the structural adapter-payload
+// asserts (the extra file ships to every adapter).
+
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { readFile as realReadFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  buildDenyReason,
+  matchAction,
+  PROCEED_ENV,
+  parsePayload,
+  resolveGateForAction,
+  resolveProceedOverride,
+  run,
+} from "../.agents/skills/policy/policy-hook.mjs";
+import {
+  mergePolicies,
+  resolveGate as realResolveGate,
+} from "../.agents/skills/policy/policy-read.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// Hermetic run() deps: kill-switch off, no proceed-override env, cwd fixed.
+const killOff = () => false;
+const bashPayload = (command) => async () =>
+  JSON.stringify({ tool_name: "Bash", tool_input: { command } });
+
+// --- (1) irreversible command + gate=ask → deny ------------------------------
+
+test("(1) gh pr merge + gate=ask → deny (exit 2) with the action + origin", async () => {
+  const denies = [];
+  const code = await run({
+    readStdinImpl: bashPayload("gh pr merge 123 --squash"),
+    killSwitchImpl: killOff,
+    resolveGateImpl: async ({ action }) => {
+      assert.equal(action, "merge", "gh pr merge classifies as the merge action");
+      return { gate: "ask", degraded: false };
+    },
+    env: {},
+    deny: (m) => denies.push(m),
+  });
+  assert.equal(code, 2, "gate=ask on an irreversible command → deny (exit 2)");
+  assert.equal(denies.length, 1, "exactly one deny message");
+  assert.match(denies[0], /'merge' is an irreversible action/);
+  assert.match(denies[0], /gate=ask/);
+  assert.match(denies[0], /main session/, "origin is tagged");
+});
+
+// --- (2) gate=proceed / batch-confirm → allow --------------------------------
+
+test("(2) gate=proceed → allow (exit 0), no deny", async () => {
+  const denies = [];
+  const code = await run({
+    readStdinImpl: bashPayload("gh pr merge 123 --squash"),
+    killSwitchImpl: killOff,
+    resolveGateImpl: async () => ({ gate: "proceed", degraded: false }),
+    env: {},
+    deny: (m) => denies.push(m),
+  });
+  assert.equal(code, 0, "gate=proceed → allow");
+  assert.equal(denies.length, 0);
+});
+
+test("(2b) gate=batch-confirm → allow (the hook only hard-blocks ask)", async () => {
+  const denies = [];
+  const code = await run({
+    readStdinImpl: bashPayload("npm publish"),
+    killSwitchImpl: killOff,
+    resolveGateImpl: async () => ({ gate: "batch-confirm", degraded: false }),
+    env: {},
+    deny: (m) => denies.push(m),
+  });
+  assert.equal(code, 0, "batch-confirm is not a hard block at the hook layer");
+  assert.equal(denies.length, 0);
+});
+
+// --- (3) non-target command → allow (never gates reads/edits/safe commands) ---
+
+test("(3) non-target commands → allow without ever resolving the policy", async () => {
+  for (const command of [
+    "gh pr view 3",
+    "gh pr list --state open",
+    "gh pr create --fill",
+    "git push origin feat/x", // plain push is NOT irreversible → not gated
+    "git status",
+    "npm test",
+    "ls -la && cat README.md",
+  ]) {
+    let resolverCalled = false;
+    const code = await run({
+      readStdinImpl: bashPayload(command),
+      killSwitchImpl: killOff,
+      resolveGateImpl: async () => {
+        resolverCalled = true;
+        return { gate: "ask", degraded: false };
+      },
+      env: {},
+    });
+    assert.equal(code, 0, `${command} → allow`);
+    assert.equal(resolverCalled, false, `${command} must not even consult the policy`);
+  }
+});
+
+test("(3b) non-Bash payload (no command) → allow", async () => {
+  const code = await run({
+    readStdinImpl: async () =>
+      JSON.stringify({ tool_name: "Read", tool_input: { file_path: "/x" } }),
+    killSwitchImpl: killOff,
+    resolveGateImpl: async () => {
+      throw new Error("must not resolve for a non-command tool");
+    },
+    env: {},
+  });
+  assert.equal(code, 0, "no command string → allow (nothing to gate)");
+});
+
+// --- (4) kill-switch present → allow (no-op), before any I/O -----------------
+
+test("(4) kill-switch present → ALLOW (exit 0), short-circuits before reading stdin", async () => {
+  const warnings = [];
+  let stdinRead = false;
+  const code = await run({
+    readStdinImpl: async () => {
+      stdinRead = true;
+      return bashPayload("gh pr merge 1")();
+    },
+    killSwitchImpl: () => true,
+    resolveGateImpl: async () => ({ gate: "ask", degraded: false }),
+    env: {},
+    warn: (m) => warnings.push(m),
+  });
+  assert.equal(code, 0, "kill-switch → no-op ALLOW");
+  assert.equal(stdinRead, false, "kill-switch short-circuits before any I/O");
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /kill-switch/);
+});
+
+test("(4b) kill-switch check throwing → treated as not disabled → gate normally", async () => {
+  const denies = [];
+  const code = await run({
+    readStdinImpl: bashPayload("gh pr merge 1"),
+    killSwitchImpl: () => {
+      throw new Error("fs error");
+    },
+    resolveGateImpl: async () => ({ gate: "ask", degraded: false }),
+    env: {},
+    deny: (m) => denies.push(m),
+  });
+  assert.equal(code, 2, "a broken kill-switch check must not disable enforcement");
+  assert.equal(denies.length, 1);
+});
+
+// --- (5) policy unreadable/unparseable → allow (fail-open) + warn ------------
+
+test("(5) resolver reports degraded → ALLOW (fail-open) + a warning", async () => {
+  const warnings = [];
+  const denies = [];
+  const code = await run({
+    readStdinImpl: bashPayload("gh pr merge 1"),
+    killSwitchImpl: killOff,
+    resolveGateImpl: async () => ({
+      gate: null,
+      degraded: true,
+      reason: "policy.yaml unparseable",
+    }),
+    env: {},
+    warn: (m) => warnings.push(m),
+    deny: (m) => denies.push(m),
+  });
+  assert.equal(code, 0, "degraded policy → fail-open ALLOW (prose checkpoint still guards)");
+  assert.equal(denies.length, 0, "never deny when the gate cannot be trusted");
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /unreadable\/unparseable/);
+  assert.match(warnings[0], /fail-open/);
+  assert.match(warnings[0], /policy\.yaml unparseable/);
+});
+
+test("(5b) resolver throwing → ALLOW (fail-open) + a warning", async () => {
+  const warnings = [];
+  const denies = [];
+  const code = await run({
+    readStdinImpl: bashPayload("git push --force origin main"),
+    killSwitchImpl: killOff,
+    resolveGateImpl: async () => {
+      throw new Error("import blew up");
+    },
+    env: {},
+    warn: (m) => warnings.push(m),
+    deny: (m) => denies.push(m),
+  });
+  assert.equal(code, 0, "a thrown resolver must fail open, never hard-stop");
+  assert.equal(denies.length, 0);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /fail-open/);
+});
+
+// --- (6) `--merge`-style proceed-override context → allow --------------------
+
+test("(6) POLICY_GUARD_PROCEED=merge → allow even though the gate would be ask", async () => {
+  const warnings = [];
+  const denies = [];
+  let resolverCalled = false;
+  const code = await run({
+    readStdinImpl: bashPayload("gh pr merge 42 --squash"),
+    killSwitchImpl: killOff,
+    resolveGateImpl: async () => {
+      resolverCalled = true;
+      return { gate: "ask", degraded: false };
+    },
+    env: { [PROCEED_ENV]: "merge" },
+    warn: (m) => warnings.push(m),
+    deny: (m) => denies.push(m),
+  });
+  assert.equal(code, 0, "a pre-authorized action is allowed (the --merge opt-in path)");
+  assert.equal(denies.length, 0);
+  assert.equal(resolverCalled, false, "override short-circuits before re-resolving the gate");
+  assert.ok(warnings.some((w) => /pre-authorized/.test(w)));
+});
+
+test("(6b) resolveProceedOverride: list / all / * / miss", () => {
+  assert.equal(resolveProceedOverride({ [PROCEED_ENV]: "merge,publish" }, "publish"), true);
+  assert.equal(resolveProceedOverride({ [PROCEED_ENV]: "merge" }, "publish"), false);
+  assert.equal(resolveProceedOverride({ [PROCEED_ENV]: "all" }, "force-push"), true);
+  assert.equal(resolveProceedOverride({ [PROCEED_ENV]: "*" }, "merge"), true);
+  assert.equal(resolveProceedOverride({}, "merge"), false);
+  assert.equal(resolveProceedOverride({ [PROCEED_ENV]: "  " }, "merge"), false);
+});
+
+// --- matcher unit coverage ---------------------------------------------------
+
+test("matchAction detects each irreversible command", () => {
+  assert.deepEqual(matchAction("gh pr merge 12"), { action: "merge", class: "irreversible" });
+  assert.deepEqual(matchAction("cd x && gh   pr   merge --admin"), {
+    action: "merge",
+    class: "irreversible",
+  });
+  assert.deepEqual(matchAction("gh release create v1.2.3 --notes x"), {
+    action: "release-create",
+    class: "irreversible",
+  });
+  assert.deepEqual(matchAction("git push --force origin main"), {
+    action: "force-push",
+    class: "irreversible",
+  });
+  assert.deepEqual(matchAction("git push -f"), { action: "force-push", class: "irreversible" });
+  assert.deepEqual(matchAction("git push --force-with-lease origin main"), {
+    action: "force-push",
+    class: "irreversible",
+  });
+  assert.deepEqual(matchAction("npm publish --access public"), {
+    action: "publish",
+    class: "irreversible",
+  });
+  assert.deepEqual(matchAction("pnpm publish"), { action: "publish", class: "irreversible" });
+});
+
+test("matchAction ignores safe / non-target commands", () => {
+  for (const c of [
+    "gh pr view 3",
+    "gh pr create",
+    "gh release view v1",
+    "gh release list",
+    "git push origin main", // plain (non-force) push is not gated
+    "git status",
+    "npm test",
+    "npm run publish:dry", // not the `publish` subcommand
+    "echo publish",
+    "",
+    "   ",
+  ]) {
+    assert.equal(matchAction(c), null, `must not gate: ${JSON.stringify(c)}`);
+  }
+  assert.equal(matchAction(null), null);
+  assert.equal(matchAction(undefined), null);
+});
+
+// --- payload parsing ---------------------------------------------------------
+
+test("parsePayload extracts tool_name, command and agent_id; tolerates junk", () => {
+  const p = parsePayload(
+    '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 1"},"agent_id":"w-7"}',
+  );
+  assert.equal(p.toolName, "Bash");
+  assert.equal(p.command, "gh pr merge 1");
+  assert.equal(p.agentId, "w-7");
+  assert.deepEqual(parsePayload(""), { toolName: null, command: null, agentId: null });
+  assert.deepEqual(parsePayload("not json"), { toolName: null, command: null, agentId: null });
+  assert.equal(parsePayload('{"tool_name":"Bash"}').command, null, "no command → null");
+});
+
+test("run() tags the deny message with the subagent origin", async () => {
+  const denies = [];
+  await run({
+    readStdinImpl: async () =>
+      JSON.stringify({
+        tool_name: "Bash",
+        tool_input: { command: "gh pr merge 1" },
+        agent_id: "worker-7",
+      }),
+    killSwitchImpl: killOff,
+    resolveGateImpl: async () => ({ gate: "ask", degraded: false }),
+    env: {},
+    deny: (m) => denies.push(m),
+  });
+  assert.match(denies[0], /subagent worker-7/, "deny message records the subagent origin");
+});
+
+// --- buildDenyReason ---------------------------------------------------------
+
+test("buildDenyReason names the action, gate, opt-in env and kill-switch", () => {
+  const r = buildDenyReason("merge", "ask");
+  assert.match(r, /'merge'/);
+  assert.match(r, /gate=ask/);
+  assert.match(r, new RegExp(PROCEED_ENV));
+  assert.match(r, /policy\.yaml/);
+  assert.match(r, /DISABLE/);
+});
+
+// --- real resolveGate wiring against policy-read.mjs -------------------------
+//
+// These drive the REAL resolveGateForAction with an injected module whose
+// `run` returns a hand-built effective policy (so no HOME ~/.agents/policy.yaml
+// dependency) but whose resolver is policy-read's REAL resolveGate — proving the
+// hook consumes policy-read's contract correctly.
+
+test("resolveGateForAction: zero-config merge resolves to ask via real resolveGate", async () => {
+  const effective = mergePolicies({}); // zero-config defaults
+  const res = await resolveGateForAction(
+    { action: "merge", klass: "irreversible", repoRoot: "/x" },
+    {
+      importImpl: async () => ({
+        run: async () => ({ ...effective, degraded: false }),
+        resolveGate: realResolveGate,
+      }),
+    },
+  );
+  assert.equal(res.degraded, false);
+  assert.equal(res.gate, "ask", "irreversible zero-config default = ask");
+});
+
+test("resolveGateForAction: repo action override merge=proceed wins", async () => {
+  const effective = mergePolicies({ repo: { actions: { merge: "proceed" } } });
+  const res = await resolveGateForAction(
+    { action: "merge", klass: "irreversible", repoRoot: "/x" },
+    {
+      importImpl: async () => ({
+        run: async () => ({ ...effective, degraded: false }),
+        resolveGate: realResolveGate,
+      }),
+    },
+  );
+  assert.equal(res.gate, "proceed");
+});
+
+test("resolveGateForAction: policy-read degraded → degraded passthrough (hook fails open)", async () => {
+  const effective = mergePolicies({});
+  const res = await resolveGateForAction(
+    { action: "merge", klass: "irreversible", repoRoot: "/x" },
+    {
+      importImpl: async () => ({
+        run: async () => ({ ...effective, degraded: true }),
+        resolveGate: realResolveGate,
+      }),
+    },
+  );
+  assert.equal(res.degraded, true);
+  assert.equal(res.gate, null);
+});
+
+test("resolveGateForAction: module missing run/resolveGate → degraded", async () => {
+  const res = await resolveGateForAction(
+    { action: "merge", klass: "irreversible", repoRoot: "/x" },
+    { importImpl: async () => ({}) },
+  );
+  assert.equal(res.degraded, true);
+  assert.match(res.reason, /missing run\/resolveGate/);
+});
+
+// --- structural: the hook extra file ships to every adapter payload ----------
+
+test("policy-hook.mjs ships in the claude-code payload (verbatim, no rewritten self-path)", async () => {
+  const script = await realReadFile(
+    join(ROOT, "dist", "claude-code", ".claude", "skills", "policy", "policy-hook.mjs"),
+    "utf8",
+  );
+  assert.match(script, /PreToolUse/, "hook extra file must ship verbatim");
+  assert.doesNotMatch(
+    script,
+    /~\/\.claude\/skills\/policy\/policy-hook\.mjs/,
+    "hook must not contain a rewritten .claude/skills/ self-path literal",
+  );
+});
+
+test("policy-hook.mjs ships to EVERY adapter payload (policy is not adapter-gated)", () => {
+  // policy has no `adapters:` gate → it (and its extras, incl. the hook) ships
+  // to all adapters. The hook is a Claude Code convention but inert elsewhere;
+  // shipping it verbatim keeps the extra-file plumbing uniform (like policy-read).
+  const cases = [
+    ["claude-code", join(".claude", "skills", "policy", "policy-hook.mjs")],
+    ["codex-cli", join(".agents", "skills", "policy", "policy-hook.mjs")],
+    ["gemini-cli", join(".agents", "skills", "policy", "policy-hook.mjs")],
+    ["copilot", join(".agents", "skills", "policy", "policy-hook.mjs")],
+  ];
+  for (const [adapter, rel] of cases) {
+    const adapterRoot = join(ROOT, "dist", adapter);
+    if (!existsSync(adapterRoot)) continue;
+    assert.equal(
+      existsSync(join(adapterRoot, rel)),
+      true,
+      `policy-hook.mjs must ship to dist/${adapter}/${rel}`,
+    );
+  }
+  // The SSOT lives under .agents/skills/policy/ (authored directly).
+  assert.equal(
+    existsSync(join(ROOT, ".agents", "skills", "policy", "policy-hook.mjs")),
+    true,
+    "policy-hook.mjs SSOT lives under .agents/skills/policy/",
+  );
+});


### PR DESCRIPTION
## 概要

中央 autonomy policy（ADR-0028 R3）の **実行エンジン側 gate 強制**。`usage-guard-hook.mjs` と同型の PreToolUse hook `policy-hook.mjs` を追加し、全 tool 呼び出し前に発火して**特定の不可逆コマンド**を検出したときだけ policy を引き、gate が `ask` なら deny（exit 2）、`proceed` / `batch-confirm` なら allow する。prose 層（各 skill の「自アクションを分類して policy を引く」）は依頼に過ぎずモデルが迂回し得るのに対し、本 hook は物理的に塞ぐ。

## 検出対象（irreversible のみ）

| コマンド | action / class | ゼロコンフィグ gate | 挙動 |
|---|---|---|---|
| `gh pr merge` | `merge` / `irreversible` | `ask` | deny |
| `gh release create` | `release-create` / `irreversible` | `ask` | deny |
| `git push --force` / `-f` / `--force-with-lease` | `force-push` / `irreversible` | `ask` | deny |
| `npm` / `pnpm` / `yarn publish` | `publish` / `irreversible` | `ask` | deny |

## 設計

- **narrow gating（全 tool deny 事故の防止）:** policy を引くのは不可逆コマンドにマッチした時だけ。それ以外は素通し。matcher にバグがあっても「危険コマンドを取りこぼす」方向にしか倒れず、全 tool を deny してセッションを wedge させない。
- **一過性で hard-stop させない（`usage-guard-hook.mjs` から踏襲）:**
  - (a) file kill-switch `~/.claude/policy-guard/DISABLE` → 冒頭で即 no-op allow
  - (b) policy 読取不能・パース不能（`policy-read.mjs` が `degraded`）／resolver throw → allow + stderr 警告。gate を信頼できないなら通す（resumable prose-layer checkpoint が同じ fail-safe な `policy-read.mjs` を引く一次ゲート、hook は二次的な網）
  - (c) proceed 上書き `POLICY_GUARD_PROCEED=<action>` → `drive --merge` の opt-in マージが強制網に阻まれないための channel
- **policy-read.mjs の `run()` + `resolveGate` を sibling dynamic import で再利用**（policy ロジックを複製しない）。
- extra file として**全 adapter payload に同梱**（policy は adapter-gated でない）。

## 配線

**本 PR では settings への配線はしない。** 将来 `hooks add policy`（#174 の hooks CLI に追加予定）が担う。それまでは policy SKILL.md の「§PreToolUse enforcement hook」節に手動配線手順（`settings.local.json` スニペット）を記載。

## テスト

`tests/policy-hook.test.mjs`（`tests/usage-guard-hook.test.mjs` のパターン、22 tests）: gate=ask→deny / proceed・batch-confirm→allow / 非対象コマンド→allow / kill-switch→allow / policy degraded・throw→allow+警告 / `POLICY_GUARD_PROCEED` 上書き→allow / matcher 網羅 / payload parse / 実 `resolveGate` 連携 / 全 adapter 同梱の構造 assert。

`pnpm build` / `pnpm test`（542 green）/ `pnpm run lint` すべて green。skill セット不変（catalog テスト green）。

---

Refs #181（PR 4/4）, ADR-0028 R3。配線は #174-PR3。

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015n4J4RWvHAsXNf5pDVypFg