### PR TITLE
feat(cli): hooks status + permissions allowlist suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Supported adapters: `claude-code`, `codex-cli`, `gemini-cli`, `copilot`. On an *
 | `remove` (alias `uninstall`) | Uninstall skills. Confirmation required (TTY prompt or `--yes`). `--skills` required. |
 | `fork <skill> <new-name>` | Copy an installed skill to a user-owned, unmanaged name (free to edit; never touched by update/remove). |
 | `diff <skill>` | Show a skill's local edits vs the current upstream. |
-| `hooks <add\|remove> <name>` | Wire/unwire an optional Claude Code hook (`usage-guard`, `observability`) into your local settings. Resolves the script's absolute path, previews a diff, confirms (`--yes` non-interactively). |
+| `hooks <add\|remove\|status> [<name>]` | Wire/unwire/inspect an optional Claude Code hook (`usage-guard`, `observability`). `add`/`remove` resolve the script's absolute path, preview a diff, and confirm (`--yes` non-interactively); `add usage-guard` also suggests the endpoint-path permissions allowlist (`--no-permissions` to skip). `status` reports each hook's wiring and, for a wired usage-guard, diagnoses whether the guard is effective or has degraded to a no-op. |
 
 ### State & editable skills
 
@@ -108,11 +108,21 @@ npx @ozzylabs/skills hooks add observability --scope=user
 # Preview the settings diff without writing anything
 npx @ozzylabs/skills hooks add usage-guard --dry-run
 
+# Wire the hook but skip the permissions suggestion
+npx @ozzylabs/skills hooks add usage-guard --no-permissions
+
 # Remove only the entry this CLI wrote (other hooks stay untouched)
 npx @ozzylabs/skills hooks remove usage-guard
+
+# Inspect wiring + diagnose whether a wired usage-guard is actually effective
+npx @ozzylabs/skills hooks status
 ```
 
 `hooks add` resolves the script from the installed skill dir (run `add --skills=usage-guard` first if it is missing), previews the settings diff, and asks before writing (`--yes` is required on non-interactive / CI runs). It edits `settings.local.json` by default (`--scope=user` for `settings.json`), is idempotent (a re-add is a no-op), only ever touches the entries it owns, and refuses to overwrite an unparseable settings file. The repo still ships no settings/hooks — this only writes your local settings on request.
+
+`hooks add usage-guard` additionally proposes the **permissions allowlist** the endpoint path needs — a `Read(//…/.credentials.json)` and a `Bash(node …/usage-check.mjs:*)` entry (see the skill's §環境要件) — folded into the same diff. It is a non-destructive, idempotent append to `permissions.allow`; `--no-permissions` opts out and still wires the hook. Without those grants the guard silently falls back to `fail-open` (effectively OFF).
+
+`hooks status` is read-only: it scans both settings files and reports, per hook, whether it is wired. For a wired usage-guard it runs `usage-check.mjs` once and diagnoses the `source` — `endpoint`/`cache` mean the guard is effective, while `jsonl`/`fail-open` mean it has degraded to a no-op (with a pointer to the skill's §環境要件). This catches the failure mode where the hook is wired but the endpoint path is blocked, so the guard is quietly off.
 
 ## Consumer setup
 

--- a/bin/lib/hooks.mjs
+++ b/bin/lib/hooks.mjs
@@ -1,5 +1,6 @@
-// `skills hooks add|remove` — wire the optional Claude Code hooks that ship as
-// extra files inside a skill directory (ozzy-labs/skills#174 PR 1).
+// `skills hooks add|remove|status` — wire, unwire, or inspect the optional
+// Claude Code hooks that ship as extra files inside a skill directory
+// (ozzy-labs/skills#174 PR 1 = add/remove, PR 2 = status + permissions).
 //
 // Two hooks are opt-in today and require a hand-written absolute path in
 // settings: usage-guard's PreToolUse ceiling (`usage-guard-hook.mjs`) and
@@ -11,11 +12,24 @@
 // every other entry byte-for-byte, and refuses to overwrite a settings file it
 // cannot parse. The repo still ships no settings/hooks — the CLI just writes local
 // settings on explicit user consent (same dry-run / diff / confirm UX as `remove`).
+//
+// PR 2 adds two things on top of that core (#174):
+//   - `hooks status`: scans both settings files and reports, per hook, whether it
+//     is wired. For a wired usage-guard it runs `usage-check.mjs` once and
+//     diagnoses the `source` — `endpoint`/`cache` mean the guard is effective,
+//     `jsonl`/`fail-open` mean it has silently degraded to a no-op (the exact
+//     failure usage-guard's own SKILL.md §環境要件 warns about).
+//   - permissions suggestion: `hooks add usage-guard` also proposes the
+//     permissions allowlist the endpoint path needs (`~/.claude/.credentials.json`
+//     Read + `node …/usage-check.mjs` exec), folded into the same diff. It is a
+//     non-destructive append to `permissions.allow`; `--no-permissions` opts out
+//     and still wires the hook.
 
+import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { parseFlags } from "./args.mjs";
 import { didYouMean } from "./detect.mjs";
 import { findPackageRoot } from "./install.mjs";
@@ -42,19 +56,36 @@ export const HOOK_DEFS = {
 
 const HOOK_NAMES = Object.keys(HOOK_DEFS);
 
-const HELP = `npx @ozzylabs/skills hooks <add|remove> <${HOOK_NAMES.join("|")}> [options]
+// Hooks that `status` lists as forward-looking but that are not wireable yet
+// (the policy PreToolUse gate lands in a later #174 PR). Surfacing them keeps the
+// status view honest about what the CLI can and cannot wire today.
+export const PLANNED_HOOK_NAMES = ["policy"];
 
-Wire (or unwire) an optional Claude Code hook shipped with a skill. The hook
-script's absolute path is resolved from the installed skill dir and written into
-your local Claude settings. Only entries this CLI owns are ever modified.
+const HELP = `npx @ozzylabs/skills hooks <add|remove|status> [<${HOOK_NAMES.join("|")}>] [options]
+
+Wire, unwire, or inspect the optional Claude Code hooks shipped with a skill. A
+hook script's absolute path is resolved from the installed skill dir and written
+into your local Claude settings. Only entries this CLI owns are ever modified.
+
+Actions:
+  add <name>      Wire a hook. For usage-guard, also suggests (in the same diff)
+                  the permissions allowlist the endpoint path needs; opt out with
+                  --no-permissions and the hook is still wired.
+  remove <name>   Remove only the hook entry this CLI wrote.
+  status          Report each hook's wiring state. For a wired usage-guard, run
+                  usage-check.mjs once and diagnose whether the guard is effective
+                  (source endpoint/cache) or has degraded to a no-op (jsonl/
+                  fail-open). Read-only — never writes settings.
 
 Hooks:
   usage-guard     PreToolUse ceiling (usage-guard-hook.mjs, matcher "*").
   observability   SessionEnd capture (obs-derive.mjs).
 
 Options:
-  --scope=<user|local>  Settings file to edit: 'local' → settings.local.json
-                        (default), 'user' → settings.json.
+  --scope=<user|local>  Settings file to edit (add/remove): 'local' →
+                        settings.local.json (default), 'user' → settings.json.
+  --no-permissions      (add usage-guard) Skip the permissions allowlist
+                        suggestion; wire the hook only.
   --dry-run             Print the diff + JSON plan and exit. Writes nothing.
   --yes                 Skip the confirmation prompt (required non-interactively).
   -h, --help            Show this help.
@@ -63,6 +94,7 @@ Options:
 const SCHEMA = {
   scope: "string",
   "dry-run": "boolean",
+  "no-permissions": "boolean",
   yes: "boolean",
   help: "boolean",
 };
@@ -189,6 +221,123 @@ export function removeHookEntry(settings, def) {
 }
 
 /**
+ * Build the permissions allowlist rules the usage-guard endpoint path needs
+ * (usage-guard SKILL.md §環境要件): a Read of the OAuth credentials file and a
+ * Bash exec of the usage-check script. Claude Code permission rule syntax:
+ *   - absolute file reads use a DOUBLE-slash prefix → `Read(//abs/path)`
+ *   - Bash rules are command prefixes with a `:*` "any trailing args" suffix.
+ *
+ * @param {{ credentialsPath: string, usageCheckPath: string }} paths
+ * @returns {string[]}
+ */
+export function buildUsagePermissionRules({ credentialsPath, usageCheckPath }) {
+  return [`Read(/${credentialsPath})`, `Bash(node ${usageCheckPath}:*)`];
+}
+
+/**
+ * Pure: non-destructively append permission rules to `permissions.allow`.
+ * Idempotent — a rule already present (byte-for-byte) is skipped. `deny`/`ask`
+ * and every existing allow entry are preserved untouched.
+ *
+ * @param {object} settings
+ * @param {string[]} rules
+ * @returns {{ settings: object, changed: boolean, added: string[] }}
+ */
+export function addPermissionEntries(settings, rules) {
+  const next = structuredClone(settings);
+  if (!next.permissions || typeof next.permissions !== "object" || Array.isArray(next.permissions)) {
+    next.permissions = {};
+  }
+  if (!Array.isArray(next.permissions.allow)) next.permissions.allow = [];
+  const allow = next.permissions.allow;
+  const added = [];
+  for (const rule of rules) {
+    if (!allow.includes(rule)) {
+      allow.push(rule);
+      added.push(rule);
+    }
+  }
+  if (added.length === 0) return { settings, changed: false, added: [] };
+  return { settings: next, changed: true, added };
+}
+
+/**
+ * Classify a usage-check `source` for the status diagnosis. `endpoint`/`cache`
+ * mean the guard is reading the real OAuth signal (effective); `jsonl`/
+ * `fail-open` mean it has degraded to a coarse estimate or a no-op — the exact
+ * silent-OFF failure usage-guard's §環境要件 warns about. Anything else is
+ * unknown.
+ *
+ * @param {string|null|undefined} source
+ * @returns {{ effective: boolean|null, symbol: string, label: string }}
+ */
+export function classifyUsageSource(source) {
+  if (source === "endpoint" || source === "cache") {
+    return { effective: true, symbol: "✅", label: `guard is effective (source=${source})` };
+  }
+  if (source === "jsonl" || source === "fail-open") {
+    return {
+      effective: false,
+      symbol: "⚠️",
+      label: `guard is DEGRADED (source=${source}) — endpoint path unavailable; see usage-guard SKILL.md §環境要件 (endpoint 経路が使えること)`,
+    };
+  }
+  return {
+    effective: null,
+    symbol: "?",
+    label: source ? `unknown source '${source}'` : "could not determine source",
+  };
+}
+
+/** Find the command string that wires `def` in `settings`, or null. */
+function findWiredCommand(settings, def) {
+  const bucket = settings?.hooks?.[def.event];
+  if (!Array.isArray(bucket)) return null;
+  for (const group of bucket) {
+    if (!group || !Array.isArray(group.hooks)) continue;
+    for (const h of group.hooks) {
+      if (commandReferencesScript(h?.command, def.script)) return h.command;
+    }
+  }
+  return null;
+}
+
+/**
+ * Diagnose the usage-check `source` for `hooks status`. Runs `node <scriptPath>`
+ * once and parses the last JSON line's `source`. A fixture JSON can be injected
+ * via `OZZYLABS_SKILLS_USAGE_CHECK_JSON` (bypasses the spawn) so status is
+ * diagnosable without touching the real endpoint / credentials — used by tests
+ * and as a manual override. Any failure resolves to `{ source: null }` so status
+ * stays read-only and never throws.
+ *
+ * @param {{ scriptPath: string|null, env?: NodeJS.ProcessEnv, spawnImpl?: Function }} opts
+ * @returns {{ source: string|null, error?: string }}
+ */
+export function diagnoseUsageSource({ scriptPath, env = process.env, spawnImpl = spawnSync }) {
+  const fixture = env?.OZZYLABS_SKILLS_USAGE_CHECK_JSON;
+  if (fixture !== undefined && fixture !== "") {
+    try {
+      return { source: JSON.parse(fixture)?.source ?? null };
+    } catch {
+      return { source: null, error: "invalid OZZYLABS_SKILLS_USAGE_CHECK_JSON fixture" };
+    }
+  }
+  if (!scriptPath) return { source: null, error: "usage-check.mjs not found" };
+  try {
+    const res = spawnImpl("node", [scriptPath], { encoding: "utf8", timeout: 15_000, env });
+    if (res?.error) return { source: null, error: res.error.message };
+    const lines = String(res?.stdout ?? "")
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+    if (lines.length === 0) return { source: null, error: "no usage-check output" };
+    return { source: JSON.parse(lines[lines.length - 1])?.source ?? null };
+  } catch (err) {
+    return { source: null, error: err.message };
+  }
+}
+
+/**
  * Minimal LCS line diff. Returns `+`/`-`/`  ` prefixed lines (the caller filters
  * to changed lines for display). Dependency-free — settings files are small.
  *
@@ -280,12 +429,21 @@ export async function runHooks(argv, opts = {}) {
   }
 
   const [action, name] = positionals;
-  if (action !== "add" && action !== "remove") {
+  if (action !== "add" && action !== "remove" && action !== "status") {
     process.stderr.write(
-      `error: expected 'add' or 'remove'${action ? ` (got '${action}')` : ""}\n\n${HELP}`,
+      `error: expected 'add', 'remove', or 'status'${action ? ` (got '${action}')` : ""}\n\n${HELP}`,
     );
     return 1;
   }
+
+  const base = process.env.OZZYLABS_SKILLS_HOME ?? homedir();
+
+  // `status` takes no hook name and never writes — dispatch before the
+  // name/def/scope validation the mutating actions need.
+  if (action === "status") {
+    return await runStatus({ base, opts, env: process.env });
+  }
+
   if (!name) {
     process.stderr.write(`error: hooks ${action} requires a hook name (${HOOK_NAMES.join(" | ")})\n`);
     return 1;
@@ -304,7 +462,6 @@ export async function runHooks(argv, opts = {}) {
     return 1;
   }
 
-  const base = process.env.OZZYLABS_SKILLS_HOME ?? homedir();
   const claudeDir = join(base, ".claude");
   const settingsFile = join(claudeDir, scope === "user" ? "settings.json" : "settings.local.json");
 
@@ -316,13 +473,10 @@ export async function runHooks(argv, opts = {}) {
   const currentSettings = read.settings;
 
   let command = null;
+  let permissionsAdded = [];
   let result;
   if (action === "add") {
-    let scopeRoots = opts.scopeRoots;
-    if (!scopeRoots) {
-      const packageRoot = await findPackageRoot().catch(() => null);
-      scopeRoots = packageRoot ? [base, packageRoot] : [base];
-    }
+    const scopeRoots = await resolveScopeRoots(base, opts);
     const scriptPath = await resolveScriptPath(scopeRoots, def);
     if (!scriptPath) {
       process.stderr.write(
@@ -331,7 +485,24 @@ export async function runHooks(argv, opts = {}) {
       return 1;
     }
     command = buildCommand(scriptPath);
-    result = addHookEntry(currentSettings, def, command);
+    const hookRes = addHookEntry(currentSettings, def, command);
+    let working = hookRes.settings;
+    let permsChanged = false;
+    // usage-guard also proposes the permissions allowlist its endpoint path needs
+    // (credentials Read + node exec, per §環境要件) folded into the same diff.
+    // Non-destructive + idempotent; `--no-permissions` opts out yet still wires
+    // the hook (#174 PR 2).
+    if (name === "usage-guard" && !parsed.values["no-permissions"]) {
+      const rules = buildUsagePermissionRules({
+        credentialsPath: join(base, ".claude", ".credentials.json"),
+        usageCheckPath: join(dirname(scriptPath), "usage-check.mjs"),
+      });
+      const permsRes = addPermissionEntries(working, rules);
+      working = permsRes.settings;
+      permsChanged = permsRes.changed;
+      permissionsAdded = permsRes.added;
+    }
+    result = { settings: working, changed: hookRes.changed || permsChanged };
   } else {
     result = removeHookEntry(currentSettings, def);
   }
@@ -351,9 +522,15 @@ export async function runHooks(argv, opts = {}) {
     .filter((l) => l.startsWith("+") || l.startsWith("-"))
     .join("\n");
 
+  const permBlock =
+    permissionsAdded.length > 0
+      ? `\n  + permissions.allow (suggested — --no-permissions to skip; declining still wires the hook):\n${permissionsAdded
+          .map((r) => `      ${r}`)
+          .join("\n")}`
+      : "";
   const header =
     action === "add"
-      ? `hooks add ${name} → ${settingsFile}\n  + ${def.event}${def.matcher ? ` (matcher: ${def.matcher})` : ""}: ${command}`
+      ? `hooks add ${name} → ${settingsFile}\n  + ${def.event}${def.matcher ? ` (matcher: ${def.matcher})` : ""}: ${command}${permBlock}`
       : `hooks remove ${name} → ${settingsFile}\n  - ${def.event} entries referencing ${def.script}`;
   process.stdout.write(`${header}\n\nDiff:\n${diff}\n`);
 
@@ -363,6 +540,7 @@ export async function runHooks(argv, opts = {}) {
     event: def.event,
     settings_file: settingsFile,
     ...(command ? { command } : {}),
+    ...(permissionsAdded.length > 0 ? { permissions_added: permissionsAdded } : {}),
     changed: true,
   };
 
@@ -386,6 +564,124 @@ export async function runHooks(argv, opts = {}) {
 
   await mkdir(claudeDir, { recursive: true });
   await writeFile(settingsFile, `${afterStr}\n`);
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  return 0;
+}
+
+/** Resolve the roots `resolveScriptPath` scans (tests may inject `scopeRoots`). */
+async function resolveScopeRoots(base, opts) {
+  if (opts.scopeRoots) return opts.scopeRoots;
+  const packageRoot = await findPackageRoot().catch(() => null);
+  return packageRoot ? [base, packageRoot] : [base];
+}
+
+/**
+ * Resolve the usage-check.mjs the status diagnosis should run: prefer the sibling
+ * of the actually-wired usage-guard-hook.mjs (so it matches the wired install
+ * byte-for-byte), else fall back to normal skill-dir resolution.
+ *
+ * @param {string|null} wiredCommand the wired PreToolUse command string
+ * @param {string[]} scopeRoots
+ * @returns {Promise<string|null>}
+ */
+async function resolveUsageCheckPath(wiredCommand, scopeRoots) {
+  const m = /(\S*usage-guard-hook\.mjs)/.exec(wiredCommand ?? "");
+  if (m) {
+    const sibling = join(dirname(m[1]), "usage-check.mjs");
+    if (existsSync(sibling)) return sibling;
+  }
+  return await resolveScriptPath(scopeRoots, { skill: "usage-guard", script: "usage-check.mjs" });
+}
+
+/**
+ * `hooks status` — read-only wiring report. Scans both settings files, reports
+ * per-hook wiring, and for a wired usage-guard runs usage-check.mjs once to
+ * diagnose whether the guard is effective (endpoint/cache) or degraded
+ * (jsonl/fail-open). Never writes settings.
+ *
+ * @param {{ base: string, opts: object, env: NodeJS.ProcessEnv }} ctx
+ * @returns {Promise<number>} exit code (always 0 — read-only)
+ */
+async function runStatus({ base, opts, env }) {
+  const claudeDir = join(base, ".claude");
+  const files = [
+    { label: "settings.local.json", path: join(claudeDir, "settings.local.json") },
+    { label: "settings.json", path: join(claudeDir, "settings.json") },
+  ];
+  const loaded = [];
+  for (const f of files) {
+    const r = await readSettings(f.path);
+    // Read-only diagnostic: a parse error is noted, not fatal (unlike the
+    // mutating actions, which refuse to overwrite an unparseable file).
+    loaded.push({ ...f, settings: r.error ? {} : r.settings, error: r.error });
+  }
+
+  const rows = [];
+  for (const hookName of HOOK_NAMES) {
+    const def = HOOK_DEFS[hookName];
+    let wiredIn = null;
+    let command = null;
+    for (const f of loaded) {
+      const cmd = findWiredCommand(f.settings, def);
+      if (cmd) {
+        wiredIn = f.label;
+        command = cmd;
+        break;
+      }
+    }
+    rows.push({ name: hookName, event: def.event, wired: Boolean(command), settings_file: wiredIn, command });
+  }
+
+  // usage-guard source diagnosis (only when wired).
+  let diagnosis = null;
+  const ug = rows.find((r) => r.name === "usage-guard");
+  if (ug?.wired) {
+    const scopeRoots = await resolveScopeRoots(base, opts);
+    const usageCheckPath = await resolveUsageCheckPath(ug.command, scopeRoots);
+    diagnosis = diagnoseUsageSource({ scriptPath: usageCheckPath, env });
+  }
+
+  // ── render (human-readable) ─────────────────────────────────────────────────
+  const out = [`Hook wiring status — ${claudeDir}`, ""];
+  for (const row of rows) {
+    if (row.wired) {
+      out.push(`  ${row.name.padEnd(14)}(${row.event}) ✅ wired [${row.settings_file}]`);
+      if (row.name === "usage-guard" && diagnosis) {
+        const c = classifyUsageSource(diagnosis.source);
+        out.push(`      usage-check: ${c.symbol} ${c.label}`);
+      }
+    } else {
+      out.push(
+        `  ${row.name.padEnd(14)}(${row.event}) ✗ not wired — \`npx @ozzylabs/skills hooks add ${row.name}\``,
+      );
+    }
+  }
+  for (const planned of PLANNED_HOOK_NAMES) {
+    out.push(`  ${planned.padEnd(14)}(planned)    — not yet available`);
+  }
+  for (const f of loaded.filter((x) => x.error)) {
+    out.push(`  note: ${f.label} unreadable — ${f.error}`);
+  }
+  process.stdout.write(`${out.join("\n")}\n\n`);
+
+  // ── machine-readable summary ────────────────────────────────────────────────
+  const summary = {
+    action: "status",
+    base: claudeDir,
+    hooks: rows.map((r) => ({
+      name: r.name,
+      event: r.event,
+      wired: r.wired,
+      ...(r.settings_file ? { settings_file: r.settings_file } : {}),
+      ...(r.name === "usage-guard" && diagnosis
+        ? {
+            usage_source: diagnosis.source,
+            usage_effective: classifyUsageSource(diagnosis.source).effective,
+          }
+        : {}),
+    })),
+    planned: PLANNED_HOOK_NAMES,
+  };
   process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
   return 0;
 }

--- a/bin/skills.mjs
+++ b/bin/skills.mjs
@@ -8,7 +8,7 @@
 //   remove  Uninstall skills (with confirmation).
 //   fork    Copy a skill to a user-owned, unmanaged name.
 //   diff    Show a skill's local diff against upstream.
-//   hooks   Wire/unwire optional Claude Code hooks shipped with a skill (#174).
+//   hooks   Wire/unwire/inspect optional Claude Code hooks shipped with a skill (#174).
 //
 // `install`/`uninstall` are accepted as aliases for `add`/`remove`. Scope is
 // expressed by `--target` (absent = user, present = project repo). See #151 for
@@ -36,8 +36,9 @@ Verbs:
   remove     Uninstall skills (confirmation required). Alias: uninstall.
   fork       Copy a skill to a user-owned name.
   diff       Show a skill's diff against upstream.
-  hooks      Wire/unwire an optional Claude Code hook shipped with a skill
-             (usage-guard, observability) into your local settings.
+  hooks      Wire/unwire/inspect an optional Claude Code hook shipped with a
+             skill (usage-guard, observability). 'status' also diagnoses whether
+             a wired usage-guard is effective or has degraded to a no-op.
 
 Run 'npx @ozzylabs/skills <verb> --help' for verb-specific options.
 `;

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -95,11 +95,21 @@ npx @ozzylabs/skills hooks add observability --scope=user
 # 書き込まずに settings の diff を確認（非対話/CI では適用に --yes 必須）
 npx @ozzylabs/skills hooks add usage-guard --dry-run
 
+# permissions 提案を出さず hook 配線のみ
+npx @ozzylabs/skills hooks add usage-guard --no-permissions
+
 # CLI が書いたエントリのみ削除（他の hook はそのまま）
 npx @ozzylabs/skills hooks remove usage-guard
+
+# 配線状態を確認し、配線済み usage-guard が実効かどうかを診断
+npx @ozzylabs/skills hooks status
 ```
 
 install 済み skill dir から script を解決し（無ければ先に `add --skills=usage-guard`）、settings の diff を提示してから確認する（非対話では `--yes` 必須）。既定は `settings.local.json`（`--scope=user` で `settings.json`）を編集し、再 add は冪等 no-op、自分が書いたエントリのみ操作し、壊れた JSON settings は上書きしない。リポは依然 settings/hooks を配信せず、要求時にローカル settings を書くだけ。
+
+`hooks add usage-guard` は加えて、endpoint 経路に必要な **permissions allowlist**（`Read(//…/.credentials.json)` と `Bash(node …/usage-check.mjs:*)`。詳細は skill の §環境要件）を同じ diff に折り込んで提案する。`permissions.allow` への非破壊・冪等な追記で、`--no-permissions` で見送っても hook 配線は続行する。この許可がないと guard は `fail-open`（事実上 OFF）に縮退する。
+
+`hooks status` は read-only。両方の settings ファイルを走査し hook ごとの配線有無を表示する。配線済み usage-guard については `usage-check.mjs` を 1 回実行して `source` を診断する（`endpoint`/`cache` は実効、`jsonl`/`fail-open` は no-op へ縮退＝§環境要件 へ案内）。hook は配線済みだが endpoint 経路がブロックされ guard が黙って OFF、という失敗を検出できる。
 
 ## Consumer セットアップ
 

--- a/docs/usage-guard-verification.md
+++ b/docs/usage-guard-verification.md
@@ -116,6 +116,14 @@ See the skill's `SKILL.md` §環境要件 for why the endpoint path can be block
 (api.anthropic.com egress + `~/.claude/.credentials.json` read) and how to
 restore it so `source` is `endpoint` rather than a degraded fallback.
 
+To check this in one command against your live install, run
+`npx @ozzylabs/skills hooks status`: for a wired usage-guard it runs
+`usage-check.mjs` once and reports whether the `source` is `endpoint`/`cache`
+(guard effective) or `jsonl`/`fail-open` (degraded — the endpoint path is still
+blocked; fix per §環境要件). Wiring the hook with
+`npx @ozzylabs/skills hooks add usage-guard` also proposes the permissions
+allowlist those grants need.
+
 ## B. `/usage-guard` standalone pause→resume (manual)
 
 Uses `scripts/usage-guard-smoke.mjs` against the REAL

--- a/tests/cli-hooks.test.mjs
+++ b/tests/cli-hooks.test.mjs
@@ -1,4 +1,5 @@
-// Tests for `skills hooks add|remove` (ozzy-labs/skills#174 PR 1).
+// Tests for `skills hooks add|remove|status` (ozzy-labs/skills#174 PR 1 = add/
+// remove, PR 2 = status + permissions suggestion).
 //
 // Split like the rest of the CLI suite: the pure settings transforms + path
 // resolution are unit-tested directly, and the end-to-end wiring runs the actual
@@ -15,7 +16,11 @@ import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import {
   addHookEntry,
+  addPermissionEntries,
   buildCommand,
+  buildUsagePermissionRules,
+  classifyUsageSource,
+  diagnoseUsageSource,
   HOOK_DEFS,
   removeHookEntry,
   resolveScriptPath,
@@ -31,7 +36,11 @@ const OBS = HOOK_DEFS.observability;
 function runCli(args, options = {}) {
   return spawnSync("node", [BIN, ...args], {
     cwd: options.cwd ?? ROOT,
-    env: { ...process.env, ...(options.home ? { OZZYLABS_SKILLS_HOME: options.home } : {}) },
+    env: {
+      ...process.env,
+      ...(options.home ? { OZZYLABS_SKILLS_HOME: options.home } : {}),
+      ...(options.env ?? {}),
+    },
     encoding: "utf8",
   });
 }
@@ -142,6 +151,118 @@ test("removeHookEntry on absent hook is a no-op", () => {
   const settings = { hooks: { PreToolUse: [] } };
   const { changed } = removeHookEntry(settings, UG);
   assert.equal(changed, false);
+});
+
+// ── permissions suggestion (PR 2) ────────────────────────────────────────────
+
+test("buildUsagePermissionRules emits a double-slash Read + a node Bash rule", () => {
+  const rules = buildUsagePermissionRules({
+    credentialsPath: "/home/alice/.claude/.credentials.json",
+    usageCheckPath: "/home/alice/.claude/skills/usage-guard/usage-check.mjs",
+  });
+  assert.deepEqual(rules, [
+    "Read(//home/alice/.claude/.credentials.json)",
+    "Bash(node /home/alice/.claude/skills/usage-guard/usage-check.mjs:*)",
+  ]);
+});
+
+test("addPermissionEntries seeds permissions.allow on empty settings", () => {
+  const rules = ["Read(//x/.credentials.json)", "Bash(node /x/usage-check.mjs:*)"];
+  const { settings, changed, added } = addPermissionEntries({}, rules);
+  assert.equal(changed, true);
+  assert.deepEqual(settings.permissions.allow, rules);
+  assert.deepEqual(added, rules);
+});
+
+test("addPermissionEntries preserves existing allow/deny and appends only new rules", () => {
+  const existing = {
+    permissions: { allow: ["Read(//keep/me)"], deny: ["Bash(rm:*)"] },
+    other: { untouched: true },
+  };
+  const rules = ["Read(//keep/me)", "Bash(node /x/usage-check.mjs:*)"];
+  const { settings, changed, added } = addPermissionEntries(existing, rules);
+  assert.equal(changed, true);
+  assert.deepEqual(settings.permissions.allow, [
+    "Read(//keep/me)",
+    "Bash(node /x/usage-check.mjs:*)",
+  ]);
+  assert.deepEqual(added, ["Bash(node /x/usage-check.mjs:*)"], "only the missing rule is added");
+  assert.deepEqual(settings.permissions.deny, ["Bash(rm:*)"], "deny is preserved");
+  assert.deepEqual(settings.other, { untouched: true }, "unrelated keys preserved");
+  assert.equal(existing.permissions.allow.length, 1, "input settings not mutated");
+});
+
+test("addPermissionEntries is idempotent when all rules already present", () => {
+  const rules = ["Read(//x/.credentials.json)", "Bash(node /x/usage-check.mjs:*)"];
+  const first = addPermissionEntries({}, rules);
+  const second = addPermissionEntries(first.settings, rules);
+  assert.equal(second.changed, false);
+  assert.deepEqual(second.added, []);
+  assert.strictEqual(second.settings, first.settings, "unchanged object returned as-is");
+});
+
+// ── usage-check source classification / diagnosis (PR 2) ──────────────────────
+
+test("classifyUsageSource: endpoint/cache are effective, jsonl/fail-open degraded", () => {
+  for (const s of ["endpoint", "cache"]) {
+    const c = classifyUsageSource(s);
+    assert.equal(c.effective, true, `${s} → effective`);
+    assert.equal(c.symbol, "✅");
+  }
+  for (const s of ["jsonl", "fail-open"]) {
+    const c = classifyUsageSource(s);
+    assert.equal(c.effective, false, `${s} → degraded`);
+    assert.equal(c.symbol, "⚠️");
+    assert.match(c.label, /環境要件/, "degraded label points to §環境要件");
+  }
+  const unknown = classifyUsageSource(null);
+  assert.equal(unknown.effective, null);
+  assert.equal(unknown.symbol, "?");
+});
+
+test("diagnoseUsageSource honors the env fixture over spawning", () => {
+  let spawned = false;
+  const d = diagnoseUsageSource({
+    scriptPath: "/should/not/run.mjs",
+    env: { OZZYLABS_SKILLS_USAGE_CHECK_JSON: '{"source":"endpoint","ok":true}' },
+    spawnImpl: () => {
+      spawned = true;
+      return {};
+    },
+  });
+  assert.equal(d.source, "endpoint");
+  assert.equal(spawned, false, "fixture bypasses the spawn");
+});
+
+test("diagnoseUsageSource spawns node and parses the last JSON line's source", () => {
+  const d = diagnoseUsageSource({
+    scriptPath: "/x/usage-check.mjs",
+    env: {},
+    spawnImpl: (cmd, args) => {
+      assert.equal(cmd, "node");
+      assert.deepEqual(args, ["/x/usage-check.mjs"]);
+      return { stdout: 'warning line\n{"source":"fail-open","ok":true}\n' };
+    },
+  });
+  assert.equal(d.source, "fail-open");
+});
+
+test("diagnoseUsageSource fails soft: null path, bad fixture, spawn error → { source: null }", () => {
+  assert.equal(diagnoseUsageSource({ scriptPath: null, env: {} }).source, null);
+  assert.equal(
+    diagnoseUsageSource({
+      scriptPath: "/x.mjs",
+      env: { OZZYLABS_SKILLS_USAGE_CHECK_JSON: "not json" },
+    }).source,
+    null,
+  );
+  const errRes = diagnoseUsageSource({
+    scriptPath: "/x.mjs",
+    env: {},
+    spawnImpl: () => ({ error: new Error("ENOENT") }),
+  });
+  assert.equal(errRes.source, null);
+  assert.match(errRes.error, /ENOENT/);
 });
 
 // ── path resolution ─────────────────────────────────────────────────────────
@@ -386,6 +507,139 @@ test("e2e: an unknown hook name is rejected with a suggestion", async () => {
     const r = runCli(["hooks", "add", "usage-gaurd", "--yes"], { home });
     assert.notEqual(r.status, 0);
     assert.match(r.stderr, /unknown hook 'usage-gaurd'/);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+// ── permissions suggestion end-to-end (PR 2) ─────────────────────────────────
+
+test("e2e: hooks add usage-guard also writes the permissions allowlist", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-hooks-e2e-"));
+  try {
+    runCli(["add", "--adapter=claude-code", "--skills=usage-guard", "--force"], { home });
+    const r = runCli(["hooks", "add", "usage-guard", "--yes"], { home });
+    assert.equal(r.status, 0, `hooks add failed: ${r.stderr}`);
+
+    const settings = JSON.parse(readFileSync(join(home, ".claude", "settings.local.json"), "utf8"));
+    const allow = settings.permissions.allow;
+    const creds = join(home, ".claude", ".credentials.json");
+    const usageCheck = join(home, ".claude", "skills", "usage-guard", "usage-check.mjs");
+    assert.ok(allow.includes(`Read(/${creds})`), "credentials Read rule added (double-slash)");
+    assert.ok(allow.includes(`Bash(node ${usageCheck}:*)`), "node exec Bash rule added");
+    // hook wiring is still intact alongside the permissions.
+    assert.match(settings.hooks.PreToolUse[0].hooks[0].command, /usage-guard-hook\.mjs$/);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: --no-permissions wires the hook only (no permissions written)", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-hooks-e2e-"));
+  try {
+    runCli(["add", "--adapter=claude-code", "--skills=usage-guard", "--force"], { home });
+    const r = runCli(["hooks", "add", "usage-guard", "--no-permissions", "--yes"], { home });
+    assert.equal(r.status, 0, r.stderr);
+    const settings = JSON.parse(readFileSync(join(home, ".claude", "settings.local.json"), "utf8"));
+    assert.ok(settings.hooks.PreToolUse, "hook still wired");
+    assert.ok(!("permissions" in settings), "no permissions key written under --no-permissions");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: permissions allowlist is idempotent (second add is a no-op)", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-hooks-e2e-"));
+  try {
+    runCli(["add", "--adapter=claude-code", "--skills=usage-guard", "--force"], { home });
+    runCli(["hooks", "add", "usage-guard", "--yes"], { home });
+    const settingsFile = join(home, ".claude", "settings.local.json");
+    const before = readFileSync(settingsFile, "utf8");
+    const r = runCli(["hooks", "add", "usage-guard", "--yes"], { home });
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /already wired|Nothing to do/i);
+    assert.equal(readFileSync(settingsFile, "utf8"), before, "no duplicate permission entries");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: a hook wired with --no-permissions gains permissions on a later plain add", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-hooks-e2e-"));
+  try {
+    runCli(["add", "--adapter=claude-code", "--skills=usage-guard", "--force"], { home });
+    runCli(["hooks", "add", "usage-guard", "--no-permissions", "--yes"], { home });
+    // Hook is wired but permissions are absent; a plain re-add must add just the
+    // permissions (changed) rather than report "already wired".
+    const r = runCli(["hooks", "add", "usage-guard", "--yes"], { home });
+    assert.equal(r.status, 0, r.stderr);
+    const settings = JSON.parse(readFileSync(join(home, ".claude", "settings.local.json"), "utf8"));
+    assert.ok(Array.isArray(settings.permissions.allow), "permissions added on the second add");
+    assert.equal(settings.hooks.PreToolUse.length, 1, "hook not duplicated");
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+// ── hooks status end-to-end (PR 2) ────────────────────────────────────────────
+
+test("e2e: hooks status reports per-hook wiring (unwired baseline)", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-hooks-e2e-"));
+  try {
+    const r = runCli(["hooks", "status"], { home });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /usage-guard.*not wired/, "usage-guard shows not wired");
+    assert.match(r.stdout, /observability.*not wired/, "observability shows not wired");
+    assert.match(r.stdout, /policy.*planned/i, "planned policy hook is surfaced");
+    const summary = JSON.parse(r.stdout.slice(r.stdout.indexOf("{")));
+    assert.equal(summary.action, "status");
+    assert.equal(summary.hooks.find((h) => h.name === "usage-guard").wired, false);
+    assert.deepEqual(summary.planned, ["policy"]);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: hooks status shows a wired hook + endpoint source → guard effective", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-hooks-e2e-"));
+  try {
+    runCli(["add", "--adapter=claude-code", "--skills=usage-guard", "--force"], { home });
+    runCli(["hooks", "add", "usage-guard", "--yes"], { home });
+    const r = runCli(["hooks", "status"], {
+      home,
+      env: { OZZYLABS_SKILLS_USAGE_CHECK_JSON: '{"source":"endpoint","ok":true}' },
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /usage-guard.*wired/);
+    assert.match(r.stdout, /source=endpoint/);
+    assert.match(r.stdout, /effective/);
+    const summary = JSON.parse(r.stdout.slice(r.stdout.indexOf("{")));
+    const ug = summary.hooks.find((h) => h.name === "usage-guard");
+    assert.equal(ug.wired, true);
+    assert.equal(ug.usage_source, "endpoint");
+    assert.equal(ug.usage_effective, true);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("e2e: hooks status flags a degraded (fail-open) source with a warning", async () => {
+  const home = await mkdtemp(join(tmpdir(), "skills-hooks-e2e-"));
+  try {
+    runCli(["add", "--adapter=claude-code", "--skills=usage-guard", "--force"], { home });
+    runCli(["hooks", "add", "usage-guard", "--yes"], { home });
+    const r = runCli(["hooks", "status"], {
+      home,
+      env: { OZZYLABS_SKILLS_USAGE_CHECK_JSON: '{"source":"fail-open","ok":true}' },
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /DEGRADED/);
+    assert.match(r.stdout, /source=fail-open/);
+    assert.match(r.stdout, /環境要件/, "points to usage-guard §環境要件");
+    const summary = JSON.parse(r.stdout.slice(r.stdout.indexOf("{")));
+    const ug = summary.hooks.find((h) => h.name === "usage-guard");
+    assert.equal(ug.usage_source, "fail-open");
+    assert.equal(ug.usage_effective, false);
   } finally {
     await rm(home, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What

Adds `hooks status` and a permissions allowlist suggestion to the `hooks` CLI verb, building on PR 1's `add`/`remove` (already merged in #194).

### `hooks status`
- Scans both `settings.local.json` and `settings.json`, reports per-hook wiring (usage-guard PreToolUse / observability SessionEnd), plus a forward-looking `policy (planned)` row.
- For a **wired** usage-guard it runs `usage-check.mjs` once and diagnoses the `source`:
  - `endpoint` / `cache` → ✅ guard effective
  - `jsonl` / `fail-open` → ⚠️ guard degraded to a no-op, with a pointer to the skill's §環境要件.
- Read-only (always exit 0). Diagnosis can be mocked via `OZZYLABS_SKILLS_USAGE_CHECK_JSON` (used by tests; also a manual override).

### permissions suggestion on `hooks add usage-guard`
- Non-destructively appends the two allowlist entries the endpoint path needs, folded into the same diff:
  - `Read(//…/.credentials.json)` (double-slash absolute Read rule)
  - `Bash(node …/usage-check.mjs:*)`
- Idempotent append to `permissions.allow`; `deny`/`ask` and existing entries untouched.
- `--no-permissions` opts out and still wires the hook. A hook wired with `--no-permissions` gains the permissions on a later plain `add`.

## Tests / docs
- Extended `tests/cli-hooks.test.mjs`: pure transforms (`buildUsagePermissionRules`, `addPermissionEntries`, `classifyUsageSource`, `diagnoseUsageSource`) + e2e (status wiring, source-diagnosis via env fixture, permissions write / idempotency / `--no-permissions`).
- Full suite green (582 tests), `pnpm build` clean (no dist drift — skill set unchanged), `pnpm run lint` exit 0.
- Documented in README.md, docs/README.ja.md, and docs/usage-guard-verification.md.

Refs #174 (PR 2/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015n4J4RWvHAsXNf5pDVypFg